### PR TITLE
docs(M0): living docs for franklinbaldo-stack migration

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -88,6 +88,11 @@ Toda decisão importante recebe entrada aqui com data. Não delete entradas — 
 - **Decisão**: raw items e parsed items são IA items distintos. Raw é imutável após upload; parsed pode ser re-uploadado quantas vezes preciso.
 - **Justificativa**: isola falhas de parsing do scraping; permite trocar estratégia de Etapa 2 sem re-scraping.
 
+### 2026-05-20 — Slug `{fonte}` é token único `[a-z]+`, sem hífens
+- **Decisão**: cada fonte tem **um único slug canônico** (`casacivil`, `diario`, `assembleia`) usado idêntico em IA identifier, `raw_meta.fonte`, `parsed_meta.fonte_canonica`/`resolvido_por`, atributo `tipo` em LeiML, coluna Parquet `fonte_canonica`, e enum `FONTES`.
+- **Justificativa**: rascunho inicial misturava `diario`, `diario_oficial`, `diario-oficial` em locais diferentes — flagged pelo Codex em #6. Reconciliação determinística requer um único valor; hífen no slug quebra parsing do identifier `leizilla-raw-{ente}-{fonte}-{chave}` (ambiguidade entre fim de fonte e início de chave).
+- **Documentado em**: `docs/SCHEMA.md` §5 "Slug `{fonte}`".
+
 ### 2026-05-20 — Múltiplas fontes oficiais com tracking de divergência
 - **Decisão**: cada lei pode ter N raw items (um por fonte: Assembleia, Casa Civil, Diário Oficial). Parsed item reconcilia.
 - **Hierarquia de autoridade**: Diário Oficial > Casa Civil > Assembleia. Divergências registradas em `parsed_meta.json.divergencias` e na coluna Parquet `tem_divergencia`.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -2,15 +2,13 @@
 
 > **Documento vivo.** Este arquivo espelha o plano de migração e é atualizado a cada PR. Sempre que uma decisão for tomada, um problema for descoberto, ou um milestone fechar, edite aqui. O git log deste arquivo é a memória institucional da migração.
 
-**Plano-mãe (read-only):** `/root/.claude/plans/eu-quero-fazer-esse-iterative-trinket.md` (não versionado — é o handoff do Claude Code).
-
 ---
 
 ## Status atual
 
 | Milestone | Status | PR | Notas |
 |---|---|---|---|
-| **M0** — Documento vivo + Design schema | 🟡 in-progress | — | M0.1 done; M0.2 rascunho em `docs/SCHEMA.md`; falta `leiml-v0.1.xsd` e fixtures |
+| **M0** — Documento vivo + Design schema | 🟡 in-progress | #6 | M0.1 done; M0.2 reescrito após review dos 3 blockers; falta `leizilla-v0.1.xsd` + fixtures + decisões §10 do SCHEMA.md |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
 | M3 — OCR fetch + LLM parse + LeiML | ⚪ todo | — | Bloqueado por M2 |
@@ -42,8 +40,9 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 3. **Etapa 2 é pluggable.** Default: Claude Haiku via API. Alternativas: Claude Code routine com Opus, parser determinístico, curadoria manual.
 4. **Múltiplas fontes por lei são esperadas.** Assembleia + Casa Civil + Diário Oficial; reconciliação com hierarquia DO > Casa Civil > Assembleia.
 5. **Genérico por ente federativo desde dia 1.** Tudo parametrizado por `{ente}`.
-6. **LeiML é canônico, HTML é apresentação.** LeiML exportável para LexML (CI round-trip). HTML renderizado no browser via XSLT/JS.
-7. **ZIP raw bulk, Parquet analytics, IA item distribuição.** Padrão ficha.
+6. **Leizilla XML é canônico, dispositivo-cêntrico.** Formato próprio (não fork). LexML é gate de CI (export reduzido sob demanda), não constraint estrutural. SSR híbrido: Astro renderiza páginas de detalhe; XSLT in-browser é fallback.
+7. **ZIP raw bulk, Parquet analytics (3 tabelas: leis + dispositivos + versoes), IA item distribuição.** Padrão ficha + normalização para timeline temporal.
+8. **Vigente compilado é canônico, histórico via timeline.** Parsed item = "como deve estar vigente hoje" (best-effort). Versões anteriores acessíveis via date picker. Fontes (DO, Casa Civil, Assembleia) cross-verificam — não competem por autoridade.
 
 ---
 
@@ -53,7 +52,7 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 |---|---|---|
 | Backend | Python | 3.12 |
 | ETL | DuckDB + PyArrow | latest |
-| Storage canônico | LeiML XML (nosso fork de LexML) | 0.1 |
+| Storage canônico | Leizilla XML (formato próprio, dispositivo-cêntrico) | 0.1 |
 | Storage distribuído | Internet Archive | — |
 | Frontend framework | Astro | 6.3 |
 | Frontend components | Svelte | 5.55 |
@@ -69,6 +68,31 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-20 — Rewrite arquitetural pós-review #6 (3 blockers)
+
+Parecer técnico de @franklinbaldo no PR #6 levantou 3 blockers que mudaram fundamentos do design. Resolvidos antes de fechar M0:
+
+- **Blocker 1 — DO×vigente como tese de canonicidade**: hierarquia "DO > Casa Civil > Assembleia" foi descartada. Decisão: parsed item canônico é o **vigente compilado** (best-effort); histórico fica acessível via timeline de versões por dispositivo (date picker → "como era a lei em 2010-01-01?"). Fontes não competem por autoridade — cross-verificam a compilação. Documentado em `docs/SCHEMA.md` §0.2.
+
+- **Blocker 2 — Alterações legislativas fora de escopo**: trazidas para v0.1. Schema Leizilla XML modela cada dispositivo como container de versões (`<versao numero="N" vigente-de="..." vigente-ate="..." alterado-por="urn:lex:...">`). `alteracoes.json` sidecar pré-computa relações (`alterada_por`, `altera`, `revogada_por`, `revoga`). Documentado em `docs/SCHEMA.md` §0.2, §4.3.
+
+- **Blocker 3 — LeiML como NIH disfarçado**: fork LeiML abandonado. **Leizilla XML v0.1** é formato próprio escrito do zero, **dispositivo-cêntrico** (não lei-cêntrico — insight do usuário: "unidade básica é dispositivo, não a lei"). LexML vira gate de CI (XSLT export valida que conseguimos representação reduzida quando preciso para gov interop) — não constraint estrutural. Perdas conhecidas (divergencias, parse meta, bloco-livre) ficam documentadas no XSLT. Documentado em `docs/SCHEMA.md` §0.3, §4, §6.
+
+Outras decisões do mesmo review já incorporadas em SCHEMA.md:
+- `git_sha` 40 chars completo (não 7).
+- Regex parsed `\d{5,}` (não `\d{5}`).
+- Tipo Parquet `VARCHAR` (não `TEXT`).
+- `urn_lex` nullable (data desconhecida não falsifica URN).
+- Bundle `lexml.xsd` no repo (reprodutibilidade).
+- Schema Parquet é v0.1 durante M0–M4, promove a v1 só em M5.
+- SSR híbrido via Astro (suaviza princípio 6 — XSLT in-browser é fallback).
+- Confiança baixa exibida explicitamente no frontend (banner LLM/OCR).
+
+### 2026-05-20 — Fixes Codex no PR #6
+
+- **P1 fallback parsed sem `{fonte}`**: pattern em §1.3 dizia `leizilla-{ente}-{tipo}-fallback-{chave}` mas regex em §5 exigia `{fonte}`. Corrigido: fallback sempre inclui `{fonte}` para evitar colisão. SCHEMA.md §1.3, §5.3.
+- **P2 `id` Parquet sem zero-pad**: descrição da coluna `id` em §3 não explicitava que `numero` é zero-padded. Corrigido: lookup `id → IA item` é literal, sem normalização extra. SCHEMA.md §3.1, §5.3.
 
 ### 2026-05-20 — Migração para stack franklinbaldo iniciada
 - **Decisão**: adotar Astro + Svelte + Pico + DuckDB-WASM, mirror do que já funciona em verne/cobogo/franklinbaldo.github.io.
@@ -163,8 +187,12 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 ## Próximos passos imediatos
 
-- [ ] **M0.2**: escrever `docs/SCHEMA.md` com decisões de granularidade IA, layout ZIP, schema Parquet v1, schema LeiML v0.1
-- [ ] **M0.2**: rascunhar `docs/schemas/leiml-v0.1.xsd`
-- [ ] **M0.2**: fixtures de 3 leis representativas em `tests/fixtures/leiml/` validando round-trip LeiML→LexML
-- [ ] **M0.3**: documentar inspirações concretas em `docs/SCHEMA.md` (links para arquivos específicos em ficha/baliza/causaganha)
-- [ ] PR de M0 para review antes de iniciar M1
+- [x] **M0.1**: `IMPLEMENTATION.md` criado e mantido.
+- [x] **M0.2**: `docs/SCHEMA.md` v1 (granularidade IA, layout ZIP, naming).
+- [x] **M0.2**: reescrita pós-review #6 (dispositivo-cêntrico, timeline temporal, formato próprio).
+- [ ] **M0.2**: rascunhar `docs/schemas/leizilla-v0.1.xsd`.
+- [ ] **M0.2**: fixtures de 3 leis representativas em `tests/fixtures/leizilla_xml/` (incluindo uma com alterações e uma com `<bloco-livre>`).
+- [ ] **M0.2**: rascunhar `scripts/leizilla-to-lexml.xsl` + teste CI de validação contra `lexml.xsd`.
+- [ ] **M0.2**: resolver decisões pendentes em `docs/SCHEMA.md` §10 (URN dialect, compressão Parquet, política re-scrape, LGPD).
+- [ ] **M0.3**: aprofundar inspirações concretas em `docs/SCHEMA.md` §8 (paths exatos de arquivos em ficha/baliza/causaganha).
+- [ ] Re-review do PR #6 após reescrita; aprovação → fechar M0 → abrir M1.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -244,7 +244,7 @@ uv run pytest tests/test_lexml_export.py -v  # gate CI: Leizilla XML → LexML (
 | Raw (individual) | `leizilla-raw-{ente}-{fonte}-{chave}` | `leizilla-raw-ro-casacivil-coddoc-00042` |
 | Raw (bundle ZIP) | `leizilla-bundle-{ente}-{fonte}-{periodo}` | `leizilla-bundle-ro-casacivil-2026-W20` |
 | Parsed (lei canônica) | `leizilla-{ente}-{tipo}-{numero:05d}-{ano}` | `leizilla-ro-lei-01234-2003` |
-| Dataset (Parquet) | `leizilla-dataset-{ente}-v{N}` | `leizilla-dataset-ro-v1` |
+| Dataset (Parquet) | `leizilla-dataset-{ente}-v{N}` | `leizilla-dataset-ro-v0` (pré-M5; ver SCHEMA.md §3.5 mapping) |
 
 Slug `{ente}`: `ro`, `sp`, `federal`, `ro-porto-velho` (kebab-case, UF-municipio).
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -90,6 +90,18 @@ Outras decisões do mesmo review já incorporadas em SCHEMA.md:
 - SSR híbrido via Astro (suaviza princípio 6 — XSLT in-browser é fallback).
 - Confiança baixa exibida explicitamente no frontend (banner LLM/OCR).
 
+### 2026-05-20 — Dispositivo universal: tudo que é texto da lei
+
+- **Decisão**: `<dispositivo>` é o elemento universal para qualquer texto da lei. `tipo` discrimina o papel.
+- **Normativos** (têm `<texto>` em `<versoes>`): `titulo-lei`, `ementa`, `preambulo`, `artigo`, `paragrafo`, `inciso`, `alinea`, `item`, `anexo`, `disposicao-transitoria`, `disposicao-final`.
+- **Organizacionais** (só `<rotulo>` em `<versoes>`, sem `<texto>`): `livro`, `parte`, `titulo`, `capitulo`, `secao`, `subsecao`. São uma **espécie** de dispositivo (insight do usuário), sem texto normativo próprio.
+- **Header** carrega só metadados bibliográficos (ente, tipo, numero, ano, data, urn, vigente-em, revogada). `<ementa>` e nome oficial da lei migraram para dispositivos.
+- **Parent obrigatório** em todo `<dispositivo>` (`parent=""` na raiz). Redundante com nesting XML mas explicitude força clareza.
+- **Path normativo é global**: `art-5` permanece `art-5` independente do bloco organizacional acima. Citação forense direta = lookup literal.
+- **Path organizacional namespaceia internamente**: `tit-1`, `tit-1-cap-1`, `tit-1-cap-1-sec-2`.
+- **Sem coluna `eh_bloco`**: redundante com `tipo`; filtros via `WHERE texto IS NOT NULL` ou `WHERE tipo IN (...)`. Insight do usuário: "qualquer dispositivo tem um bloco que o agrupa em algum lugar, o XML permite isso" — não precisa de flag explícito.
+- **Documentado em**: SCHEMA.md §0.1, §3.2, §4.2 (header slim), §4.3 (exemplo cobrindo titulo-lei + ementa + preambulo + blocos + articulação + anexo).
+
 ### 2026-05-20 — Wayback Machine como caminho primário de fetch
 
 - **Decisão**: crawler dispara `POST /save` no Wayback Machine para `fonte_url` + `pdf_url`, depois **fetch o PDF do snapshot Wayback** (não da fonte original) para upload na nossa coleção IA. Fail-open: timeout/erro/rate-limit do Wayback → fallback para download direto da fonte, gravar `fetched_from: "source-fallback"` em `raw_meta.json.provenance_wayback`.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -28,7 +28,7 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
                                               ↓
                 ETAPA 2 (LLM/agentes parsing) → Leizilla XML + parsed_meta.json no IA
                                               ↓
-                etl/consolidate                → Parquet v1 no IA (dataset item)
+                etl/consolidate                → Parquet v0.1 no IA (dataset item)
                                               ↓
                 deploy-web                     → Astro+Svelte+Pico+DuckDB-WASM no GH Pages
 ```
@@ -41,7 +41,7 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 4. **Múltiplas fontes por lei são esperadas.** Assembleia + Casa Civil + Diário Oficial fazem **cross-verificação** do vigente compilado — não competem por canonicidade. Divergências indicam possível erro de consolidação ou retificação não-aplicada; frontend exibe como "verificar", não como ranking de autoridade. Ver SCHEMA.md §0.2.
 5. **Genérico por ente federativo desde dia 1.** Tudo parametrizado por `{ente}`.
 6. **Leizilla XML é canônico, dispositivo-cêntrico.** Formato próprio (não fork). LexML é gate de CI (export reduzido sob demanda), não constraint estrutural. SSR híbrido: Astro renderiza páginas de detalhe; XSLT in-browser é fallback.
-7. **ZIP raw bulk, Parquet analytics (3 tabelas: leis + dispositivos + versoes), IA item distribuição.** Padrão ficha + normalização para timeline temporal.
+7. **ZIP raw bulk (padrão ficha) + Parquet relacional normalizado (3 tabelas com FKs: leis ← dispositivos ← versoes) + IA item para distribuição.** Ficha tem 1 Parquet por entidade; nosso modelo introduz normalização relacional explícita para suportar timeline temporal por dispositivo. Manifest CSV no IA como source of truth (padrão baliza).
 8. **Vigente compilado é canônico, histórico via timeline.** Parsed item = "como deve estar vigente hoje" (best-effort). Versões anteriores acessíveis via date picker. Fontes (DO, Casa Civil, Assembleia) cross-verificam — não competem por autoridade.
 
 ---
@@ -88,6 +88,13 @@ Outras decisões do mesmo review já incorporadas em SCHEMA.md:
 - Schema Parquet é v0.1 durante M0–M4, promove a v1 só em M5.
 - SSR híbrido via Astro (suaviza princípio 6 — XSLT in-browser é fallback).
 - Confiança baixa exibida explicitamente no frontend (banner LLM/OCR).
+
+### 2026-05-20 — Renomear `origem` → `ente` em CLI e schema (M1)
+
+- **Decisão**: a coluna `origem` no DuckDB schema (storage.py:44) e a flag `--origem` no CLI (cli.py:29,69,169,199,260) serão renomeadas para `ente`. SCHEMA.md já assume `ente` em todo o Parquet v0.1 e identifiers IA.
+- **Quando**: migração executa em M1 junto com o restructure do package (`src/` → `src/leizilla/`). Não fazemos compat shim — o pipeline atual não tem dados em produção, é só desenvolvimento.
+- **Por quê**: `origem` era nome herdado da fase pré-stack-franklinbaldo (ADR-0003); `ente` é mais preciso (ente federativo) e generaliza para União/estados/municípios.
+- **Por que registrar agora**: reviewer #6 apontou que o log de decisões não tinha entrada explícita; sem isso, no M1 vão aparecer dois nomes convivendo sem rastreio.
 
 ### 2026-05-20 — Fixes Codex no PR #6
 
@@ -180,7 +187,7 @@ uv run pytest tests/test_lexml_export.py -v  # gate CI: Leizilla XML → LexML (
 |---|---|---|
 | Raw (individual) | `leizilla-raw-{ente}-{fonte}-{chave}` | `leizilla-raw-ro-casacivil-coddoc-00042` |
 | Raw (bundle ZIP) | `leizilla-bundle-{ente}-{fonte}-{periodo}` | `leizilla-bundle-ro-casacivil-2026-W20` |
-| Parsed (lei canônica) | `leizilla-{ente}-{tipo}-{numero}-{ano}` | `leizilla-ro-lei-01234-2003` |
+| Parsed (lei canônica) | `leizilla-{ente}-{tipo}-{numero:05d}-{ano}` | `leizilla-ro-lei-01234-2003` |
 | Dataset (Parquet) | `leizilla-dataset-{ente}-v{N}` | `leizilla-dataset-ro-v1` |
 
 Slug `{ente}`: `ro`, `sp`, `federal`, `ro-porto-velho` (kebab-case, UF-municipio).

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -11,7 +11,7 @@
 | **M0** — Documento vivo + Design schema | 🟡 in-progress | #6 | M0.1 done; M0.2 reescrito após review dos 3 blockers; falta `leizilla-v0.1.xsd` + fixtures + decisões §10 do SCHEMA.md |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
-| M3 — OCR fetch + LLM parse + LeiML | ⚪ todo | — | Bloqueado por M2 |
+| M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
 | M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |
 | M6 — GitHub Actions | ⚪ todo | — | Depende de M2–M5 |
@@ -26,7 +26,7 @@ Legenda: ⚪ todo · 🟡 in-progress · 🟢 done · 🔴 blocked
 ```
 Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt)
                                               ↓
-                ETAPA 2 (LLM/agentes parsing) → LeiML XML + parsed_meta.json no IA
+                ETAPA 2 (LLM/agentes parsing) → Leizilla XML + parsed_meta.json no IA
                                               ↓
                 etl/consolidate                → Parquet v1 no IA (dataset item)
                                               ↓
@@ -38,7 +38,7 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 1. **Duas etapas no IA, sempre separadas.** Raw é imutável; parsed re-roda quantas vezes for preciso.
 2. **OCR é responsabilidade do Internet Archive.** Nunca rodamos OCR local.
 3. **Etapa 2 é pluggable.** Default: Claude Haiku via API. Alternativas: Claude Code routine com Opus, parser determinístico, curadoria manual.
-4. **Múltiplas fontes por lei são esperadas.** Assembleia + Casa Civil + Diário Oficial; reconciliação com hierarquia DO > Casa Civil > Assembleia.
+4. **Múltiplas fontes por lei são esperadas.** Assembleia + Casa Civil + Diário Oficial fazem **cross-verificação** do vigente compilado — não competem por canonicidade. Divergências indicam possível erro de consolidação ou retificação não-aplicada; frontend exibe como "verificar", não como ranking de autoridade. Ver SCHEMA.md §0.2.
 5. **Genérico por ente federativo desde dia 1.** Tudo parametrizado por `{ente}`.
 6. **Leizilla XML é canônico, dispositivo-cêntrico.** Formato próprio (não fork). LexML é gate de CI (export reduzido sob demanda), não constraint estrutural. SSR híbrido: Astro renderiza páginas de detalhe; XSLT in-browser é fallback.
 7. **ZIP raw bulk, Parquet analytics (3 tabelas: leis + dispositivos + versoes), IA item distribuição.** Padrão ficha + normalização para timeline temporal.
@@ -98,11 +98,14 @@ Outras decisões do mesmo review já incorporadas em SCHEMA.md:
 - **Decisão**: adotar Astro + Svelte + Pico + DuckDB-WASM, mirror do que já funciona em verne/cobogo/franklinbaldo.github.io.
 - **Justificativa**: stack provada, build static, zero servidor, integra DuckDB-WASM nativamente.
 
-### 2026-05-20 — LeiML em vez de LexML cru
-- **Decisão**: criar formato próprio `LeiML` v0.1 (namespace `https://leizilla.org/leiml/0.1`), inspirado em LexML mas modernizado.
-- **Justificativa**: LexML/e-PING parado desde ~2010, XSD pesado, tooling Python esparso.
-- **Constraint inviolável**: LeiML é 100% exportável para LexML via `leiml-to-lexml.xsl`. CI valida round-trip a cada PR.
-- **URN compartilhado**: `urn:lex:br;...` (padrão LEX é OK e estável).
+### 2026-05-20 — LeiML em vez de LexML cru ⚠️ **SUPERSEDED**
+
+> **Superseded por** "Rewrite arquitetural pós-review #6 (3 blockers)" acima (mesmo dia). LeiML foi abandonado como fork — formato canônico atual é **Leizilla XML v0.1** (formato próprio, escrito do zero, dispositivo-cêntrico). LexML não é mais round-trip, é gate de CI one-way. Mantido aqui apenas como audit trail da iteração.
+
+- ~~**Decisão**: criar formato próprio `LeiML` v0.1 (namespace `https://leizilla.org/leiml/0.1`), inspirado em LexML mas modernizado.~~
+- ~~**Justificativa**: LexML/e-PING parado desde ~2010, XSD pesado, tooling Python esparso.~~
+- ~~**Constraint inviolável**: LeiML é 100% exportável para LexML via `leiml-to-lexml.xsl`. CI valida round-trip a cada PR.~~
+- **URN compartilhado**: `urn:lex:br;...` (padrão LEX é OK e estável). _Esta parte permanece válida._
 
 ### 2026-05-20 — OCR delegado ao Internet Archive
 - **Decisão**: não rodar OCR local em circunstância alguma. Upload PDF → IA OCR automático → poll `_djvu.txt`.
@@ -113,14 +116,15 @@ Outras decisões do mesmo review já incorporadas em SCHEMA.md:
 - **Justificativa**: isola falhas de parsing do scraping; permite trocar estratégia de Etapa 2 sem re-scraping.
 
 ### 2026-05-20 — Slug `{fonte}` é token único `[a-z]+`, sem hífens
-- **Decisão**: cada fonte tem **um único slug canônico** (`casacivil`, `diario`, `assembleia`) usado idêntico em IA identifier, `raw_meta.fonte`, `parsed_meta.fonte_canonica`/`resolvido_por`, atributo `tipo` em LeiML, coluna Parquet `fonte_canonica`, e enum `FONTES`.
+- **Decisão**: cada fonte tem **um único slug canônico** (`casacivil`, `diario`, `assembleia`) usado idêntico em IA identifier, `raw_meta.fonte`, `parsed_meta.fontes_consultadas`, elemento `<fonte-canonica>` em Leizilla XML, coluna Parquet `fonte_canonica`, e enum `FONTES`.
 - **Justificativa**: rascunho inicial misturava `diario`, `diario_oficial`, `diario-oficial` em locais diferentes — flagged pelo Codex em #6. Reconciliação determinística requer um único valor; hífen no slug quebra parsing do identifier `leizilla-raw-{ente}-{fonte}-{chave}` (ambiguidade entre fim de fonte e início de chave).
 - **Documentado em**: `docs/SCHEMA.md` §5 "Slug `{fonte}`".
 
-### 2026-05-20 — Múltiplas fontes oficiais com tracking de divergência
-- **Decisão**: cada lei pode ter N raw items (um por fonte: Assembleia, Casa Civil, Diário Oficial). Parsed item reconcilia.
-- **Hierarquia de autoridade**: Diário Oficial > Casa Civil > Assembleia. Divergências registradas em `parsed_meta.json.divergencias` e na coluna Parquet `tem_divergencia`.
-- **Frontend**: `LawCard.svelte` mostra badge "⚠ Divergência entre fontes" com modal de diff.
+### 2026-05-20 — Múltiplas fontes oficiais com tracking de divergência (atualizado pós-rewrite)
+- **Decisão**: cada lei pode ter N raw items (um por fonte: Assembleia, Casa Civil, Diário Oficial). Parsed item compila o vigente e expõe divergências.
+- **Cross-verificação, não ranking**: ~~Hierarquia Diário Oficial > Casa Civil > Assembleia~~ — descartada na reescrita. Fontes cross-verificam o vigente compilado; divergência sinaliza "verificar", não "fonte X ganha". Ver SCHEMA.md §0.2.
+- **Divergências registradas** em `parsed_meta.json.tem_divergencia` + `parsed_meta.json.num_divergencias` (flag rápido), tabela Parquet `versoes.divergencias` (JSON com diff por versão de dispositivo), e elemento `<divergencia>` em `law.xml`.
+- **Frontend**: `LawCard.svelte` mostra badge "⚠ Divergência entre fontes" com modal; banner adicional se `confianca_parse < 0.8` ou `parse_method` for LLM.
 
 ---
 
@@ -165,7 +169,7 @@ npm run build  # static build → dist/
 
 ```bash
 uv run leizilla dev check    # lint + format + typecheck + test
-uv run pytest tests/test_leiml_export.py -v  # round-trip LeiML→LexML
+uv run pytest tests/test_lexml_export.py -v  # gate CI: Leizilla XML → LexML (one-way)
 ```
 
 ---

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -8,7 +8,8 @@
 
 | Milestone | Status | PR | Notas |
 |---|---|---|---|
-| **M0** — Documento vivo + Design schema | 🟡 in-progress | #6 | M0.1 done; M0.2 reescrito após review dos 3 blockers; falta `leizilla-v0.1.xsd` + fixtures + decisões §10 do SCHEMA.md |
+| **M0.1** — Documento vivo + SCHEMA.md design | 🟢 done | #6 | Aprovado em re-review; pronto para merge. |
+| **M0.2** — XSD + fixtures + lexml-export script | ⚪ todo | — | Próximo. Inclui `leizilla-v0.1.xsd`, 3 fixtures Leizilla XML, `scripts/leizilla-to-lexml.xsl`, teste CI de export, consistency-checker script, e resolução de 6 pendentes §10. |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
@@ -254,12 +255,17 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 ## Próximos passos imediatos
 
-- [x] **M0.1**: `IMPLEMENTATION.md` criado e mantido.
-- [x] **M0.2**: `docs/SCHEMA.md` v1 (granularidade IA, layout ZIP, naming).
-- [x] **M0.2**: reescrita pós-review #6 (dispositivo-cêntrico, timeline temporal, formato próprio).
-- [ ] **M0.2**: rascunhar `docs/schemas/leizilla-v0.1.xsd`.
-- [ ] **M0.2**: fixtures de 3 leis representativas em `tests/fixtures/leizilla_xml/` (incluindo uma com alterações e uma com `<bloco-livre>`).
-- [ ] **M0.2**: rascunhar `scripts/leizilla-to-lexml.xsl` + teste CI de validação contra `lexml.xsd`.
-- [ ] **M0.2**: resolver decisões pendentes em `docs/SCHEMA.md` §10 (URN dialect, compressão Parquet, política re-scrape, LGPD).
-- [ ] **M0.3**: aprofundar inspirações concretas em `docs/SCHEMA.md` §8 (paths exatos de arquivos em ficha/baliza/causaganha).
-- [ ] Re-review do PR #6 após reescrita; aprovação → fechar M0 → abrir M1.
+**M0.1 — fechado** ✅ (PR #6 aprovado em re-review). Merge em sequência.
+
+**M0.2 — XSD + fixtures + export** (próximo PR):
+- [ ] Rascunhar `docs/schemas/leizilla-v0.1.xsd` consolidando todas decisões §4 do SCHEMA.md (dispositivo universal, caput implícito, parent obrigatório, path global/namespaceado, versoes ≥1).
+- [ ] Fixtures em `tests/fixtures/leizilla_xml/` (mínimo 3): (a) lei simples sem alterações, (b) lei com timeline de alterações e `<rotulo_versao>`, (c) lei com `<bloco-livre quality="raw">` (fallback OCR ruim).
+- [ ] `scripts/leizilla-to-lexml.xsl` + teste CI `tests/test_lexml_export.py` validando contra `tests/fixtures/lexml.xsd` (bundle no repo).
+- [ ] **Consistency checker script** (`scripts/check_schema_consistency.py`): extrai exemplos de identifier e schema_version do SCHEMA.md, valida contra regex §5, checa que `v{N}` no path bate com `int(major(schema_version))`. Reduz Codex catches futuros.
+- [ ] **FK invariant test** (no ETL M3 mas validação local em M0.2): com 1 tabela denormalizada, garantir que `(lei_id, dispositivo_path, dispositivo_parent_path)` permanece consistente entre todas as rows da mesma lei (não há outra forma de detectar inconsistência sem JOIN).
+- [ ] Resolver pendentes §10: URN dialect contra CGPID spec, compressão Parquet (SNAPPY vs ZSTD em DuckDB-WASM), granularidade bundle ZIP, XPath dialect, robots.txt rate-limit, XSLT in-browser deprecation status.
+
+**M0.3 — Inspirações concretas** (paralelo a M0.2):
+- [ ] Aprofundar `docs/SCHEMA.md` §8 com paths exatos em ficha/baliza/causaganha (manifest CSV columns, naming patterns, footer KV examples).
+
+**M1 — Foundation** (após M0.2 fechar): package restructure `src/` → `src/leizilla/`, ADRs 0004–0010, deps, e a migração `origem` → `ente` em CLI + schema (storage.py:44, cli.py:29,69,169,199,260).

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,0 +1,165 @@
+# IMPLEMENTATION.md — Leizilla → franklinbaldo stack
+
+> **Documento vivo.** Este arquivo espelha o plano de migração e é atualizado a cada PR. Sempre que uma decisão for tomada, um problema for descoberto, ou um milestone fechar, edite aqui. O git log deste arquivo é a memória institucional da migração.
+
+**Plano-mãe (read-only):** `/root/.claude/plans/eu-quero-fazer-esse-iterative-trinket.md` (não versionado — é o handoff do Claude Code).
+
+---
+
+## Status atual
+
+| Milestone | Status | PR | Notas |
+|---|---|---|---|
+| **M0** — Documento vivo + Design schema | 🟡 in-progress | — | M0.1 done; M0.2 rascunho em `docs/SCHEMA.md`; falta `leiml-v0.1.xsd` e fixtures |
+| M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
+| M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
+| M3 — OCR fetch + LLM parse + LeiML | ⚪ todo | — | Bloqueado por M2 |
+| M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
+| M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |
+| M6 — GitHub Actions | ⚪ todo | — | Depende de M2–M5 |
+| M7 — Claude Code routines | ⚪ todo | — | Depende de M6 |
+
+Legenda: ⚪ todo · 🟡 in-progress · 🟢 done · 🔴 blocked
+
+---
+
+## Visão arquitetural (resumo executivo)
+
+```
+Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt)
+                                              ↓
+                ETAPA 2 (LLM/agentes parsing) → LeiML XML + parsed_meta.json no IA
+                                              ↓
+                etl/consolidate                → Parquet v1 no IA (dataset item)
+                                              ↓
+                deploy-web                     → Astro+Svelte+Pico+DuckDB-WASM no GH Pages
+```
+
+### Princípios load-bearing (não violar sem RFC)
+
+1. **Duas etapas no IA, sempre separadas.** Raw é imutável; parsed re-roda quantas vezes for preciso.
+2. **OCR é responsabilidade do Internet Archive.** Nunca rodamos OCR local.
+3. **Etapa 2 é pluggable.** Default: Claude Haiku via API. Alternativas: Claude Code routine com Opus, parser determinístico, curadoria manual.
+4. **Múltiplas fontes por lei são esperadas.** Assembleia + Casa Civil + Diário Oficial; reconciliação com hierarquia DO > Casa Civil > Assembleia.
+5. **Genérico por ente federativo desde dia 1.** Tudo parametrizado por `{ente}`.
+6. **LeiML é canônico, HTML é apresentação.** LeiML exportável para LexML (CI round-trip). HTML renderizado no browser via XSLT/JS.
+7. **ZIP raw bulk, Parquet analytics, IA item distribuição.** Padrão ficha.
+
+---
+
+## Stack confirmado
+
+| Camada | Tecnologia | Versão |
+|---|---|---|
+| Backend | Python | 3.12 |
+| ETL | DuckDB + PyArrow | latest |
+| Storage canônico | LeiML XML (nosso fork de LexML) | 0.1 |
+| Storage distribuído | Internet Archive | — |
+| Frontend framework | Astro | 6.3 |
+| Frontend components | Svelte | 5.55 |
+| CSS | Pico CSS | 2.1 |
+| Browser DB | DuckDB-WASM | 1.28 |
+| Data fetching | TanStack Svelte Query | 6.1 |
+| Hosting | GitHub Pages | — |
+| LLM parsing | Claude Haiku | `claude-haiku-4-5-20251001` |
+| LLM fallback | Claude Opus | `claude-opus-4-7` |
+
+---
+
+## Decisões técnicas (log cronológico)
+
+Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-20 — Migração para stack franklinbaldo iniciada
+- **Decisão**: adotar Astro + Svelte + Pico + DuckDB-WASM, mirror do que já funciona em verne/cobogo/franklinbaldo.github.io.
+- **Justificativa**: stack provada, build static, zero servidor, integra DuckDB-WASM nativamente.
+
+### 2026-05-20 — LeiML em vez de LexML cru
+- **Decisão**: criar formato próprio `LeiML` v0.1 (namespace `https://leizilla.org/leiml/0.1`), inspirado em LexML mas modernizado.
+- **Justificativa**: LexML/e-PING parado desde ~2010, XSD pesado, tooling Python esparso.
+- **Constraint inviolável**: LeiML é 100% exportável para LexML via `leiml-to-lexml.xsl`. CI valida round-trip a cada PR.
+- **URN compartilhado**: `urn:lex:br;...` (padrão LEX é OK e estável).
+
+### 2026-05-20 — OCR delegado ao Internet Archive
+- **Decisão**: não rodar OCR local em circunstância alguma. Upload PDF → IA OCR automático → poll `_djvu.txt`.
+- **Trade-off aceito**: latência de horas até OCR disponível; manifest CSV rastreia `ocr_ready` separado de `raw_uploaded`.
+
+### 2026-05-20 — Duas etapas separadas no IA
+- **Decisão**: raw items e parsed items são IA items distintos. Raw é imutável após upload; parsed pode ser re-uploadado quantas vezes preciso.
+- **Justificativa**: isola falhas de parsing do scraping; permite trocar estratégia de Etapa 2 sem re-scraping.
+
+### 2026-05-20 — Múltiplas fontes oficiais com tracking de divergência
+- **Decisão**: cada lei pode ter N raw items (um por fonte: Assembleia, Casa Civil, Diário Oficial). Parsed item reconcilia.
+- **Hierarquia de autoridade**: Diário Oficial > Casa Civil > Assembleia. Divergências registradas em `parsed_meta.json.divergencias` e na coluna Parquet `tem_divergencia`.
+- **Frontend**: `LawCard.svelte` mostra badge "⚠ Divergência entre fontes" com modal de diff.
+
+---
+
+## Problemas encontrados
+
+> Adicione aqui qualquer obstáculo, bug, ou descoberta que mude o plano. Inclua data, descrição, e link para PR/issue de resolução (se houver).
+
+_(vazio — preencher conforme implementação avança)_
+
+---
+
+## Como rodar localmente
+
+### Pipeline backend (Python)
+
+```bash
+# Setup
+uv venv && source .venv/bin/activate
+uv sync --dev
+uv run leizilla dev setup
+
+# Pipeline completo (após M2)
+uv run leizilla pipeline --ente ro --start-coddoc 1 --end-coddoc 10
+
+# Etapas separadas
+uv run leizilla scrape --ente ro --fonte casacivil --start-coddoc 1 --end-coddoc 10
+uv run leizilla parse --ente ro --raw-ids leizilla-raw-ro-casacivil-coddoc-00001
+uv run leizilla consolidate --ente ro
+uv run leizilla release-dataset --ente ro --version 1
+```
+
+### Frontend (após M5)
+
+```bash
+cd web/
+npm install
+npm run dev    # http://localhost:4321
+npm run build  # static build → dist/
+```
+
+### Testes
+
+```bash
+uv run leizilla dev check    # lint + format + typecheck + test
+uv run pytest tests/test_leiml_export.py -v  # round-trip LeiML→LexML
+```
+
+---
+
+## Referência rápida — IA identifiers
+
+| Tipo | Pattern | Exemplo |
+|---|---|---|
+| Raw (individual) | `leizilla-raw-{ente}-{fonte}-{chave}` | `leizilla-raw-ro-casacivil-coddoc-00042` |
+| Raw (bundle ZIP) | `leizilla-bundle-{ente}-{fonte}-{periodo}` | `leizilla-bundle-ro-casacivil-2026-W20` |
+| Parsed (lei canônica) | `leizilla-{ente}-{tipo}-{numero}-{ano}` | `leizilla-ro-lei-01234-2003` |
+| Dataset (Parquet) | `leizilla-dataset-{ente}-v{N}` | `leizilla-dataset-ro-v1` |
+
+Slug `{ente}`: `ro`, `sp`, `federal`, `ro-porto-velho` (kebab-case, UF-municipio).
+
+Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
+
+---
+
+## Próximos passos imediatos
+
+- [ ] **M0.2**: escrever `docs/SCHEMA.md` com decisões de granularidade IA, layout ZIP, schema Parquet v1, schema LeiML v0.1
+- [ ] **M0.2**: rascunhar `docs/schemas/leiml-v0.1.xsd`
+- [ ] **M0.2**: fixtures de 3 leis representativas em `tests/fixtures/leiml/` validando round-trip LeiML→LexML
+- [ ] **M0.3**: documentar inspirações concretas em `docs/SCHEMA.md` (links para arquivos específicos em ficha/baliza/causaganha)
+- [ ] PR de M0 para review antes de iniciar M1

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -42,6 +42,7 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 5. **Genérico por ente federativo desde dia 1.** Tudo parametrizado por `{ente}`.
 6. **Leizilla XML é canônico, dispositivo-cêntrico.** Formato próprio (não fork). LexML é gate de CI (export reduzido sob demanda), não constraint estrutural. SSR híbrido: Astro renderiza páginas de detalhe; XSLT in-browser é fallback.
 7. **ZIP raw bulk (padrão ficha) + Parquet relacional normalizado (3 tabelas com FKs: leis ← dispositivos ← versoes) + IA item para distribuição.** Ficha tem 1 Parquet por entidade; nosso modelo introduz normalização relacional explícita para suportar timeline temporal por dispositivo. Manifest CSV no IA como source of truth (padrão baliza).
+9. **Wayback Machine é caminho primário de fetch.** Crawler não bate na fonte original — dispara Wayback save de `fonte_url` + `pdf_url`, depois fetch o PDF do snapshot Wayback para upload na nossa coleção IA. Fail-open: se Wayback falha, fallback de download direto. Polite com sites .gov.br frágeis + testemunha externa automática. Detalhes em SCHEMA.md §0.5.
 8. **Vigente compilado é canônico, histórico via timeline.** Parsed item = "como deve estar vigente hoje" (best-effort). Versões anteriores acessíveis via date picker. Fontes (DO, Casa Civil, Assembleia) cross-verificam — não competem por autoridade.
 
 ---
@@ -88,6 +89,41 @@ Outras decisões do mesmo review já incorporadas em SCHEMA.md:
 - Schema Parquet é v0.1 durante M0–M4, promove a v1 só em M5.
 - SSR híbrido via Astro (suaviza princípio 6 — XSLT in-browser é fallback).
 - Confiança baixa exibida explicitamente no frontend (banner LLM/OCR).
+
+### 2026-05-20 — Wayback Machine como caminho primário de fetch
+
+- **Decisão**: crawler dispara `POST /save` no Wayback Machine para `fonte_url` + `pdf_url`, depois **fetch o PDF do snapshot Wayback** (não da fonte original) para upload na nossa coleção IA. Fail-open: timeout/erro/rate-limit do Wayback → fallback para download direto da fonte, gravar `fetched_from: "source-fallback"` em `raw_meta.json.provenance_wayback`.
+- **Não substitui IA**: nossa coleção continua sendo o archive primário (necessário para OCR automático que alimenta Etapa 2). Wayback é buffer + testemunha externa.
+- **Por que**: (a) bate na fonte original uma única vez (via bot Wayback), polite com sites .gov.br frágeis; (b) timestamp Wayback é testemunha independente para auditoria forense; (c) reduz superfície de rate-limit do nosso lado.
+- **Cache**: antes de disparar save, checar `GET https://archive.org/wayback/available?url=...`. Reusa snapshot < 24h.
+- **Documentado em**: SCHEMA.md §0.5; sidecar em §2.1 (`provenance_wayback`).
+
+### 2026-05-20 — Caput como índice 0 implícito (Opção D)
+
+- **Decisão**: caput não é elemento separado no Leizilla XML. Todo `<dispositivo>` container (artigo, parágrafo, inciso) tem `<versoes>` opcional carregando **seu próprio texto intrínseco** — que corresponde semanticamente ao "caput" na terminologia jurídica. Sem `<dispositivo tipo="caput">`.
+- **Insight do usuário**: "caput é como um índice 0". Conceitualmente o caput é o "filho zero" do container; serialização XML deixa implícito via `<versoes>` no próprio container.
+- **Aplica recursivamente**: parágrafo com incisos também tem caput (seu texto antes dos incisos). Inciso com alíneas idem.
+- **URN**: `urn:lex:...!art-5` resolve para o texto intrínseco (caput) do art-5. Sub-itens via `!art-5!par-1`.
+- **Parquet**: 1 row por dispositivo. Row do container **é** o caput. Sem row extra.
+- **Export LexML**: XSLT wrap mecânico — `<dispositivo path="art-5"><versoes>...</versoes>` vira `<Artigo><Caput><Texto>...</Texto></Caput>`.
+- **Documentado em**: SCHEMA.md §4.3.
+
+### 2026-05-20 — LGPD: leis públicas não despublicam
+
+- **Posição cravada**: leis estaduais e federais são atos públicos por força da CF (art. 5º LX, art. 84 IV, art. 37 caput). LGPD (Lei 13.709/2018) não autoriza despublicação de norma pública e não está acima da Constituição.
+- **Citação de pessoas físicas em leis antigas** (nomeações, aposentadorias, concessões individuais — comuns em leis estaduais pré-2000) faz parte do ato administrativo público original. Indexar e republicar é **continuidade do ato**, não tratamento novo de dados pessoais sujeito a consentimento.
+- **Não rodamos triagem/redação** de nomes. Documentar formalmente em ADR-0009 (Claude routines + ética) em M1.
+
+### 2026-05-20 — Custo LLM diluído no tempo, sem ressalva de design
+
+- **Estimativa realista**: ~$40–100/ente (5k leis × 10k tokens × Haiku), revisada do "<$5" inicial.
+- **Aceitável**: ingestão é one-shot por lei; custo amortiza no tempo. Re-parsing pontual via fill-gaps é marginal. Não é fator de bloqueio para design.
+
+### 2026-05-20 — Re-scrape sob auditoria; nova fonte sob auditoria
+
+- **Re-scrape**: NÃO é automático. Só dispara quando auditoria periódica de qualidade conclui que o raw está degradado (e.g., versão do PDF foi corrigida pela fonte, ou OCR muito ruim para LLM extrair). Novo raw item vira `{chave}-r{N}` (revisão); raw anterior permanece imutável (princípio 1).
+- **Nova fonte por ente**: processo paralelo de auditoria periódica avalia se fontes adicionais oficiais devem ser declaradas em `src/leizilla/fontes/{ente}.py` (e.g., portal de transparência que reúne consolidados).
+- **Cadência**: pendente — definir em M1 se é trimestral, anual, ou demand-driven.
 
 ### 2026-05-20 — Renomear `origem` → `ente` em CLI e schema (M1)
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -41,9 +41,9 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 4. **Múltiplas fontes por lei são esperadas.** Assembleia + Casa Civil + Diário Oficial fazem **cross-verificação** do vigente compilado — não competem por canonicidade. Divergências indicam possível erro de consolidação ou retificação não-aplicada; frontend exibe como "verificar", não como ranking de autoridade. Ver SCHEMA.md §0.2.
 5. **Genérico por ente federativo desde dia 1.** Tudo parametrizado por `{ente}`.
 6. **Leizilla XML é canônico, dispositivo-cêntrico.** Formato próprio (não fork). LexML é gate de CI (export reduzido sob demanda), não constraint estrutural. SSR híbrido: Astro renderiza páginas de detalhe; XSLT in-browser é fallback.
-7. **ZIP raw bulk (padrão ficha) + Parquet relacional normalizado (3 tabelas com FKs: leis ← dispositivos ← versoes) + IA item para distribuição.** Ficha tem 1 Parquet por entidade; nosso modelo introduz normalização relacional explícita para suportar timeline temporal por dispositivo. Manifest CSV no IA como source of truth (padrão baliza).
-9. **Wayback Machine é caminho primário de fetch.** Crawler não bate na fonte original — dispara Wayback save de `fonte_url` + `pdf_url`, depois fetch o PDF do snapshot Wayback para upload na nossa coleção IA. Fail-open: se Wayback falha, fallback de download direto. Polite com sites .gov.br frágeis + testemunha externa automática. Detalhes em SCHEMA.md §0.5.
+7. **ZIP raw bulk (padrão ficha) + Parquet single-table denormalizado + IA item para distribuição.** Manifest CSV no IA como source of truth (padrão baliza). Uma única tabela `versoes` (grain: lei × dispositivo × versão) cobre tudo durante M0–M4; estrutura emerge via `SELECT DISTINCT`. Pode evoluir para tabelas separadas se DuckDB-WASM ficar gargalo (decisão em M5).
 8. **Vigente compilado é canônico, histórico via timeline.** Parsed item = "como deve estar vigente hoje" (best-effort). Versões anteriores acessíveis via date picker. Fontes (DO, Casa Civil, Assembleia) cross-verificam — não competem por autoridade.
+9. **Wayback Machine é caminho primário de fetch.** Crawler não bate na fonte original — dispara Wayback save de `fonte_url` + `pdf_url`, depois fetch o PDF do snapshot Wayback para upload na nossa coleção IA. Fail-open: se Wayback falha, fallback de download direto. Polite com sites .gov.br frágeis + testemunha externa automática. Detalhes em SCHEMA.md §0.5.
 
 ---
 
@@ -89,6 +89,14 @@ Outras decisões do mesmo review já incorporadas em SCHEMA.md:
 - Schema Parquet é v0.1 durante M0–M4, promove a v1 só em M5.
 - SSR híbrido via Astro (suaviza princípio 6 — XSLT in-browser é fallback).
 - Confiança baixa exibida explicitamente no frontend (banner LLM/OCR).
+
+### 2026-05-20 — Parquet single table (versoes), denormalizado
+
+- **Decisão**: uma única tabela `versoes` no Parquet, com grain (lei × dispositivo × versão). Metadados de lei e dispositivo denormalizados em cada row. Substitui o design anterior de 3 tabelas relacionais (`leis` + `dispositivos` + `versoes`).
+- **Justificativa**: Parquet é read-only servido estaticamente do IA; dictionary encoding + SNAPPY mitigam a redundância. Zero JOIN em DuckDB-WASM = queries triviais + menos arquivos pro browser baixar (1 fetch). Estrutura (TOC, listagem) emerge via `SELECT DISTINCT`. Pré-agregados (num_dispositivos, num_divergencias) viram queries `COUNT(DISTINCT ...)` cacheáveis no client.
+- **Trade-off aceito**: redundância de dados (lei metadata repetida por dispositivo-versão). Estimativa RO: 5k leis × ~30 dispositivos × ~2 versões = ~300k rows. Tamanho do Parquet medido em M4 com dados reais.
+- **Revisitar em M5**: se DuckDB-WASM ficar gargalo (file size grande, latência de fetch), reavaliar split em 2 ou 3 tabelas. Por enquanto: single table.
+- **Documentado em**: SCHEMA.md §3 (rewrite completo, com padrões de query exemplificados).
 
 ### 2026-05-20 — Dispositivo universal: tudo que é texto da lei
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -150,7 +150,7 @@ Não inclui HTML pré-gerado (renderização SSR via Astro a partir de `law.xml`
 
 **Pattern**: `leizilla-dataset-{ente}-v{N}`
 
-Conteúdo: `leis-{ente}-v{N}.parquet`, `dispositivos-{ente}-v{N}.parquet`, `versoes-{ente}-v{N}.parquet`, `manifest-{ente}.csv`, `README.md`.
+Conteúdo: `versoes-{ente}-v{N}.parquet` (single table, ver §3), `manifest-{ente}.csv`, `README.md`.
 
 Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado de forma incompatível).
 
@@ -260,106 +260,133 @@ Relações computadas com outras leis. Permite ao frontend mostrar "esta lei foi
 
 ---
 
-## 3. Schema Parquet v0.1 — três tabelas
+## 3. Schema Parquet v0.1 — single table (transitório)
 
-> Schema é **v0.1 durante M0–M4**; promove a **v1 apenas no fechamento de M5** (ver §3.6 e §7). Identificadores `leizilla.schema_version` no footer KV e o `v{N}` no caminho do arquivo refletem isso.
+> Schema é **v0.1 durante M0–M4**; promove a **v1 apenas no fechamento de M5** (ver §3.4 e §7). Identificadores `leizilla.schema_version` no footer KV e o `v{N}` no caminho do arquivo refletem isso.
 
-Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet separado no dataset item.
+**Decisão (aprovada): uma única tabela `versoes`** com grain (lei × dispositivo × versão). Metadados de lei e dispositivo denormalizados em cada row. Estrutura/listagem emerge via `SELECT DISTINCT`. Read-only Parquet servido estaticamente do IA — dictionary encoding + SNAPPY compress as repetições. Tradeoff explícito: simplicidade de query (zero JOIN no DuckDB-WASM) vs redundância de dados (compressão Parquet mitiga).
 
-### 3.1 Tabela `leis` — header por lei
+Pode evoluir para 2 ou 3 tabelas se DuckDB-WASM ficar gargalo na prática — decisão revisitada em M5 com dados reais (~5k leis RO × ~30 dispositivos × ~2 versões = ~300k rows, tamanho do Parquet a medir).
+
+### 3.1 Tabela `versoes` — single source of truth
+
+Cada row é uma versão de um dispositivo de uma lei. Colunas agrupadas por origem semântica:
+
+**Lei (denormalizado, repetido por row da mesma lei):**
 
 | coluna | tipo | nullable | nota |
 |---|---|---|---|
-| `id` | VARCHAR | NO | identifier IA do parsed item, **zero-padded** (e.g. `leizilla-ro-lei-01234-2003`) |
+| `lei_id` | VARCHAR | NO | identifier IA do parsed item, zero-padded (e.g. `leizilla-ro-lei-01234-2003`) |
 | `ente` | VARCHAR | NO | `ro`, `sp`, `federal`, `ro-porto-velho`... |
-| `tipo` | VARCHAR | NO | `lei`, `decreto`, `lc`, `resolucao`... |
-| `numero` | VARCHAR | YES | nullable porque fallback existe |
+| `tipo_lei` | VARCHAR | NO | `lei`, `decreto`, `lc`, `resolucao`... |
+| `numero_lei` | VARCHAR | YES | nullable porque fallback existe |
 | `ano` | INTEGER | NO | |
 | `data_publicacao` | DATE | YES | |
-| `urn_lex` | VARCHAR | YES | nullable se `data_publicacao` desconhecida (URN LEX requer data) — ver §5.4 |
-| `titulo` | VARCHAR | YES | |
-| `ementa` | VARCHAR | YES | |
+| `urn_lex` | VARCHAR | YES | nullable se `data_publicacao` desconhecida; URN LEX requer data — ver §5.5 |
+| `titulo_lei` | VARCHAR | YES | título oficial denormalizado (mesmo conteúdo do dispositivo `tipo_dispositivo='titulo-lei'`) |
+| `ementa` | VARCHAR | YES | ementa denormalizada (mesmo conteúdo do dispositivo `tipo_dispositivo='ementa'`) |
 | `url_law_xml_ia` | VARCHAR | NO | URL do `law.xml` no IA |
-| `vigente_em` | DATE | NO | data da compilação vigente |
-| `tem_divergencia` | BOOLEAN | NO | flag rápido frontend; agregado: `OR` sobre todas as `versoes.tem_divergencia` de dispositivos desta lei |
-| `num_divergencias` | INTEGER | NO | soma de `versoes.tem_divergencia=true` |
-| `num_dispositivos` | INTEGER | NO | pré-computado para listagens baratas |
-| `num_versoes_total` | INTEGER | NO | soma de versoes em todos os dispositivos |
-| `revogada` | BOOLEAN | NO | |
+| `vigente_em` | DATE | NO | data de referência da compilação (toda a lei) |
+| `revogada` | BOOLEAN | NO | a lei inteira foi revogada |
 | `parse_status` | VARCHAR | NO | `raw_only`/`parsed`/`failed` |
 | `parse_method` | VARCHAR | YES | `llm-haiku`/`llm-opus`/`manual`/`deterministic` |
 | `confianca_parse` | FLOAT | YES | 0.0–1.0 |
+
+**Dispositivo (denormalizado, repetido por versão do mesmo dispositivo):**
+
+| coluna | tipo | nullable | nota |
+|---|---|---|---|
+| `dispositivo_path` | VARCHAR | NO | `art-3` / `art-3-par-2` / `tit-1-cap-1` / etc. Normativos = global; organizacionais = namespaceado (§4.3 regras 3 e 4) |
+| `dispositivo_parent_path` | VARCHAR | NO | path do pai; raiz = `""`; sempre declarado (§0.1) |
+| `tipo_dispositivo` | VARCHAR | NO | enum unificado (§0.1): normativos (`titulo-lei`, `ementa`, `preambulo`, `artigo`, `paragrafo`, `inciso`, `alinea`, `item`, `anexo`, `disposicao-transitoria`, `disposicao-final`) + organizacionais (`livro`, `parte`, `titulo`, `capitulo`, `secao`, `subsecao`). **Não inclui `caput`** — caput é índice 0 implícito (§4.3). |
+| `rotulo` | VARCHAR | NO | "Art. 1º", "§ 2º", "II", "a)", "TÍTULO I — Dos Princípios"... estável; override por versão fica em `rotulo_versao` |
+| `ordem` | INTEGER | NO | ordem dentro do parent (1, 2, 3...) |
+| `urn_dispositivo` | VARCHAR | YES | NULL ⟺ `urn_lex` é NULL |
+
+**Versão (único por row):**
+
+| coluna | tipo | nullable | nota |
+|---|---|---|---|
+| `versao_id` | VARCHAR | NO | `{lei_id}#{dispositivo_path}#v{N}` — PK |
+| `numero_versao` | INTEGER | NO | 1, 2, 3... cronológico dentro do dispositivo |
+| `vigente_de` | DATE | NO | |
+| `vigente_ate` | DATE | YES | NULL = ainda vigente |
+| `texto` | VARCHAR | YES | NULL quando dispositivo é organizacional (tipo ∈ {livro, parte, titulo, capitulo, secao, subsecao}); NOT NULL para normativos |
+| `texto_normalizado` | VARCHAR | YES | NFC + cleanup p/ busca client-side. NULL nas mesmas condições de `texto` |
+| `rotulo_versao` | VARCHAR | YES | override do `rotulo` estável; útil quando rotulo muda entre versões (renomear capítulo). Normalmente NULL |
+| `alterado_por_lei_id` | VARCHAR | YES | NULL na versão original; senão lei_id da lei alteradora |
+| `fonte_canonica` | VARCHAR | NO | slug curto da fonte (`casacivil`, `diario`, `assembleia`...) |
+| `fontes_consultadas` | VARCHAR (JSON array) | NO | lista de raw IA ids usados nesta versão |
+| `tem_divergencia` | BOOLEAN | NO | |
+| `divergencias` | VARCHAR (JSON) | YES | diff summary entre fontes para esta versão |
+| `hash_texto` | VARCHAR | YES | sha256 de `texto`; NULL quando `texto` é NULL |
+| `bloco_livre_quality` | VARCHAR | YES | `null` (parsing OK) / `low` / `medium` / `high` / `raw` se `<bloco-livre>` foi usado (§4.4) |
 | `created_at` | TIMESTAMP | NO | |
 | `updated_at` | TIMESTAMP | NO | |
 
-### 3.2 Tabela `dispositivos` — uma linha por dispositivo
+### 3.2 Padrões de query
 
-| coluna | tipo | nullable | nota |
-|---|---|---|---|
-| `dispositivo_id` | VARCHAR | NO | composto: `{lei_id}#{path}` (e.g. `leizilla-ro-lei-01234-2003#art-3-par-2`) |
-| `lei_id` | VARCHAR | NO | FK para `leis.id` |
-| `urn_dispositivo` | VARCHAR | YES | `urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-3!par-2` (LexML dialect, ver §5.5). Regra: `urn_dispositivo` é `NULL` ⟺ `leis.urn_lex` da lei pai é `NULL` (lei sem data extraível) |
-| `tipo` | VARCHAR | NO | enum unificado (ver §0.1): normativos (`titulo-lei`, `ementa`, `preambulo`, `artigo`, `paragrafo`, `inciso`, `alinea`, `item`, `anexo`, `disposicao-transitoria`, `disposicao-final`) + organizacionais (`livro`, `parte`, `titulo`, `capitulo`, `secao`, `subsecao`). **Não inclui `caput`** — caput é índice 0 implícito (§4.3). Filtrar blocos vs normativos: `WHERE texto IS NOT NULL` (normativos têm texto) ou `WHERE tipo IN (...)` por enum. |
-| `rotulo` | VARCHAR | NO | "Art. 1º", "§ 2º", "II", "a)" |
-| `path` | VARCHAR | NO | hierárquico: `art-3` / `art-3-par-2` / `art-3-par-2-inc-1` / `art-3-par-2-inc-1-ali-a` |
-| `parent_path` | VARCHAR | NO | path do dispositivo pai. Raiz: string vazia `""`. Sempre declarado (§0.1: parent obrigatório). |
-| `ordem` | INTEGER | NO | ordem dentro do parent (1, 2, 3...) |
-| `texto_vigente` | VARCHAR | YES | texto da versão atualmente vigente (denormalizado para query rápida) |
-| `vigente_desde` | DATE | YES | data efeito da versão vigente |
-| `revogado` | BOOLEAN | NO | |
-| `revogado_em` | DATE | YES | |
+```sql
+-- Texto vigente de art-5 da Lei 1234/2003 hoje
+SELECT texto FROM versoes
+WHERE lei_id = 'leizilla-ro-lei-01234-2003'
+  AND dispositivo_path = 'art-5'
+  AND vigente_ate IS NULL;
 
-### 3.3 Tabela `versoes` — uma linha por versão histórica de cada dispositivo
+-- Texto de art-5 como estava em 2010-01-01
+SELECT texto FROM versoes
+WHERE lei_id = 'leizilla-ro-lei-01234-2003'
+  AND dispositivo_path = 'art-5'
+  AND vigente_de <= DATE '2010-01-01'
+  AND (vigente_ate > DATE '2010-01-01' OR vigente_ate IS NULL);
 
-| coluna | tipo | nullable | nota |
-|---|---|---|---|
-| `versao_id` | VARCHAR | NO | `{dispositivo_id}#v{N}` |
-| `dispositivo_id` | VARCHAR | NO | FK para `dispositivos.dispositivo_id` |
-| `lei_id` | VARCHAR | NO | denormalizado p/ join-free queries |
-| `numero_versao` | INTEGER | NO | 1, 2, 3... cronológico |
-| `vigente_de` | DATE | NO | |
-| `vigente_ate` | DATE | YES | NULL = ainda vigente |
-| `texto` | VARCHAR | YES | NULL quando o dispositivo é organizacional (tipo ∈ {livro, parte, titulo, capitulo, secao, subsecao}); NOT NULL para normativos. |
-| `texto_normalizado` | VARCHAR | YES | NFC + cleanup, alimenta busca client-side. Mesmo padrão de nullability que `texto`. |
-| `rotulo` | VARCHAR | YES | rotulo na versão (override do `dispositivos.rotulo` estável). Útil quando rotulo muda entre versões (renomear capítulo). Normalmente NULL. |
-| `alterado_por_lei_id` | VARCHAR | YES | NULL na versão original; senão FK para `leis.id` da lei alteradora |
-| `fonte_canonica` | VARCHAR | NO | slug curto da fonte usada (`casacivil`, `diario`, `assembleia`...) |
-| `fontes_consultadas` | VARCHAR (JSON array) | NO | lista de raw IA ids usados |
-| `tem_divergencia` | BOOLEAN | NO | |
-| `divergencias` | VARCHAR (JSON) | YES | diff summary entre fontes |
-| `hash_texto` | VARCHAR | NO | sha256 |
-| `bloco_livre_quality` | VARCHAR | YES | `null` (parsing OK) / `low` / `medium` / `high` / `raw` se `<bloco-livre>` foi usado (ver §4.4 — `raw` para casos onde OCR é tão ruim que nem dá pra estimar qualidade) |
+-- Estrutura/TOC de uma lei (DISTINCT extrai dispositivos)
+SELECT DISTINCT dispositivo_path, tipo_dispositivo, dispositivo_parent_path, rotulo, ordem
+FROM versoes
+WHERE lei_id = 'leizilla-ro-lei-01234-2003'
+ORDER BY ordem;
 
-### 3.4 Representação de arrays e JSON
+-- Listagem de todas as leis de um ente
+SELECT DISTINCT lei_id, titulo_lei, ementa, ano, parse_status, confianca_parse
+FROM versoes
+WHERE ente = 'ro'
+ORDER BY ano DESC, numero_lei;
 
-**Decisão (aprovada)**: arrays **no Parquet** como `VARCHAR` com JSON serializado, **não** Parquet LIST nativo. Justificativa: simplifica TanStack Query + Svelte components; JSON universal; custo storage irrelevante com SNAPPY.
+-- Busca full-text em texto normalizado
+SELECT lei_id, dispositivo_path, texto FROM versoes
+WHERE ente = 'ro'
+  AND vigente_ate IS NULL
+  AND texto_normalizado LIKE '%servidor publico%';
+```
 
-**Sidecars JSON** (`raw_meta.json`, `parsed_meta.json`, `provenance.json`, `alteracoes.json`) usam arrays JSON nativos — a restrição §3.4 é específica do Parquet. Mesma semântica, formato adequado a cada camada.
+### 3.3 Representação de arrays e JSON
 
-### 3.5 Footer KV metadata (PyArrow)
+Arrays **no Parquet** como `VARCHAR` com JSON serializado, **não** Parquet LIST nativo. Justificativa: simplifica TanStack Query + Svelte components; JSON universal; custo storage irrelevante com SNAPPY.
+
+**Sidecars JSON** (`raw_meta.json`, `parsed_meta.json`, `provenance.json`, `alteracoes.json`) usam arrays JSON nativos — a restrição é específica do Parquet.
+
+### 3.4 Footer KV metadata (PyArrow)
 
 ```python
 {
   "leizilla.schema_version": "0.1",
   "leizilla.xml_schema_version": "0.1",
   "leizilla.ente": "ro",
-  "leizilla.table": "dispositivos",  # ou leis / versoes
+  "leizilla.table": "versoes",
   "leizilla.generated_at": "2026-05-20T19:00:00Z",
-  "leizilla.row_count": "12483",
+  "leizilla.row_count": "298473",
   "leizilla.git_sha": "abc1234def5678901234567890abcdef12345678"
 }
 ```
 
-Escrita via `pyarrow.parquet.write_table` (não DuckDB `COPY` — esse não embute KV custom).
+Escrita via `pyarrow.parquet.write_table` (não DuckDB `COPY` — esse não embute KV custom). `git_sha` é o SHA completo (40 chars), não truncado.
 
-> Reviewer #6 ponto 8 fix: `git_sha` é o SHA completo (40 chars), não truncado.
-
-### 3.6 Versioning
+### 3.5 Versioning
 
 - `schema_version` semver-ish na coluna `leizilla.schema_version`: major bump apenas em break.
 - **Mapping `schema_version` → identifier `v{N}`**: `N` é o **major** do `schema_version`. Pré-M5: `schema_version="0.1"` → identifier `v0` (e.g. `leizilla-dataset-ro-v0`, `leis-ro-v0.parquet`). Pós-M5: `schema_version="1"` → identifier `v1`. Identifier IA permanece inteiro `v\d+` por compatibilidade com regex de naming (§5.4); versão pré-release fica codificada no major `0`. Minor/patch (`0.1`, `0.2`) atualizam o footer KV sem novo identifier.
 - CI valida que `int(N)` no caminho do arquivo bate com `int(schema_version.split('.')[0])` do footer KV.
-- Zod schema em `web/src/schemas/v0/lei.ts` + `dispositivo.ts` + `versao.ts` durante M0–M4; movido para `v1/` quando schema_version promover para `1`.
+- Zod schema único em `web/src/schemas/v0/versao.ts` (matches single table) durante M0–M4; movido para `v1/` quando schema_version promover para `1`.
 - v1 só é cravado depois do MVP rodar (reviewer #6 ponto 13). Durante M0–M4 o schema é **v0.1** (identifier `v0`); promove para v1 no fechamento de M5.
 
 ---
@@ -414,7 +441,7 @@ Cada dispositivo carrega sua própria **timeline de versões**. Nested para hier
 
 **Regra do caput (Opção D — aprovada)**: caput não é elemento separado nem tipo. Todo `<dispositivo>` normativo container (artigo, parágrafo, inciso) carrega `<texto>` na sua própria `<versao>` — isso **é** o caput quando o dispositivo tem filhos. Conceitualmente o caput é o "índice 0" dos filhos do container. Implica:
 
-- **Sem `<dispositivo tipo="caput">`**. Caput é propriedade implícita do container normativo. `caput` **não está** no enum de `tipo` (§3.2).
+- **Sem `<dispositivo tipo="caput">`**. Caput é propriedade implícita do container normativo. `caput` **não está** no enum de `tipo_dispositivo` (§3.1).
 - **URN aponta para o container**: `urn:lex:...!art-5` resolve para o texto intrínseco (caput) do art-5. Sub-itens via `!art-5!par-1`, etc.
 - **Versionamento granular preservado**: alterar só o caput = nova `<versao>` no próprio `<dispositivo path="art-5">`. Alterar só o §1 = nova `<versao>` em `<dispositivo path="art-5-par-1">`. Independentes.
 - **Aplica recursivamente**: parágrafo com incisos também tem "caput" (seu próprio texto antes dos incisos), mesma regra.
@@ -538,7 +565,7 @@ Cada dispositivo carrega sua própria **timeline de versões**. Nested para hier
 4. **Path do dispositivo organizacional namespaceia internamente** (`tit-1`, `tit-1-cap-1`, `tit-1-cap-1-sec-2`). Hierarquia de blocos é própria.
 5. **Caput é implícito (índice 0)**: container normativo (`artigo`, `paragrafo`, `inciso`) carrega seu próprio `<texto>` no nível do container; filhos `<dispositivo>` são sub-itens. Sem `<dispositivo tipo="caput">`. Ver detalhes abaixo.
 
-**Mapping nesting XML ↔ `path` flat na tabela Parquet `dispositivos`** (§3.2): geração determinística do path. Frontend e ETL usam o **mesmo gerador** (`src/leizilla/leizilla_xml/path.py` em M3).
+**Mapping nesting XML ↔ `dispositivo_path` flat na tabela Parquet `versoes`** (§3.1): geração determinística do path. Frontend e ETL usam o **mesmo gerador** (`src/leizilla/leizilla_xml/path.py` em M3).
 
 ```
 TÍTULO I  >  CAPÍTULO I  >  Art. 1º  >  § 1º  >  inciso I  >  alínea a
@@ -619,7 +646,7 @@ Abrir o XML direto no browser exibe HTML (XSLT in-browser). **Não** é o caminh
 
 > Reviewer #6 ponto 4 fix: `\d{5,}` em vez de `\d{5}` — leis federais já passam de 5 dígitos por extenso; zero-pad mínimo de 5 mantém ordenação lexicográfica para a maioria.
 
-> Codex P2 fix: o `id` no Parquet (§3.1) **sempre** usa o `numero` zero-padded para bater com o IA identifier. Lookup `id → IA item` é literal, sem normalização extra.
+> Codex P2 fix: o `lei_id` no Parquet (§3.1) **sempre** usa o `numero` zero-padded para bater com o IA identifier. Lookup `lei_id → IA item` é literal, sem normalização extra.
 
 **Numero não-numérico** (algumas leis antigas: "Lei A-12", romanos): tratar como caso de fallback. Não tentar normalizar para inteiro. O identifier vai para o pattern fallback abaixo, com `chave` derivado da fonte primária.
 
@@ -713,8 +740,8 @@ CI: ao bumpar major, `web/src/schemas/v{N}/` precisa existir + ser referenciado 
 
 ### Da ficha
 - ZIP de raw bulk (§1.2) ← ficha mirror dos 37 ZIPs RFB.
-- Parquet como camada canônica ← ficha tem `cnpjs.parquet`, `socios.parquet`. Nossa `leis-{ente}-v{N}.parquet` + `dispositivos-{ente}-v{N}.parquet` + `versoes-{ente}-v{N}.parquet` seguem mesma filosofia, normalizada em 3 tabelas.
-- Footer KV `schema_version` ← ficha embute; replicamos em §3.5.
+- Parquet como camada canônica ← ficha tem `cnpjs.parquet`, `socios.parquet`. Nossa `versoes-{ente}-v{N}.parquet` segue mesma filosofia (single table denormalizada por grain, ver §3).
+- Footer KV `schema_version` ← ficha embute; replicamos em §3.4.
 
 ### Da baliza
 - Manifest CSV no IA como source of truth ← baliza usa `baliza-pncp-manifest/manifest.csv`. Nossa `manifest-{ente}.csv` segue mesma estrutura.
@@ -729,17 +756,18 @@ CI: ao bumpar major, `web/src/schemas/v{N}/` precisa existir + ser referenciado 
 - ✅ **Granularidade IA raw**: individual por PDF (§1.1) + bundle ZIP semanal redundante (§1.2).
 - ✅ **Slug fonte é `[a-z]+` único** (§5.7).
 - ✅ **Bundle `lexml.xsd` no repo** (§6) — reprodutibilidade.
-- ✅ **`git_sha` SHA completo (40 chars)** (§3.5).
+- ✅ **`git_sha` SHA completo (40 chars)** (§3.4).
 - ✅ **Regex parsed aceita `\d{5,}`** (§5.3).
-- ✅ **Tipo Parquet usa `VARCHAR`** (§3.1–3.3), não `TEXT`.
+- ✅ **Tipo Parquet usa `VARCHAR`** (§3.1), não `TEXT`.
 - ✅ **Fallback parsed inclui `{fonte}`** (§5.3).
-- ✅ **`id` Parquet sempre zero-padded** (§3.1).
+- ✅ **`lei_id` Parquet sempre zero-padded** (§3.1).
 - ✅ **Dispositivo é unidade primária** (§0.1).
 - ✅ **Vigente compilado é canônico, histórico via timeline** (§0.2).
 - ✅ **Formato próprio (Leizilla XML), não fork LexML** (§0.3).
 - ✅ **SSR híbrido via Astro** (§0.4), softening do princípio 6 anterior.
 - ✅ **`urn_lex` Parquet é nullable** (§5.5).
-- ✅ **Schema Parquet é v0.1 durante M0–M4; promove a v1 em M5** (§3.6, §7).
+- ✅ **Schema Parquet é v0.1 durante M0–M4; promove a v1 em M5** (§3.5, §7).
+- ✅ **Single table `versoes` (denormalizada)** (§3) — substitui 3 tabelas relacionais. Decisão revisitável em M5 com dados reais.
 - ✅ **Caput é índice 0 implícito** (§4.3) — Opção D: container carrega `<versoes>` próprio; sem `<dispositivo tipo="caput">` separado. Aplica recursivamente a todos containers.
 - ✅ **Wayback Machine como caminho primário de fetch** (§0.5) — buffer/CDN entre nós e a fonte; fail-open para fallback de download direto.
 - ✅ **LGPD: leis publicadas, sem despublicação** — Leis estaduais e federais são atos públicos (CF art. 5º LX, art. 84 IV, art. 37 caput). LGPD (Lei 13.709/2018) não autoriza despublicação de norma pública e não está acima da Constituição. Citação de pessoas físicas em leis antigas (nomeações, aposentadorias, concessões) faz parte do ato administrativo público — indexar e republicar é continuidade do ato original, não tratamento novo. Documentar em ADR-0009 (Claude routines + ética) em M1.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -137,10 +137,10 @@ Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado
       "fonte_a": "leizilla-raw-ro-casacivil-coddoc-00042",
       "fonte_b": "leizilla-raw-ro-diario-2003-06-15-p0012",
       "diff_summary": "§2º ausente em casacivil; texto idêntico no resto",
-      "resolvido_por": "diario_oficial"
+      "resolvido_por": "diario"
     }
   ],
-  "fonte_canonica": "diario_oficial",
+  "fonte_canonica": "diario",
   "parse_method": "llm-haiku",
   "parse_model": "claude-haiku-4-5-20251001",
   "parse_timestamp": "2026-05-20T18:45:00Z",
@@ -194,7 +194,7 @@ Tabela canônica `leis` no DuckDB e Parquet espelho.
 | `url_leiml_ia` | VARCHAR | NO | URL do `law.leiml` |
 | `url_ocr_ia` | VARCHAR (JSON array) | NO | lista de URLs `_djvu.txt` por fonte |
 | `url_pdf_ia` | VARCHAR (JSON array) | NO | lista de URLs PDF por fonte |
-| `fonte_canonica` | VARCHAR | NO | `diario_oficial`/`casacivil`/`assembleia` |
+| `fonte_canonica` | VARCHAR | NO | slug curto da fonte (`casacivil`, `diario`, `assembleia`) — ver §5 |
 | `num_fontes` | INTEGER | NO | quantidade de fontes capturadas |
 | `tem_divergencia` | BOOLEAN | NO | flag rápido frontend |
 | `divergencias` | TEXT (JSON) | YES | diff summary estruturado |
@@ -296,12 +296,12 @@ Fallback se texto não puder ser estruturado:
 ```xml
 <anotacoes>
   <fontes>
-    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042" tipo="casa-civil"/>
-    <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012" tipo="diario-oficial"/>
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042" tipo="casacivil"/>
+    <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012" tipo="diario"/>
   </fontes>
   <divergencia campo="articulacao/artigo[@id='art-3']/caput"
-               entre="casa-civil,diario-oficial"
-               resolvido-por="diario-oficial">
+               entre="casacivil,diario"
+               resolvido-por="diario">
     §2º ausente em casacivil
   </divergencia>
   <parse method="llm-haiku"
@@ -361,6 +361,8 @@ Permite abrir `law.leiml` diretamente no browser e ver HTML renderizado (XSLT na
 
 ### Slug `{fonte}` — enum por ente
 
+**Regra de slug (load-bearing)**: `{fonte}` é um token único `[a-z]+` — **sem hífens nem underscores**. Toda referência (IA identifier, `raw_meta.json.fonte`, `parsed_meta.json.fonte_canonica` / `resolvido_por`, atributo `tipo` em LeiML `<fonte>` / `<divergencia>`, coluna Parquet `fonte_canonica`, enum `FONTES` Python) usa **exatamente o mesmo slug**. Hífens no slug quebrariam a parsing do identifier `leizilla-raw-{ente}-{fonte}-{chave}` por torná-lo ambíguo (e.g., `diario-oficial-2003-06-15` não tem fronteira reconhecível entre fonte e chave). Diff/join determinístico por fonte exige um único valor canônico em todas as camadas.
+
 Cada ente declara suas fontes oficiais em `src/leizilla/fontes/{ente}.py`. Exemplo:
 
 ```python
@@ -368,9 +370,11 @@ Cada ente declara suas fontes oficiais em `src/leizilla/fontes/{ente}.py`. Exemp
 FONTES = {
     "casacivil": "https://ditel.casacivil.ro.gov.br/cotel/",
     "assembleia": "https://sapl.al.ro.leg.br/",
-    "diario": "https://www.diof.ro.gov.br/",
+    "diario": "https://www.diof.ro.gov.br/",   # Diário Oficial — slug curto sem hífen
 }
 ```
+
+Nomes longos (`diário oficial`, `casa civil`) ficam em campos `display_name` / metadata IA legível, nunca no slug.
 
 ---
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -379,12 +379,12 @@ Arrays **no Parquet** como `VARCHAR` com JSON serializado, **não** Parquet LIST
 }
 ```
 
-Escrita via `pyarrow.parquet.write_table` (não DuckDB `COPY` — esse não embute KV custom). `git_sha` é o SHA completo (40 chars), não truncado.
+Escrita preferida via `pyarrow.parquet.write_table` (controle granular do KV + interop com Arrow ecosystem). DuckDB também suporta KV custom via `COPY (...) TO 'file.parquet' (FORMAT parquet, KV_METADATA {...})` — ambos os paths são válidos; escolha do writer fica para M4 baseada em complexidade do ETL. `git_sha` é o SHA completo (40 chars), não truncado.
 
 ### 3.5 Versioning
 
 - `schema_version` semver-ish na coluna `leizilla.schema_version`: major bump apenas em break.
-- **Mapping `schema_version` → identifier `v{N}`**: `N` é o **major** do `schema_version`. Pré-M5: `schema_version="0.1"` → identifier `v0` (e.g. `leizilla-dataset-ro-v0`, `leis-ro-v0.parquet`). Pós-M5: `schema_version="1"` → identifier `v1`. Identifier IA permanece inteiro `v\d+` por compatibilidade com regex de naming (§5.4); versão pré-release fica codificada no major `0`. Minor/patch (`0.1`, `0.2`) atualizam o footer KV sem novo identifier.
+- **Mapping `schema_version` → identifier `v{N}`**: `N` é o **major** do `schema_version`. Pré-M5: `schema_version="0.1"` → identifier `v0` (e.g. `leizilla-dataset-ro-v0`, `versoes-ro-v0.parquet`). Pós-M5: `schema_version="1"` → identifier `v1`. Identifier IA permanece inteiro `v\d+` por compatibilidade com regex de naming (§5.4); versão pré-release fica codificada no major `0`. Minor/patch (`0.1`, `0.2`) atualizam o footer KV sem novo identifier.
 - CI valida que `int(N)` no caminho do arquivo bate com `int(schema_version.split('.')[0])` do footer KV.
 - Zod schema único em `web/src/schemas/v0/versao.ts` (matches single table) durante M0–M4; movido para `v1/` quando schema_version promover para `1`.
 - v1 só é cravado depois do MVP rodar (reviewer #6 ponto 13). Durante M0–M4 o schema é **v0.1** (identifier `v0`); promove para v1 no fechamento de M5.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -328,7 +328,7 @@ Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet
 | `tem_divergencia` | BOOLEAN | NO | |
 | `divergencias` | VARCHAR (JSON) | YES | diff summary entre fontes |
 | `hash_texto` | VARCHAR | NO | sha256 |
-| `bloco_livre_quality` | VARCHAR | YES | `null` (parsing OK) / `low` / `medium` / `high` se `<bloco-livre>` foi usado |
+| `bloco_livre_quality` | VARCHAR | YES | `null` (parsing OK) / `low` / `medium` / `high` / `raw` se `<bloco-livre>` foi usado (ver §4.4 — `raw` para casos onde OCR é tão ruim que nem dá pra estimar qualidade) |
 
 ### 3.4 Representação de arrays e JSON
 
@@ -357,9 +357,10 @@ Escrita via `pyarrow.parquet.write_table` (não DuckDB `COPY` — esse não embu
 ### 3.6 Versioning
 
 - `schema_version` semver-ish na coluna `leizilla.schema_version`: major bump apenas em break.
-- CI valida que o `v{N}` no caminho do arquivo bate com o footer KV.
-- Zod schema em `web/src/schemas/v1/lei.ts` + `dispositivo.ts` + `versao.ts` bumped junto.
-- v1 só é cravado depois do MVP rodar (reviewer #6 ponto 13). Durante M0–M4 o schema é **v0.1**; promove para v1 no fechamento de M5.
+- **Mapping `schema_version` → identifier `v{N}`**: `N` é o **major** do `schema_version`. Pré-M5: `schema_version="0.1"` → identifier `v0` (e.g. `leizilla-dataset-ro-v0`, `leis-ro-v0.parquet`). Pós-M5: `schema_version="1"` → identifier `v1`. Identifier IA permanece inteiro `v\d+` por compatibilidade com regex de naming (§5.4); versão pré-release fica codificada no major `0`. Minor/patch (`0.1`, `0.2`) atualizam o footer KV sem novo identifier.
+- CI valida que `int(N)` no caminho do arquivo bate com `int(schema_version.split('.')[0])` do footer KV.
+- Zod schema em `web/src/schemas/v0/lei.ts` + `dispositivo.ts` + `versao.ts` durante M0–M4; movido para `v1/` quando schema_version promover para `1`.
+- v1 só é cravado depois do MVP rodar (reviewer #6 ponto 13). Durante M0–M4 o schema é **v0.1** (identifier `v0`); promove para v1 no fechamento de M5.
 
 ---
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -46,7 +46,27 @@ Em vez disso: **Leizilla XML v0.1 é escrito do zero**, otimizado para nossos ca
 
 O esboço anterior cravou "HTML renderizado no browser via XSLT/JS, nunca server-side". Suavizado: páginas de detalhe de lei (`/lei/{id}`) renderizam server-side via Astro (acessibilidade WCAG, SEO, no-JS funciona, LBI 13.146/2015). Busca/timeline interativa fica client-side com Svelte+DuckDB-WASM. XSLT in-browser é fallback opcional para quem abre `law.xml` diretamente.
 
-### 0.5 Genericidade real, não só de slug
+### 0.5 Wayback Machine como caminho primário de fetch (aprovada)
+
+**Decisão**: o crawler **não baixa direto da fonte oficial**. Em vez disso:
+
+1. Crawler descobre `fonte_url` (HTML que lista a lei) e `pdf_url`
+2. Dispara `POST https://web.archive.org/save/{url}` para ambos (com check prévio `/wayback/available?url=...` para reuso de snapshot recente <24h)
+3. **Fetcha o PDF de volta da Wayback Machine** (não da fonte original)
+4. Upload do PDF para nossa coleção IA (continua acionando OCR automático)
+5. Grava `provenance_wayback` em `raw_meta.json` com URLs de snapshot
+
+**Justificativa**:
+- Bate na fonte original **uma única vez** (via bot do Wayback), não centenas. Polite com sites .gov.br frágeis
+- Timestamp Wayback é testemunha independente para auditoria forense — terceiro confiável atesta "esta URL continha este PDF em T"
+- Wayback funciona como CDN/buffer: tira nosso crawler do caminho crítico da fonte
+- Nossa coleção IA + OCR pipeline continua intocada
+
+**Política de falha**: fail-open. Se Wayback timeout, rate-limit, ou erro → log warning, **fallback para download direto da fonte**, gravar `provenance_wayback: null`. Wayback é reforço de provenance, não bloqueante para captura.
+
+**Não-decisão**: Wayback **não substitui** nossa coleção IA. Snapshots Wayback não geram `_djvu.txt` (OCR automático do IA só roda em items de coleção, não em snapshots). Etapa 2 depende do OCR — então o PDF tem que viver na nossa coleção IA.
+
+### 0.6 Genericidade real, não só de slug
 
 O esboço anterior afirmou "genérico por ente desde dia 1" mas o vocabulário era estadual. Realidade: cada nível federativo tem fontes diferentes (Federal: Câmara, Senado, Planalto, DOU; Municípios: ~5.570 estruturas distintas). O modelo Leizilla XML **não** assume estrutura de fonte — apenas que cada dispositivo tem `<fonte ia-id="..."/>` apontando para um raw item. O catálogo `src/leizilla/fontes/{ente}.py` declara fontes válidas por ente; o resto do código consome a lista sem hardcode.
 
@@ -129,13 +149,22 @@ Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado
   "ente": "ro",
   "fonte": "casacivil",
   "fonte_url": "https://ditel.casacivil.ro.gov.br/cotel/livros/Folder.aspx?coddoc=42",
+  "pdf_url": "https://ditel.casacivil.ro.gov.br/.../doc-1234.pdf",
   "chave": "coddoc-00042",
   "data_captura": "2026-05-20T14:30:00Z",
   "hash_pdf": "sha256:abc123...",
   "user_agent": "leizilla-crawler/1.0",
-  "ia_id_bundle": "leizilla-bundle-ro-casacivil-2026-W20"
+  "ia_id_bundle": "leizilla-bundle-ro-casacivil-2026-W20",
+  "provenance_wayback": {
+    "fonte_url_snapshot": "https://web.archive.org/web/20260520143000/https://ditel.casacivil.ro.gov.br/cotel/livros/Folder.aspx?coddoc=42",
+    "pdf_url_snapshot": "https://web.archive.org/web/20260520143015/https://ditel.casacivil.ro.gov.br/.../doc-1234.pdf",
+    "captured_at": "2026-05-20T14:30:15Z",
+    "fetched_from": "wayback"
+  }
 }
 ```
+
+`provenance_wayback.fetched_from` é `"wayback"` quando o PDF foi baixado via Wayback (caminho primário, §0.5) ou `"source-fallback"` quando Wayback falhou e baixamos direto da fonte. `null` se Wayback falhou e o fallback ainda não rodou. Os snapshots ficam `null` individualmente em caso de falha por URL.
 
 ### 2.2 `parsed_meta.json` (sidecar do parsed item)
 
@@ -362,6 +391,15 @@ Esboço. Definição XSD formal em `docs/schemas/leizilla-v0.1.xsd` (M0.2).
 
 Cada dispositivo carrega sua própria **timeline de versões**. Nested para hierarquia.
 
+**Regra do caput (Opção D — aprovada)**: caput não é elemento separado. Todo `<dispositivo>` container (artigo, parágrafo, inciso) tem `<versoes>` opcional carregando **seu próprio texto intrínseco** — que corresponde ao "caput" na terminologia jurídica quando o dispositivo tem filhos. Conceitualmente o caput é o "índice 0" dos filhos do container. Implica:
+
+- **Sem elemento `<dispositivo tipo="caput">`**. Caput é propriedade implícita do container.
+- **URN aponta para o container**: `urn:lex:...!art-5` resolve para o texto intrínseco (caput) do art-5. Sub-itens via `!art-5!par-1`, etc.
+- **Versionamento granular preservado**: alterar só o caput = nova `<versao>` no próprio `<dispositivo path="art-5">`. Alterar só o §1 = nova `<versao>` em `<dispositivo path="art-5-par-1">`. Independentes.
+- **Aplica recursivamente**: parágrafo com incisos também tem "caput" (seu próprio texto antes dos incisos), mesma regra.
+- **Parquet `dispositivos`**: 1 row por dispositivo. A row do container **é** o caput. Não há row extra "caput".
+- **Export LexML** (XSLT): wrap mecânico — `<dispositivo path="art-5"><versoes>{T}</versoes>...</dispositivo>` vira `<Artigo><Caput><Texto>{T}</Texto></Caput>...</Artigo>`.
+
 ```xml
 <dispositivos>
   <dispositivo tipo="artigo" path="art-1"
@@ -520,7 +558,7 @@ Lista canônica em `src/leizilla/entes.py` (M1) com nome oficial, UF pai, códig
 
 ### 5.7 Slug `{fonte}` — regra load-bearing
 
-`{fonte}` é token único `[a-z]+` — **sem hífens nem underscores**. Toda referência (IA identifier, `raw_meta.json.fonte`, `parsed_meta.json.fonte_consultadas`, atributo `<fonte-canonica>` em XML, coluna Parquet `fonte_canonica`, enum `FONTES` Python) usa **exatamente o mesmo slug**.
+`{fonte}` é token único `[a-z]+` — **sem hífens nem underscores**. Toda referência (IA identifier, `raw_meta.json.fonte`, `parsed_meta.json.fontes_consultadas[]`, atributo `<fonte-canonica>` em XML, coluna Parquet `fonte_canonica` e `versoes.fontes_consultadas`, enum `FONTES` Python) usa **exatamente o mesmo slug**.
 
 Hífens quebrariam parsing de `leizilla-raw-{ente}-{fonte}-{chave}` (sem fronteira reconhecível). Nomes longos (`diário oficial`, `casa civil`) ficam em campos `display_name` / metadata IA legível.
 
@@ -599,23 +637,26 @@ CI: ao bumpar major, `web/src/schemas/v{N}/` precisa existir + ser referenciado 
 - ✅ **SSR híbrido via Astro** (§0.4), softening do princípio 6 anterior.
 - ✅ **`urn_lex` Parquet é nullable** (§5.5).
 - ✅ **Schema Parquet é v0.1 durante M0–M4; promove a v1 em M5** (§3.6, §7).
+- ✅ **Caput é índice 0 implícito** (§4.3) — Opção D: container carrega `<versoes>` próprio; sem `<dispositivo tipo="caput">` separado. Aplica recursivamente a todos containers.
+- ✅ **Wayback Machine como caminho primário de fetch** (§0.5) — buffer/CDN entre nós e a fonte; fail-open para fallback de download direto.
+- ✅ **LGPD: leis publicadas, sem despublicação** — Leis estaduais e federais são atos públicos (CF art. 5º LX, art. 84 IV, art. 37 caput). LGPD (Lei 13.709/2018) não autoriza despublicação de norma pública e não está acima da Constituição. Citação de pessoas físicas em leis antigas (nomeações, aposentadorias, concessões) faz parte do ato administrativo público — indexar e republicar é continuidade do ato original, não tratamento novo. Documentar em ADR-0009 (Claude routines + ética) em M1.
+- ✅ **Custo LLM diluído no tempo** — estimativa de ~$40–100/ente (5k leis × 10k tokens × Haiku) é aceitável; ingestão é one-shot por lei, custo amortiza. Re-parsing pontual em fill-gaps é marginal. Não é fator de bloqueio do design.
+- ✅ **Re-scrape sob auditoria** — re-scrape NÃO é automático. Disparado só quando auditoria periódica conclui que qualidade do raw caiu (e.g., versão do PDF foi corrigida pela fonte, ou OCR muito ruim). Quando re-scrape acontece, novo raw item vira `{chave}-r{N}` (revisão); raw anterior permanece (imutabilidade §0.X). Documentado como processo em IMPLEMENTATION.md (auditoria periódica de qualidade).
+- ✅ **Auditoria de novas fontes por ente** — processo paralelo à re-scrape: auditoria periódica avalia se novas fontes oficiais devem ser adicionadas ao `src/leizilla/fontes/{ente}.py` (e.g., descobrir que estado X tem um portal de transparência que reúne consolidados). Não bloqueia M0.
 
 ## 10. Decisões pendentes (resolver em M0.2)
 
-- [ ] **Modelagem de `caput`** (§4.3) — duas opções para o XSD: (a) atributo `tem-caput="true"` em `<dispositivo tipo="artigo">` com o texto do caput dentro do próprio elemento, ou (b) primeiro `<dispositivo>` filho com `tipo="caput"` carregando o texto. LexML usa (b). Decidir antes de escrever `leizilla-v0.1.xsd`.
 - [ ] **Verificar URN LEX dialect** (§5.5) — separadores `;`/`,`/`:` contra spec CGPID atual.
 - [ ] **Compressão Parquet**: SNAPPY vs ZSTD. Verificar DuckDB-WASM 1.28 (ou versão atual) suporta ZSTD via teste real em M0.2.
 - [ ] **Granularidade bundle ZIP**: semanal (`YYYY-Www`) atual; revisitar se tamanho ficar trivial.
 - [ ] **XPath dialect em `diff-xpath`** (§4.5) — declarar "XPath 1.0 subset, atributos com aspas simples" (reviewer #6 ponto 9).
-- [ ] **Política de re-scrape**: PDF re-publicado pela fonte (hash diferente do anterior) vira novo raw item `{chave}-v2`? Ou substitui? (reviewer #6 ponto 11) — decidir antes de M2.
-- [ ] **Robots.txt + rate limiting** como princípio explícito no crawler (reviewer #6 ponto 12) — adicionar em ADR-0008 (pipeline) e `src/leizilla/crawler.py`.
-- [ ] **LGPD em leis antigas com nomes** (reviewer #6 ponto 8 da parecer) — triagem necessária? Política de redação? Adiar para v0.2 ou decidir agora?
+- [ ] **Robots.txt + rate limiting** como princípio explícito no crawler (reviewer #6 ponto 12) — adicionar em ADR-0008 (pipeline) e `src/leizilla/crawler.py`. Nota: com §0.5 (Wayback como fetch primário), bater na fonte original fica raro — robots.txt continua valendo, rate-limit do nosso crawler vira proteção do Wayback save endpoint (15 req/min sem auth, 100 com SavePageNow).
 - [ ] **XSLT in-browser deprecation** (reviewer #6 ponto 4) — confirmar que primário é Astro SSR, XSLT é fallback opcional. Atualizar §4.6 se Astro SSR cobrir 100%.
-- [ ] **Estimativa custo LLM realista** (reviewer #6 ponto 6) — recalcular: 5.000 leis × 10k tokens × Haiku ≈ $40–100/ente. Atualizar IMPLEMENTATION.md se diferir muito.
+- [ ] **Modelagem de blocos legislativos** (livro, parte, título, capítulo, seção, subseção, anexos) — agrupadores organizacionais sem texto normativo próprio. Atualmente fora do schema; CF e códigos não cabem sem isso. Decidir: hierarquia única com `<bloco>` aninhado com `<dispositivo>`, ou duas hierarquias paralelas (`<estrutura>` + `<dispositivos>` flat com `<dispositivo-ref>`). Path do dispositivo permanece global (`art-5`), não namespaceado por bloco.
 
 ## 11. Open questions (v0.2 ou posterior)
 
-- **Catálogo de fontes federais** (Câmara, Senado, Planalto, DOU) — modelagem em §0.5 acomoda, mas vocabulário concreto fica para quando atacarmos `ente=federal`.
+- **Catálogo de fontes federais** (Câmara, Senado, Planalto, DOU) — modelagem em §0.6 acomoda, mas vocabulário concreto fica para quando atacarmos `ente=federal`.
 - **Catálogo de fontes municipais** — ~5.570 estruturas distintas; modelo `src/leizilla/fontes/{ente}.py` escala, mas curadoria é desafio próprio.
 - **Versionamento de raw quando fonte republica** (overlap com §10) — política mais fina depois.
 - **Acessibilidade WCAG completa** — Astro SSR resolve maior parte; auditoria formal em M5.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -287,7 +287,7 @@ Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet
 
 ```python
 {
-  "leizilla.schema_version": "1",
+  "leizilla.schema_version": "0.1",
   "leizilla.xml_schema_version": "0.1",
   "leizilla.ente": "ro",
   "leizilla.table": "dispositivos",  # ou leis / versoes

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -79,7 +79,24 @@ O esboço anterior cravou "HTML renderizado no browser via XSLT/JS, nunca server
 - Wayback funciona como CDN/buffer: tira nosso crawler do caminho crítico da fonte
 - Nossa coleção IA + OCR pipeline continua intocada
 
-**Política de falha**: fail-open. Se Wayback timeout, rate-limit, ou erro → log warning, **fallback para download direto da fonte**, gravar `provenance_wayback: null`. Wayback é reforço de provenance, não bloqueante para captura.
+**Política de falha (detalhada)**:
+
+| Cenário Wayback | Ação |
+|---|---|
+| HTTP 200 + snapshot URL retornada | Caminho feliz. Fetch PDF do snapshot. `fetched_from="wayback"`. |
+| HTTP 429 (rate limit) | Backoff exponencial (1s, 2s, 4s, máx 30s). 3 tentativas, depois fallback. |
+| HTTP 5xx (server error) | Backoff curto (2s, 5s). 2 tentativas, depois fallback. |
+| HTTP 403/451 com body indicando robots.txt | **Permanente, não retry**. Wayback recusa-se a arquivar essa URL. Fallback imediato, gravar `fetched_from="source-fallback"` + `wayback_blocked_robots=true`. |
+| Timeout (>60s) | Fallback. Sem retry (Wayback save é lento por natureza, mas >60s indica problema). |
+| Snapshot existente < 24h via `/wayback/available` | Reusa, não dispara novo save. Economiza throttle quota. |
+
+**Rate limit Wayback público**: ~12 saves/min sem auth, ~120/min com chave SavePageNow ([docs IA](https://archive.org/details/spn-2)). Para scrape de Rondônia inteira (~5k leis × 2 URLs = 10k saves), throttle público leva ~14h. M2 inclui:
+- Token bucket no crawler para respeitar 12/min (worker pool size = 2).
+- Avaliar custo de SavePageNow paid API se 14h ficar inviável.
+
+**Frontend (M5)**: badge visível "fetched via source-fallback (Wayback indisponível)" quando `provenance_wayback.fetched_from = "source-fallback"`. Mantém transparência da garantia "external witness".
+
+Quando o sistema cai inteiramente em fallback de download direto, log warning para auditoria; estatística agregada (% raws com `source-fallback`) é métrica de saúde do pipeline.
 
 **Não-decisão**: Wayback **não substitui** nossa coleção IA. Snapshots Wayback não geram `_djvu.txt` (OCR automático do IA só roda em items de coleção, não em snapshots). Etapa 2 depende do OCR — então o PDF tem que viver na nossa coleção IA.
 
@@ -266,7 +283,16 @@ Relações computadas com outras leis. Permite ao frontend mostrar "esta lei foi
 
 **Decisão (aprovada): uma única tabela `versoes`** com grain (lei × dispositivo × versão). Metadados de lei e dispositivo denormalizados em cada row. Estrutura/listagem emerge via `SELECT DISTINCT`. Read-only Parquet servido estaticamente do IA — dictionary encoding + SNAPPY compress as repetições. Tradeoff explícito: simplicidade de query (zero JOIN no DuckDB-WASM) vs redundância de dados (compressão Parquet mitiga).
 
-Pode evoluir para 2 ou 3 tabelas se DuckDB-WASM ficar gargalo na prática — decisão revisitada em M5 com dados reais (~5k leis RO × ~30 dispositivos × ~2 versões = ~300k rows, tamanho do Parquet a medir).
+Pode evoluir para 2 ou 3 tabelas se DuckDB-WASM ficar gargalo na prática — decisão revisitada em M5 com dados reais.
+
+**Gatilhos de revert (qualquer um dispara discussão de split)**:
+- Parquet `versoes-{ente}-v0.parquet` excede **100 MB** comprimido (limite confortável de fetch HTTP em conexões ruins).
+- Cold DuckDB-WASM init + primeira query (single SELECT por `lei_id`) excede **5s P50** em laptop padrão (M1/M2 Air, conexão 50 Mbps).
+- Memória DuckDB-WASM durante query típica excede **500 MB** (afeta browsers em devices modestos).
+- Latência user-visible de search/filter (texto_normalizado LIKE) excede **1s P95** em dataset RO completo.
+- Cardinalidade real ultrapassa **2M rows** por ente (estimativa atual: ~1.5M para RO; >2M sugere que custos lineares começam a doer).
+
+Critério: 1 gatilho disparado abre RFC de split; 2+ obrigam split antes do M5 fechar. M4 inclui benchmark scripts para medir todos.
 
 ### 3.1 Tabela `versoes` — single source of truth
 
@@ -340,11 +366,26 @@ WHERE lei_id = 'leizilla-ro-lei-01234-2003'
   AND vigente_de <= DATE '2010-01-01'
   AND (vigente_ate > DATE '2010-01-01' OR vigente_ate IS NULL);
 
--- Estrutura/TOC de uma lei (DISTINCT extrai dispositivos)
-SELECT DISTINCT dispositivo_path, tipo_dispositivo, dispositivo_parent_path, rotulo, ordem
+-- Estrutura/TOC de uma lei (rotulo vigente por dispositivo)
+-- Regra: rotulo mostrado no TOC = COALESCE(rotulo_versao, rotulo) da versão atualmente vigente
+SELECT DISTINCT
+  dispositivo_path,
+  tipo_dispositivo,
+  dispositivo_parent_path,
+  COALESCE(rotulo_versao, rotulo) AS rotulo_tos,
+  ordem
 FROM versoes
 WHERE lei_id = 'leizilla-ro-lei-01234-2003'
+  AND vigente_ate IS NULL   -- versão vigente apenas
 ORDER BY ordem;
+
+-- Busca por nome de capítulo/título (texto_normalizado é NULL em blocos
+-- organizacionais; busca em rotulo)
+SELECT DISTINCT lei_id, dispositivo_path, rotulo
+FROM versoes
+WHERE ente = 'ro'
+  AND tipo_dispositivo IN ('livro', 'parte', 'titulo', 'capitulo', 'secao', 'subsecao')
+  AND rotulo ILIKE '%direitos fundamentais%';
 
 -- Listagem de todas as leis de um ente
 SELECT DISTINCT lei_id, titulo_lei, ementa, ano, parse_status, confianca_parse
@@ -385,6 +426,7 @@ Escrita preferida via `pyarrow.parquet.write_table` (controle granular do KV + i
 
 - `schema_version` semver-ish na coluna `leizilla.schema_version`: major bump apenas em break.
 - **Mapping `schema_version` → identifier `v{N}`**: `N` é o **major** do `schema_version`. Pré-M5: `schema_version="0.1"` → identifier `v0` (e.g. `leizilla-dataset-ro-v0`, `versoes-ro-v0.parquet`). Pós-M5: `schema_version="1"` → identifier `v1`. Identifier IA permanece inteiro `v\d+` por compatibilidade com regex de naming (§5.4); versão pré-release fica codificada no major `0`. Minor/patch (`0.1`, `0.2`) atualizam o footer KV sem novo identifier.
+- **Nota interpretativa**: `v0` **não** significa "empty/draft/abandonado" — é o major do `schema_version="0.1"`, indicando design pré-MVP. Dataset `v0` é válido, citável, e tem garantias formais de schema (XSD validado, footer KV preenchido). Promove-se a `v1` quando o MVP M5 fechar e o schema for considerado estável.
 - CI valida que `int(N)` no caminho do arquivo bate com `int(schema_version.split('.')[0])` do footer KV.
 - Zod schema único em `web/src/schemas/v0/versao.ts` (matches single table) durante M0–M4; movido para `v1/` quando schema_version promover para `1`.
 - v1 só é cravado depois do MVP rodar (reviewer #6 ponto 13). Durante M0–M4 o schema é **v0.1** (identifier `v0`); promove para v1 no fechamento de M5.
@@ -562,7 +604,7 @@ Cada dispositivo carrega sua própria **timeline de versões**. Nested para hier
 1. **`parent` attribute obrigatório** em todo `<dispositivo>`. Raiz: `parent=""`.
 2. **`<versoes>` obrigatório** com **no mínimo 1 `<versao>`** (a original). Sem exceção. Blocos organizacionais têm `<versao>` carregando só `<rotulo>` (sem `<texto>`); normativos têm `<texto>` (e opcionalmente `<rotulo>` override).
 3. **Path do dispositivo normativo é GLOBAL** (`art-5`, `art-5-par-1`, `art-5-par-1-inc-1`, `art-5-par-1-inc-1-ali-a`). Não namespaceia por bloco organizacional acima. Citação forense ("art. 5º") = lookup literal.
-4. **Path do dispositivo organizacional namespaceia internamente** (`tit-1`, `tit-1-cap-1`, `tit-1-cap-1-sec-2`). Hierarquia de blocos é própria.
+4. **Path do dispositivo organizacional namespaceia internamente** (`tit-1`, `tit-1-cap-1`, `tit-1-cap-1-sec-2`, `liv-2-tit-3-cap-1`). Hierarquia de blocos namespaceia o próprio bloco; normativos contidos não herdam o prefix. Token map: `liv-N` (livro), `parte-N` (parte), `tit-N` (titulo), `cap-N` (capitulo), `sec-N` (secao), `subsec-N` (subsecao), `anexo-N` (anexo). Numeração sequential dentro do parent.
 5. **Caput é implícito (índice 0)**: container normativo (`artigo`, `paragrafo`, `inciso`) carrega seu próprio `<texto>` no nível do container; filhos `<dispositivo>` são sub-itens. Sem `<dispositivo tipo="caput">`. Ver detalhes abaixo.
 
 **Mapping nesting XML ↔ `dispositivo_path` flat na tabela Parquet `versoes`** (§3.1): geração determinística do path. Frontend e ETL usam o **mesmo gerador** (`src/leizilla/leizilla_xml/path.py` em M3).

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -189,9 +189,11 @@ Audit trail mínimo separado para facilitar verificação sem carregar `parsed_m
 }
 ```
 
-### 2.4 `alteracoes.json` (novo)
+### 2.4 `alteracoes.json` (novo, derivado)
 
 Relações computadas com outras leis. Permite ao frontend mostrar "esta lei foi alterada por X" sem ter que escanear o `law.xml` inteiro.
+
+> **Derivado, não fonte primária**: source-of-truth é o atributo `alterado-por` de cada `<versao>` dentro de `law.xml`. Este sidecar é **regenerado** a cada update do `law.xml` (mesmo upload IA). Em caso de conflito, `law.xml` ganha. Não editar manualmente.
 
 ```json
 {
@@ -212,7 +214,9 @@ Relações computadas com outras leis. Permite ao frontend mostrar "esta lei foi
 
 ---
 
-## 3. Schema Parquet v1 — três tabelas
+## 3. Schema Parquet v0.1 — três tabelas
+
+> Schema é **v0.1 durante M0–M4**; promove a **v1 apenas no fechamento de M5** (ver §3.6 e §7). Identificadores `leizilla.schema_version` no footer KV e o `v{N}` no caminho do arquivo refletem isso.
 
 Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet separado no dataset item.
 
@@ -231,9 +235,9 @@ Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet
 | `ementa` | VARCHAR | YES | |
 | `url_law_xml_ia` | VARCHAR | NO | URL do `law.xml` no IA |
 | `vigente_em` | DATE | NO | data da compilação vigente |
-| `tem_divergencia` | BOOLEAN | NO | flag rápido frontend |
-| `num_divergencias` | INTEGER | NO | |
-| `num_dispositivos` | INTEGER | NO | |
+| `tem_divergencia` | BOOLEAN | NO | flag rápido frontend; agregado: `OR` sobre todas as `versoes.tem_divergencia` de dispositivos desta lei |
+| `num_divergencias` | INTEGER | NO | soma de `versoes.tem_divergencia=true` |
+| `num_dispositivos` | INTEGER | NO | pré-computado para listagens baratas |
 | `num_versoes_total` | INTEGER | NO | soma de versoes em todos os dispositivos |
 | `revogada` | BOOLEAN | NO | |
 | `parse_status` | VARCHAR | NO | `raw_only`/`parsed`/`failed` |
@@ -248,7 +252,7 @@ Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet
 |---|---|---|---|
 | `dispositivo_id` | VARCHAR | NO | composto: `{lei_id}#{path}` (e.g. `leizilla-ro-lei-01234-2003#art-3-par-2`) |
 | `lei_id` | VARCHAR | NO | FK para `leis.id` |
-| `urn_dispositivo` | VARCHAR | YES | `urn:lex:...;1234!art-3!par-2` (LexML dialect, ver §5.4) |
+| `urn_dispositivo` | VARCHAR | YES | `urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-3!par-2` (LexML dialect, ver §5.5). Regra: `urn_dispositivo` é `NULL` ⟺ `leis.urn_lex` da lei pai é `NULL` (lei sem data extraível) |
 | `tipo` | VARCHAR | NO | `artigo`/`paragrafo`/`inciso`/`alinea`/`item`/`caput` |
 | `rotulo` | VARCHAR | NO | "Art. 1º", "§ 2º", "II", "a)" |
 | `path` | VARCHAR | NO | hierárquico: `art-3` / `art-3-par-2` / `art-3-par-2-inc-1` / `art-3-par-2-inc-1-ali-a` |
@@ -270,7 +274,7 @@ Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet
 | `vigente_de` | DATE | NO | |
 | `vigente_ate` | DATE | YES | NULL = ainda vigente |
 | `texto` | VARCHAR | NO | |
-| `texto_normalizado` | VARCHAR | YES | NFC + cleanup, p/ busca |
+| `texto_normalizado` | VARCHAR | NO | NFC + cleanup, alimenta busca client-side. **Sempre gerado quando `texto` é NOT NULL** — nullable só faz sentido se `texto` também fosse null (não acontece). |
 | `alterado_por_lei_id` | VARCHAR | YES | NULL na versão original; senão FK para `leis.id` da lei alteradora |
 | `fonte_canonica` | VARCHAR | NO | slug curto da fonte usada (`casacivil`, `diario`, `assembleia`...) |
 | `fontes_consultadas` | VARCHAR (JSON array) | NO | lista de raw IA ids usados |
@@ -281,7 +285,9 @@ Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet
 
 ### 3.4 Representação de arrays e JSON
 
-**Decisão (aprovada)**: arrays como `VARCHAR` com JSON serializado, **não** Parquet LIST nativo. Justificativa: simplifica TanStack Query + Svelte components; JSON universal; custo storage irrelevante com SNAPPY.
+**Decisão (aprovada)**: arrays **no Parquet** como `VARCHAR` com JSON serializado, **não** Parquet LIST nativo. Justificativa: simplifica TanStack Query + Svelte components; JSON universal; custo storage irrelevante com SNAPPY.
+
+**Sidecars JSON** (`raw_meta.json`, `parsed_meta.json`, `provenance.json`, `alteracoes.json`) usam arrays JSON nativos — a restrição §3.4 é específica do Parquet. Mesma semântica, formato adequado a cada camada.
 
 ### 3.5 Footer KV metadata (PyArrow)
 
@@ -319,9 +325,10 @@ Esboço. Definição XSD formal em `docs/schemas/leizilla-v0.1.xsd` (M0.2).
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
+<!-- ⚠️ Todos URN LEX nos exemplos são dialect provisório — ver §10 pendentes (verificar contra spec CGPID). -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia:lei:2003-06-15;1234">
+     urn-lex="urn:lex:br;estado:rondonia;lei:2003-06-15;1234">
   <header>...</header>
   <dispositivos>...</dispositivos>
   <anotacoes>...</anotacoes>
@@ -341,6 +348,14 @@ Esboço. Definição XSD formal em `docs/schemas/leizilla-v0.1.xsd` (M0.2).
   <vigente-em>2026-05-20</vigente-em>
   <revogada>false</revogada>
 </header>
+<!--
+  Semântica das datas:
+  - <vigente-em> (header) = data de referência da compilação. "Esta versão
+    do law.xml representa a lei como ela estava vigente em 2026-05-20."
+    Update sempre que reprocessar.
+  - <versao vigente-de="..." vigente-ate="..."> (dispositivo) = intervalo
+    de validade daquela redação específica do dispositivo. Não confundir.
+-->
 ```
 
 ### 4.3 `<dispositivos>` — corpo dispositivo-cêntrico
@@ -349,11 +364,12 @@ Cada dispositivo carrega sua própria **timeline de versões**. Nested para hier
 
 ```xml
 <dispositivos>
-  <dispositivo tipo="artigo" path="art-1" urn="urn:lex:...;1234!art-1">
+  <dispositivo tipo="artigo" path="art-1"
+               urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-1">
     <rotulo>Art. 1º</rotulo>
     <versoes>
       <versao numero="1" vigente-de="2003-06-15" vigente-ate="2024-07-30"
-              alterado-por="urn:lex:br;estado:rondonia:lei:2024-06-30;5678">
+              alterado-por="urn:lex:br;estado:rondonia;lei:2024-06-30;5678">
         <texto>Esta Lei dispõe sobre...</texto>
         <fonte-canonica>casacivil</fonte-canonica>
         <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
@@ -365,7 +381,8 @@ Cada dispositivo carrega sua própria **timeline de versões**. Nested para hier
         <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00187"/>
       </versao>
     </versoes>
-    <dispositivo tipo="paragrafo" path="art-1-par-1" urn="urn:lex:...;1234!art-1!par-1">
+    <dispositivo tipo="paragrafo" path="art-1-par-1"
+                 urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-1!par-1">
       <rotulo>§ 1º</rotulo>
       <versoes>
         <versao numero="1" vigente-de="2003-06-15">
@@ -377,6 +394,14 @@ Cada dispositivo carrega sua própria **timeline de versões**. Nested para hier
     </dispositivo>
   </dispositivo>
 </dispositivos>
+```
+
+**Mapping nesting XML ↔ `path` flat na tabela Parquet `dispositivos`** (§3.2): o `path` é determinístico, derivado do nesting da hierarquia. Exemplo: `<dispositivo tipo="artigo">` no índice 3 contendo `<dispositivo tipo="paragrafo">` no índice 2 → `path="art-3-par-2"`. Frontend e ETL usam o **mesmo gerador** (`src/leizilla/leiml/path.py` em M3).
+
+```
+artigo[3] > paragrafo[2] > inciso[1] > alinea[a]
+   └────────┬──────────────┬──────────┬─────────┘
+        art-3        art-3-par-2  art-3-par-2-inc-1  art-3-par-2-inc-1-ali-a
 ```
 
 Regras:
@@ -455,6 +480,8 @@ Abrir o XML direto no browser exibe HTML (XSLT in-browser). **Não** é o caminh
 
 > Codex P2 fix: o `id` no Parquet (§3.1) **sempre** usa o `numero` zero-padded para bater com o IA identifier. Lookup `id → IA item` é literal, sem normalização extra.
 
+**Numero não-numérico** (algumas leis antigas: "Lei A-12", romanos): tratar como caso de fallback. Não tentar normalizar para inteiro. O identifier vai para o pattern fallback abaixo, com `chave` derivado da fonte primária.
+
 **Fallback**:
 ```
 ^leizilla-(?P<ente>[a-z][a-z0-9-]*)-(?P<tipo>[a-z]+)-fallback-(?P<fonte>[a-z]+)-(?P<chave>[a-z0-9-]+)$
@@ -469,6 +496,8 @@ Abrir o XML direto no browser exibe HTML (XSLT in-browser). **Não** é o caminh
 
 ### 5.5 URN LEX
 
+> ⚠️ **Dialect provisório**: todos os exemplos URN abaixo (e em §4) usam separadores que ainda precisam ser validados contra a especificação oficial CGPID — ver §10. Se o dialect mudar, todos os exemplos do doc precisam refresh em PR único.
+
 **Lei**: `urn:lex:br;{jurisdicao};lei:{YYYY-MM-DD};{numero}`
 - `{jurisdicao}` para estados: `estado:rondonia` / `estado:sao-paulo`
 - `{jurisdicao}` para federal: `federal`
@@ -476,7 +505,7 @@ Abrir o XML direto no browser exibe HTML (XSLT in-browser). **Não** é o caminh
 
 **Dispositivo**: `{urn-lei}!art-N` ou `{urn-lei}!art-N!par-M!inc-K!ali-L` (separador `!` cf. extensão LexML para sub-document addressing).
 
-**Fallback URN quando `data_publicacao` desconhecida** (reviewer #6 ponto 3): `urn_lex` na coluna Parquet é nullable. Quando data não é extraível, gravar `NULL` (não falsificar). Identifier IA usa fallback `{ente}-{tipo}-fallback-{fonte}-{chave}` que não depende de URN.
+**Fallback URN quando `data_publicacao` desconhecida** (reviewer #6 ponto 3): `urn_lex` na coluna Parquet é nullable. Quando data não é extraível, gravar `NULL` (não falsificar). Identifier IA usa fallback `leizilla-{ente}-{tipo}-fallback-{fonte}-{chave}` (§5.3) que não depende de URN.
 
 > **Pendente M0.2**: verificar contra a especificação oficial CGPID se o separador interno é `;`, `,` ou `:` em casos como `urn:lex:br;rondonia:estadual:lei,2003-06-15;1234`. Reviewer #6 sugeriu que CGPID usa vírgulas em alguns campos. Validar antes de cravar o exemplo.
 
@@ -496,6 +525,8 @@ Lista canônica em `src/leizilla/entes.py` (M1) com nome oficial, UF pai, códig
 Hífens quebrariam parsing de `leizilla-raw-{ente}-{fonte}-{chave}` (sem fronteira reconhecível). Nomes longos (`diário oficial`, `casa civil`) ficam em campos `display_name` / metadata IA legível.
 
 Slugs canônicos lockados: `casacivil`, `diario`, `assembleia`, `planalto`, `camara`, `senado`.
+
+**Slug `diario` cobre todo Diário Oficial** (estadual, municipal, federal/DOU). A distinção entre DO-RO e DOU é resolvida pelo `{ente}` no identifier: `leizilla-raw-ro-diario-...` vs `leizilla-raw-federal-diario-...`. O slug `{fonte}` é orientado a **tipo de fonte**, não a instituição específica.
 
 ---
 
@@ -571,6 +602,7 @@ CI: ao bumpar major, `web/src/schemas/v{N}/` precisa existir + ser referenciado 
 
 ## 10. Decisões pendentes (resolver em M0.2)
 
+- [ ] **Modelagem de `caput`** (§4.3) — duas opções para o XSD: (a) atributo `tem-caput="true"` em `<dispositivo tipo="artigo">` com o texto do caput dentro do próprio elemento, ou (b) primeiro `<dispositivo>` filho com `tipo="caput"` carregando o texto. LexML usa (b). Decidir antes de escrever `leizilla-v0.1.xsd`.
 - [ ] **Verificar URN LEX dialect** (§5.5) — separadores `;`/`,`/`:` contra spec CGPID atual.
 - [ ] **Compressão Parquet**: SNAPPY vs ZSTD. Verificar DuckDB-WASM 1.28 (ou versão atual) suporta ZSTD via teste real em M0.2.
 - [ ] **Granularidade bundle ZIP**: semanal (`YYYY-Www`) atual; revisitar se tamanho ficar trivial.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,19 +1,60 @@
 # SCHEMA.md — Design de dados do Leizilla
 
-> Decisões load-bearing sobre granularidade de IA items, layout de bundles, schema Parquet v1, schema LeiML v0.1, e naming. Este documento é editado quando uma decisão muda — a coluna **Status** indica se está `proposta`, `aprovada`, ou `superseded-by-#PR`.
+> Decisões load-bearing sobre granularidade de IA items, modelo XML dispositivo-cêntrico, schema Parquet, naming, e export LexML. Editado quando uma decisão muda — coluna **Status** indica `proposta`, `aprovada`, ou `superseded-by-#PR`.
+
+**Histórico**: a v0 deste documento esboçava um formato "LeiML" como fork de LexML, com a lei como unidade primária. Reescrito após review do PR #6: (a) **dispositivo é a unidade primária**, não a lei; (b) formato próprio escrito do zero ("Leizilla XML"), com export LexML apenas como gate de CI — não como constraint estrutural; (c) timeline temporal nativa de dispositivos para tratar alterações legislativas; (d) parsed item = "vigente compilado" como objeto principal, histórico exposto via timeline. Ver §0.
 
 Companion docs:
 - `IMPLEMENTATION.md` (raiz) — status geral e log de decisões cronológico
 - `docs/adr/0005-ia-identifiers.md` (a criar em M1) — formalização normativa
-- `docs/schemas/leiml-v0.1.xsd` (a criar em M0) — schema XML
+- `docs/schemas/leizilla-v0.1.xsd` (a criar em M0.2) — schema XML
+
+---
+
+## 0. Princípios de modelagem (reescrita pós-review #6)
+
+### 0.1 Dispositivo é a unidade primária
+
+A unidade básica de dado **não é a lei** — é o **dispositivo** (artigo, parágrafo, inciso, alínea, item). Justificativa:
+
+- Lawyers citam dispositivos, não leis inteiras ("art. 5º, §2º, II, alínea b da CF/88").
+- Alterações legislativas operam sobre dispositivos individuais, não sobre a lei toda.
+- Revogações são parciais com frequência (revoga art. 3º mantém o resto).
+- Cross-references naturais ("Lei 14.133/2021 art. 3 alterou Lei 1.234/2003 art. 5 §2").
+- DuckDB-WASM consegue indexar e buscar dispositivos com SQL trivial; a lei é apenas o agregador.
+
+Isso difere de LexML/Akoma Ntoso, que centram em document/work. Para nosso uso (busca jurídica + timeline temporal), dispositivo-cêntrico é mais expressivo.
+
+### 0.2 Vigente compilado é o objeto canônico; histórico é timeline
+
+O parsed item canônico representa a lei **como ela deve estar vigente hoje** (best-effort compilation). Versões anteriores são **acessíveis** mas não são objetos primários — são snapshots indexados na timeline de cada dispositivo (date picker → "como era em 2010-01-01?").
+
+A "hierarquia de autoridade DO > Casa Civil > Assembleia" do esboço anterior foi descartada. As fontes não competem por canonicidade — elas cross-verificam a compilação vigente:
+
+- Casa Civil/COTEL geralmente mantém o consolidado vigente — fonte primária para texto atual.
+- Diário Oficial dá fé da publicação original — fonte primária para snapshots históricos.
+- Assembleia Legislativa dá o texto legislativo original (pode diferir de DO por retificações tardias).
+- Divergências entre fontes indicam **possível erro de consolidação ou retificação não-aplicada**, não ranking. Frontend mostra como "verificar".
+
+### 0.3 Formato próprio (não fork), com export LexML como gate de CI
+
+O esboço anterior propunha "LeiML" como fork de LexML. Descartado: dispositivo-cêntrico + timeline + divergencias multi-fonte + parse-LLM-metadata + bloco-livre não cabem confortavelmente em LexML, e a regra de round-trip ficaria perdendo dados em todo PR.
+
+Em vez disso: **Leizilla XML v0.1 é escrito do zero**, otimizado para nossos casos de uso. Mantemos a **disciplina** de LexML/Akoma Ntoso (URN LEX para identificar dispositivos, semântica jurídica) e um **gate de CI**: a cada PR, rodar `scripts/lexml_export.py` que produz um LexML válido a partir do nosso XML para casos representativos. O LexML resultante é uma **representação reduzida** (perde divergencias, parse meta, bloco-livre quality) — isso é OK; o gate só garante que conseguimos exportar para gov interop quando preciso, sem amarrar nosso design.
+
+### 0.4 Granularidade na renderização — SSR híbrido
+
+O esboço anterior cravou "HTML renderizado no browser via XSLT/JS, nunca server-side". Suavizado: páginas de detalhe de lei (`/lei/{id}`) renderizam server-side via Astro (acessibilidade WCAG, SEO, no-JS funciona, LBI 13.146/2015). Busca/timeline interativa fica client-side com Svelte+DuckDB-WASM. XSLT in-browser é fallback opcional para quem abre `law.xml` diretamente.
+
+### 0.5 Genericidade real, não só de slug
+
+O esboço anterior afirmou "genérico por ente desde dia 1" mas o vocabulário era estadual. Realidade: cada nível federativo tem fontes diferentes (Federal: Câmara, Senado, Planalto, DOU; Municípios: ~5.570 estruturas distintas). O modelo Leizilla XML **não** assume estrutura de fonte — apenas que cada dispositivo tem `<fonte ia-id="..."/>` apontando para um raw item. O catálogo `src/leizilla/fontes/{ente}.py` declara fontes válidas por ente; o resto do código consome a lista sem hardcode.
 
 ---
 
 ## 1. Granularidade dos IA items
 
-### 1.1 Raw items — individual por PDF (decisão primária)
-
-**Decisão (aprovada)**: cada PDF é um IA item separado.
+### 1.1 Raw items — individual por PDF (aprovada)
 
 **Pattern**: `leizilla-raw-{ente}-{fonte}-{chave}`
 
@@ -22,88 +63,69 @@ Companion docs:
 | `ro` | `casacivil` | `coddoc-{N:05d}` | `leizilla-raw-ro-casacivil-coddoc-00042` |
 | `ro` | `assembleia` | `coddoc-{N:05d}` | `leizilla-raw-ro-assembleia-coddoc-00042` |
 | `ro` | `diario` | `{YYYY-MM-DD}-p{pagina:04d}` | `leizilla-raw-ro-diario-2003-06-15-p0012` |
-| `federal` | `planalto` | `lei-{numero}-{ano}` | `leizilla-raw-federal-planalto-lei-12345-2024` |
+| `federal` | `planalto` | `lei-{numero:05d}-{ano}` | `leizilla-raw-federal-planalto-lei-12345-2024` |
 
-**Justificativa**:
-- Internet Archive faz OCR automático **apenas** em PDFs uploadados como item; PDFs dentro de ZIP não recebem OCR.
-- Permalink estável por PDF facilita citação e debugging.
-- Manifest CSV rastreia milhares de itens sem dificuldade (padrão causaganha).
+**Justificativa**: IA faz OCR **apenas** em PDFs individuais (não em PDFs dentro de ZIP). Permalink por PDF facilita citação e debugging. Manifest CSV escala para milhares de items.
 
-**Trade-off aceito**: muitos itens (~5.000 só para Rondônia). Acceptable — IA não cobra por número de itens.
+### 1.2 Raw items — bundle ZIP semanal (aprovada, redundância)
 
-### 1.2 Raw items — bundle ZIP periódico (decisão secundária, redundância)
-
-**Decisão (aprovada)**: além dos PDFs individuais, gerar ZIPs semanais com o lote scrapeado, para arquivamento defensivo (padrão ficha).
-
-**Pattern**: `leizilla-bundle-{ente}-{fonte}-{periodo}` onde `{periodo}` segue ISO week: `YYYY-Www`.
+**Pattern**: `leizilla-bundle-{ente}-{fonte}-{periodo}` onde `{periodo}` = ISO week (`YYYY-Www`).
 
 Exemplo: `leizilla-bundle-ro-casacivil-2026-W20`
 
-**Layout interno do ZIP**:
+**Layout interno**:
 ```
-leizilla-bundle-ro-casacivil-2026-W20.zip
-├── manifest.csv
-│   columns: coddoc, ia_id, fonte_url, hash_pdf, data_captura
-├── pdfs/
-│   ├── 00042.pdf
-│   ├── 00043.pdf
-│   └── ...
-└── meta/
-    ├── 00042.json    ← cópia do raw_meta.json do item individual
-    ├── 00043.json
-    └── ...
+manifest.csv         columns: coddoc, ia_id, fonte_url, hash_pdf, data_captura
+pdfs/{chave}.pdf
+meta/{chave}.json
 ```
 
-**Justificativa**:
-- Redundância contra perda acidental de items individuais.
-- Permite download em lote (1 ZIP de N MB > N requests).
-- Mirror histórico das fontes (snapshot semanal).
+Forensics + download em lote. Mirror histórico das fontes.
 
-### 1.3 Parsed items — 1 lei = 1 item
+### 1.3 Parsed items — 1 lei = 1 IA item (aprovada)
 
-**Decisão (aprovada)**: cada lei canônica é um IA item permanente.
-
-**Pattern**: `leizilla-{ente}-{tipo}-{numero:05d}-{ano}`
+**Pattern canônico**: `leizilla-{ente}-{tipo}-{numero:05d}-{ano}`
 
 | Exemplo | Notas |
 |---|---|
 | `leizilla-ro-lei-01234-2003` | caso normal |
-| `leizilla-ro-decreto-00056-2024` | tipo = decreto |
+| `leizilla-ro-decreto-00056-2024` | tipo=decreto |
 | `leizilla-federal-lc-00141-2012` | LC = lei complementar |
 
-**Fallback se `numero` ausente** (algumas leis antigas perderam numeração formal):
-- Pattern: `leizilla-{ente}-{tipo}-fallback-{chave}` onde `{chave}` é o coddoc da fonte primária.
-- Exemplo: `leizilla-ro-lei-fallback-casacivil-coddoc-00099`
+**Pattern fallback** (lei antiga sem numeração formal): `leizilla-{ente}-{tipo}-fallback-{fonte}-{chave}`
 
-**Conteúdo do parsed item**:
+Exemplo: `leizilla-ro-lei-fallback-casacivil-coddoc-00099`
+
+> Codex P1 fix (PR #6): fallback **inclui obrigatoriamente** o segmento `{fonte}` para evitar colisão quando diferentes fontes compartilham a mesma chave.
+
+**Conteúdo do parsed item** (vigente compilado + histórico em timeline):
 ```
 leizilla-ro-lei-01234-2003/
-├── law.leiml          ← formato canônico (XML LeiML v0.1)
-├── parsed_meta.json   ← metadados estruturados
-└── provenance.json    ← rastreabilidade
+├── law.xml             ← Leizilla XML v0.1 (dispositivo-cêntrico, com timeline)
+├── parsed_meta.json    ← metadados estruturados de produção
+├── provenance.json     ← rastreabilidade raw items + parse method
+└── alteracoes.json     ← relações computadas (alteradoPor, altera, revogadoPor)
 ```
 
-Não inclui `law.html` (renderizado no browser via XSLT) nem `law.lexml` (export sob demanda; ver §6).
+Não inclui HTML pré-gerado (renderização SSR via Astro a partir de `law.xml`). Não inclui `law.lexml` (export sob demanda; ver §6).
 
-### 1.4 Dataset items — versionados por schema
-
-**Decisão (aprovada)**: 1 IA item por `{ente}` × `{schema_version}`.
+### 1.4 Dataset items — versionados (aprovada)
 
 **Pattern**: `leizilla-dataset-{ente}-v{N}`
 
-Exemplo: `leizilla-dataset-ro-v1` contém `leis-ro-v1.parquet` + `manifest-ro.csv` + `README.md`.
+Conteúdo: `leis-{ente}-v{N}.parquet`, `dispositivos-{ente}-v{N}.parquet`, `versoes-{ente}-v{N}.parquet`, `manifest-{ente}.csv`, `README.md`.
 
-Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado de forma incompatível). Adicionar coluna nullable não bumpa.
+Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado de forma incompatível).
 
 ---
 
-## 2. Layout dentro dos JSON sidecars
+## 2. Layout dos JSON sidecars
 
 ### 2.1 `raw_meta.json` (sidecar do raw item)
 
 ```json
 {
-  "leiml_meta_version": "0.1",
+  "leizilla_meta_version": "0.1",
   "ente": "ro",
   "fonte": "casacivil",
   "fonte_url": "https://ditel.casacivil.ro.gov.br/cotel/livros/Folder.aspx?coddoc=42",
@@ -119,7 +141,8 @@ Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado
 
 ```json
 {
-  "leiml_meta_version": "0.1",
+  "leizilla_meta_version": "0.1",
+  "schema_xml_version": "0.1",
   "urn_lex": "urn:lex:br;estado:rondonia:lei:2003-06-15;1234",
   "ente": "ro",
   "tipo": "lei",
@@ -127,20 +150,15 @@ Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado
   "ano": 2003,
   "data_publicacao": "2003-06-15",
   "ementa": "Dispõe sobre...",
-  "fontes": [
+  "vigente_em": "2026-05-20",
+  "num_dispositivos": 27,
+  "num_versoes_total": 31,
+  "fontes_consultadas": [
     "leizilla-raw-ro-casacivil-coddoc-00042",
     "leizilla-raw-ro-diario-2003-06-15-p0012"
   ],
-  "divergencias": [
-    {
-      "campo": "articulacao/artigo[@id='art-3']/caput",
-      "fonte_a": "leizilla-raw-ro-casacivil-coddoc-00042",
-      "fonte_b": "leizilla-raw-ro-diario-2003-06-15-p0012",
-      "diff_summary": "§2º ausente em casacivil; texto idêntico no resto",
-      "resolvido_por": "diario"
-    }
-  ],
-  "fonte_canonica": "diario",
+  "tem_divergencia": true,
+  "num_divergencias": 1,
   "parse_method": "llm-haiku",
   "parse_model": "claude-haiku-4-5-20251001",
   "parse_timestamp": "2026-05-20T18:45:00Z",
@@ -149,9 +167,9 @@ Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado
 }
 ```
 
-### 2.3 `provenance.json` (sidecar do parsed item)
+### 2.3 `provenance.json`
 
-Audit trail mínimo separado para facilitar auditoria sem carregar `parsed_meta.json` completo.
+Audit trail mínimo separado para facilitar verificação sem carregar `parsed_meta.json` completo.
 
 ```json
 {
@@ -166,279 +184,407 @@ Audit trail mínimo separado para facilitar auditoria sem carregar `parsed_meta.
   "produced_by": {
     "tool": "leizilla.etl.llm_parse",
     "version": "0.1.0",
-    "git_sha": "abc1234"
+    "git_sha": "abc1234def5678901234567890abcdef12345678"
   }
+}
+```
+
+### 2.4 `alteracoes.json` (novo)
+
+Relações computadas com outras leis. Permite ao frontend mostrar "esta lei foi alterada por X" sem ter que escanear o `law.xml` inteiro.
+
+```json
+{
+  "leizilla_meta_version": "0.1",
+  "alterada_por": [
+    {
+      "urn_lex": "urn:lex:br;estado:rondonia:lei:2024-06-30;5678",
+      "ia_id": "leizilla-ro-lei-05678-2024",
+      "dispositivos_afetados": ["art-3-par-2", "art-5"],
+      "data_efeito": "2024-07-30"
+    }
+  ],
+  "altera": [],
+  "revogada_por": null,
+  "revoga": []
 }
 ```
 
 ---
 
-## 3. Schema Parquet v1
+## 3. Schema Parquet v1 — três tabelas
 
-Tabela canônica `leis` no DuckDB e Parquet espelho.
+Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet separado no dataset item.
+
+### 3.1 Tabela `leis` — header por lei
 
 | coluna | tipo | nullable | nota |
 |---|---|---|---|
-| `id` | VARCHAR | NO | identifier IA do parsed item (`leizilla-{ente}-{tipo}-{numero}-{ano}`) |
+| `id` | VARCHAR | NO | identifier IA do parsed item, **zero-padded** (e.g. `leizilla-ro-lei-01234-2003`) |
 | `ente` | VARCHAR | NO | `ro`, `sp`, `federal`, `ro-porto-velho`... |
 | `tipo` | VARCHAR | NO | `lei`, `decreto`, `lc`, `resolucao`... |
 | `numero` | VARCHAR | YES | nullable porque fallback existe |
 | `ano` | INTEGER | NO | |
-| `data_publicacao` | DATE | YES | nullable se não extraível |
-| `urn_lex` | VARCHAR | NO | URN LEX canônico |
-| `titulo` | VARCHAR | YES | título informal se houver |
-| `ementa` | TEXT | YES | resumo oficial |
-| `texto_completo` | TEXT | YES | denormalizado: OCR concatenado da fonte canônica |
-| `texto_normalizado` | TEXT | YES | NFC + whitespace cleanup, busca client-side |
-| `url_raw_ia` | VARCHAR (JSON array) | NO | lista de raw IA ids consumidos |
-| `url_leiml_ia` | VARCHAR | NO | URL do `law.leiml` |
-| `url_ocr_ia` | VARCHAR (JSON array) | NO | lista de URLs `_djvu.txt` por fonte |
-| `url_pdf_ia` | VARCHAR (JSON array) | NO | lista de URLs PDF por fonte |
-| `fonte_canonica` | VARCHAR | NO | slug curto da fonte (`casacivil`, `diario`, `assembleia`) — ver §5 |
-| `num_fontes` | INTEGER | NO | quantidade de fontes capturadas |
+| `data_publicacao` | DATE | YES | |
+| `urn_lex` | VARCHAR | YES | nullable se `data_publicacao` desconhecida (URN LEX requer data) — ver §5.4 |
+| `titulo` | VARCHAR | YES | |
+| `ementa` | VARCHAR | YES | |
+| `url_law_xml_ia` | VARCHAR | NO | URL do `law.xml` no IA |
+| `vigente_em` | DATE | NO | data da compilação vigente |
 | `tem_divergencia` | BOOLEAN | NO | flag rápido frontend |
-| `divergencias` | TEXT (JSON) | YES | diff summary estruturado |
+| `num_divergencias` | INTEGER | NO | |
+| `num_dispositivos` | INTEGER | NO | |
+| `num_versoes_total` | INTEGER | NO | soma de versoes em todos os dispositivos |
+| `revogada` | BOOLEAN | NO | |
 | `parse_status` | VARCHAR | NO | `raw_only`/`parsed`/`failed` |
 | `parse_method` | VARCHAR | YES | `llm-haiku`/`llm-opus`/`manual`/`deterministic` |
 | `confianca_parse` | FLOAT | YES | 0.0–1.0 |
-| `hash_conteudo` | VARCHAR | YES | sha256 do `texto_completo` |
 | `created_at` | TIMESTAMP | NO | |
 | `updated_at` | TIMESTAMP | NO | |
 
-### 3.1 Representação de arrays
+### 3.2 Tabela `dispositivos` — uma linha por dispositivo
 
-**Decisão (aprovada)**: usar `VARCHAR` com JSON serializado, **não** Parquet LIST nativo.
+| coluna | tipo | nullable | nota |
+|---|---|---|---|
+| `dispositivo_id` | VARCHAR | NO | composto: `{lei_id}#{path}` (e.g. `leizilla-ro-lei-01234-2003#art-3-par-2`) |
+| `lei_id` | VARCHAR | NO | FK para `leis.id` |
+| `urn_dispositivo` | VARCHAR | YES | `urn:lex:...;1234!art-3!par-2` (LexML dialect, ver §5.4) |
+| `tipo` | VARCHAR | NO | `artigo`/`paragrafo`/`inciso`/`alinea`/`item`/`caput` |
+| `rotulo` | VARCHAR | NO | "Art. 1º", "§ 2º", "II", "a)" |
+| `path` | VARCHAR | NO | hierárquico: `art-3` / `art-3-par-2` / `art-3-par-2-inc-1` / `art-3-par-2-inc-1-ali-a` |
+| `parent_path` | VARCHAR | YES | NULL para raiz; senão path do dispositivo pai |
+| `ordem` | INTEGER | NO | ordem dentro do parent (1, 2, 3...) |
+| `texto_vigente` | VARCHAR | YES | texto da versão atualmente vigente (denormalizado para query rápida) |
+| `vigente_desde` | DATE | YES | data efeito da versão vigente |
+| `revogado` | BOOLEAN | NO | |
+| `revogado_em` | DATE | YES | |
 
-**Justificativa**:
-- DuckDB-WASM 1.28 lê LISTs nativos, mas TanStack Query + Svelte components ficam mais simples com JSON strings.
-- JSON é universal (compatível com qualquer ferramenta downstream).
-- Custo: ~5–10% maior em storage, irrelevante para Parquet (compressão SNAPPY).
+### 3.3 Tabela `versoes` — uma linha por versão histórica de cada dispositivo
 
-### 3.2 Representação de divergências
+| coluna | tipo | nullable | nota |
+|---|---|---|---|
+| `versao_id` | VARCHAR | NO | `{dispositivo_id}#v{N}` |
+| `dispositivo_id` | VARCHAR | NO | FK para `dispositivos.dispositivo_id` |
+| `lei_id` | VARCHAR | NO | denormalizado p/ join-free queries |
+| `numero_versao` | INTEGER | NO | 1, 2, 3... cronológico |
+| `vigente_de` | DATE | NO | |
+| `vigente_ate` | DATE | YES | NULL = ainda vigente |
+| `texto` | VARCHAR | NO | |
+| `texto_normalizado` | VARCHAR | YES | NFC + cleanup, p/ busca |
+| `alterado_por_lei_id` | VARCHAR | YES | NULL na versão original; senão FK para `leis.id` da lei alteradora |
+| `fonte_canonica` | VARCHAR | NO | slug curto da fonte usada (`casacivil`, `diario`, `assembleia`...) |
+| `fontes_consultadas` | VARCHAR (JSON array) | NO | lista de raw IA ids usados |
+| `tem_divergencia` | BOOLEAN | NO | |
+| `divergencias` | VARCHAR (JSON) | YES | diff summary entre fontes |
+| `hash_texto` | VARCHAR | NO | sha256 |
+| `bloco_livre_quality` | VARCHAR | YES | `null` (parsing OK) / `low` / `medium` / `high` se `<bloco-livre>` foi usado |
 
-**Decisão (aprovada)**: `divergencias` é JSON string única, não colunas separadas.
+### 3.4 Representação de arrays e JSON
 
-**Justificativa**:
-- Cardinalidade variável (0–N divergências por lei).
-- Frontend renderiza apenas se `tem_divergencia=true` (flag rápido).
-- Drill-down é uso minoritário; full-table scan é tolerável.
+**Decisão (aprovada)**: arrays como `VARCHAR` com JSON serializado, **não** Parquet LIST nativo. Justificativa: simplifica TanStack Query + Svelte components; JSON universal; custo storage irrelevante com SNAPPY.
 
-### 3.3 Footer KV metadata (PyArrow)
+### 3.5 Footer KV metadata (PyArrow)
 
 ```python
 {
   "leizilla.schema_version": "1",
+  "leizilla.xml_schema_version": "0.1",
   "leizilla.ente": "ro",
+  "leizilla.table": "dispositivos",  # ou leis / versoes
   "leizilla.generated_at": "2026-05-20T19:00:00Z",
-  "leizilla.row_count": "4827",
-  "leizilla.git_sha": "abc1234",
-  "leizilla.leiml_version": "0.1"
+  "leizilla.row_count": "12483",
+  "leizilla.git_sha": "abc1234def5678901234567890abcdef12345678"
 }
 ```
 
 Escrita via `pyarrow.parquet.write_table` (não DuckDB `COPY` — esse não embute KV custom).
 
-### 3.4 Versioning
+> Reviewer #6 ponto 8 fix: `git_sha` é o SHA completo (40 chars), não truncado.
 
-- `schema_version` semver-ish: major bump apenas em break.
+### 3.6 Versioning
+
+- `schema_version` semver-ish na coluna `leizilla.schema_version`: major bump apenas em break.
 - CI valida que o `v{N}` no caminho do arquivo bate com o footer KV.
-- Zod schema em `web/src/schemas/v1/lei.ts` deve ser bumped junto.
+- Zod schema em `web/src/schemas/v1/lei.ts` + `dispositivo.ts` + `versao.ts` bumped junto.
+- v1 só é cravado depois do MVP rodar (reviewer #6 ponto 13). Durante M0–M4 o schema é **v0.1**; promove para v1 no fechamento de M5.
 
 ---
 
-## 4. Schema LeiML v0.1
+## 4. Leizilla XML v0.1 — formato canônico
 
-Definição mínima v0.1. Schema XSD formal em `docs/schemas/leiml-v0.1.xsd` (a criar).
+Esboço. Definição XSD formal em `docs/schemas/leizilla-v0.1.xsd` (M0.2).
 
-### 4.1 Elementos raiz
+### 4.1 Estrutura raiz
 
 ```xml
-<lei xmlns="https://leizilla.org/leiml/0.1" version="0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia:lei:2003-06-15;1234">
   <header>...</header>
-  <articulacao>...</articulacao>
+  <dispositivos>...</dispositivos>
   <anotacoes>...</anotacoes>
 </lei>
 ```
 
-### 4.2 `<header>` — metadados obrigatórios
+### 4.2 `<header>` — metadados da lei
 
-| Elemento | Obrigatório | Tipo | Nota |
-|---|---|---|---|
-| `<ente>` | sim | enum | slug do ente (`ro`, `federal`, `ro-porto-velho`) |
-| `<tipo>` | sim | enum | `lei`, `decreto`, `lc`, `resolucao`, `portaria` |
-| `<numero>` | não | string | nullable se fallback |
-| `<ano>` | sim | int | |
-| `<data-publicacao>` | não | date ISO | |
-| `<ementa>` | não | string | |
-| `<urn-lex>` | sim | string | `urn:lex:br;...` canônico |
-
-### 4.3 `<articulacao>` — corpo da lei
-
-Hierarquia (do mais externo para o mais interno):
-- `<artigo id="art-N">` ← rotulo + caput + paragrafos
-  - `<rotulo>` ← "Art. 1º"
-  - `<caput>` ← `<p>` com texto principal
-  - `<paragrafo id="art-N-par-M">` ← rotulo + p
-    - `<rotulo>` ← "§ 1º"
-    - `<p>` ← texto
-  - `<inciso id="art-N-inc-M">` ← rotulo + p (Roman: I, II, III...)
-  - `<alinea id="art-N-inc-M-ali-L">` ← rotulo + p (a, b, c...)
-
-Fallback se texto não puder ser estruturado:
 ```xml
-<articulacao>
-  <bloco-livre quality="low"><p>...texto OCR cru...</p></bloco-livre>
-</articulacao>
+<header>
+  <ente>ro</ente>
+  <tipo>lei</tipo>
+  <numero>1234</numero>
+  <ano>2003</ano>
+  <data-publicacao>2003-06-15</data-publicacao>
+  <ementa>Dispõe sobre...</ementa>
+  <vigente-em>2026-05-20</vigente-em>
+  <revogada>false</revogada>
+</header>
 ```
 
-### 4.4 `<anotacoes>` — metadados de processamento
+### 4.3 `<dispositivos>` — corpo dispositivo-cêntrico
+
+Cada dispositivo carrega sua própria **timeline de versões**. Nested para hierarquia.
+
+```xml
+<dispositivos>
+  <dispositivo tipo="artigo" path="art-1" urn="urn:lex:...;1234!art-1">
+    <rotulo>Art. 1º</rotulo>
+    <versoes>
+      <versao numero="1" vigente-de="2003-06-15" vigente-ate="2024-07-30"
+              alterado-por="urn:lex:br;estado:rondonia:lei:2024-06-30;5678">
+        <texto>Esta Lei dispõe sobre...</texto>
+        <fonte-canonica>casacivil</fonte-canonica>
+        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+        <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
+      </versao>
+      <versao numero="2" vigente-de="2024-07-30">
+        <texto>Esta Lei dispõe sobre (redação dada pela Lei 5.678/2024)...</texto>
+        <fonte-canonica>casacivil</fonte-canonica>
+        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00187"/>
+      </versao>
+    </versoes>
+    <dispositivo tipo="paragrafo" path="art-1-par-1" urn="urn:lex:...;1234!art-1!par-1">
+      <rotulo>§ 1º</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="2003-06-15">
+          <texto>...</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+  </dispositivo>
+</dispositivos>
+```
+
+Regras:
+- Cada `<dispositivo>` tem **no mínimo 1** `<versao>` (a original).
+- `vigente-ate` ausente = ainda vigente.
+- `alterado-por` aponta para URN da lei alteradora (não para versão específica).
+- Hierarquia via nesting; `path` é a chave determinística (gerada do nesting).
+
+### 4.4 Fallback: `<bloco-livre>` para OCR ruim
+
+Se o LLM não conseguir estruturar dispositivos:
+
+```xml
+<dispositivos>
+  <bloco-livre quality="low">
+    <p>...texto OCR cru, possivelmente fragmentado...</p>
+  </bloco-livre>
+</dispositivos>
+```
+
+Atributo `quality` é extensível: `low` / `medium` / `high` / `raw` (reviewer #6 ponto 🟢). Frontend renderiza com banner "texto não estruturado".
+
+### 4.5 `<anotacoes>` — metadados de processamento
 
 ```xml
 <anotacoes>
-  <fontes>
-    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042" tipo="casacivil"/>
-    <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012" tipo="diario"/>
-  </fontes>
-  <divergencia campo="articulacao/artigo[@id='art-3']/caput"
-               entre="casacivil,diario"
-               resolvido-por="diario">
-    §2º ausente em casacivil
+  <divergencia
+      dispositivo-path="art-3-par-2"
+      versao-numero="1"
+      entre="casacivil,diario"
+      diff-xpath="/dispositivo/versoes/versao[@numero='1']/texto">
+    §2º está ausente em casacivil; presente em diario. Texto vigente
+    adotado de casacivil (consolidado oficial); inconsistência marcada
+    para verificação manual.
   </divergencia>
-  <parse method="llm-haiku"
-         model="claude-haiku-4-5-20251001"
-         confianca="0.92"
-         timestamp="2026-05-20T18:45:00Z"/>
+  <parse
+      method="llm-haiku"
+      model="claude-haiku-4-5-20251001"
+      confianca="0.92"
+      timestamp="2026-05-20T18:45:00Z"/>
 </anotacoes>
 ```
 
-### 4.5 Stylesheet processing instruction
+> **Confiança baixa exibida explicitamente**: reviewer #6 ponto 5. Frontend mostra banner no card de detalhe da lei se `confianca_parse < 0.8` ou `parse_method = "llm-*"`: "Este texto foi compilado por LLM a partir de OCR — para texto oficial, consulte: [links das fontes raw]".
 
-Todo `law.leiml` deve começar com:
+### 4.6 Stylesheet processing instruction
+
+Todo `law.xml` começa com:
 ```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="https://leizilla.org/leiml.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
 ```
 
-Permite abrir `law.leiml` diretamente no browser e ver HTML renderizado (XSLT nativo).
+Abrir o XML direto no browser exibe HTML (XSLT in-browser). **Não** é o caminho de renderização primário (esse é Astro SSR — reviewer #6 ponto 12). É fallback opcional.
 
 ---
 
 ## 5. Naming completo — regex formal
 
-### Raw individual
+### 5.1 Raw individual
 ```
 ^leizilla-raw-(?P<ente>[a-z][a-z0-9-]*)-(?P<fonte>[a-z]+)-(?P<chave>[a-z0-9-]+)$
 ```
 
-### Raw bundle ZIP
+### 5.2 Raw bundle ZIP
 ```
 ^leizilla-bundle-(?P<ente>[a-z][a-z0-9-]*)-(?P<fonte>[a-z]+)-(?P<periodo>\d{4}-W\d{2})$
 ```
 
-### Parsed canônico
+### 5.3 Parsed
+**Canônico**:
 ```
-^leizilla-(?P<ente>[a-z][a-z0-9-]*)-(?P<tipo>[a-z]+)-(?P<numero>\d{5})-(?P<ano>\d{4})$
+^leizilla-(?P<ente>[a-z][a-z0-9-]*)-(?P<tipo>[a-z]+)-(?P<numero>\d{5,})-(?P<ano>\d{4})$
 ```
 
-### Parsed fallback (sem numero)
+> Reviewer #6 ponto 4 fix: `\d{5,}` em vez de `\d{5}` — leis federais já passam de 5 dígitos por extenso; zero-pad mínimo de 5 mantém ordenação lexicográfica para a maioria.
+
+> Codex P2 fix: o `id` no Parquet (§3.1) **sempre** usa o `numero` zero-padded para bater com o IA identifier. Lookup `id → IA item` é literal, sem normalização extra.
+
+**Fallback**:
 ```
 ^leizilla-(?P<ente>[a-z][a-z0-9-]*)-(?P<tipo>[a-z]+)-fallback-(?P<fonte>[a-z]+)-(?P<chave>[a-z0-9-]+)$
 ```
 
-### Dataset
+> Codex P1 fix: `{fonte}` é obrigatório no fallback, evitando colisão quando fontes diferentes compartilham `chave`.
+
+### 5.4 Dataset
 ```
 ^leizilla-dataset-(?P<ente>[a-z][a-z0-9-]*)-v(?P<version>\d+)$
 ```
 
-### Slug `{ente}` — produção controlada
+### 5.5 URN LEX
+
+**Lei**: `urn:lex:br;{jurisdicao};lei:{YYYY-MM-DD};{numero}`
+- `{jurisdicao}` para estados: `estado:rondonia` / `estado:sao-paulo`
+- `{jurisdicao}` para federal: `federal`
+- `{jurisdicao}` para municípios: `municipio:rondonia;porto-velho`
+
+**Dispositivo**: `{urn-lei}!art-N` ou `{urn-lei}!art-N!par-M!inc-K!ali-L` (separador `!` cf. extensão LexML para sub-document addressing).
+
+**Fallback URN quando `data_publicacao` desconhecida** (reviewer #6 ponto 3): `urn_lex` na coluna Parquet é nullable. Quando data não é extraível, gravar `NULL` (não falsificar). Identifier IA usa fallback `{ente}-{tipo}-fallback-{fonte}-{chave}` que não depende de URN.
+
+> **Pendente M0.2**: verificar contra a especificação oficial CGPID se o separador interno é `;`, `,` ou `:` em casos como `urn:lex:br;rondonia:estadual:lei,2003-06-15;1234`. Reviewer #6 sugeriu que CGPID usa vírgulas em alguns campos. Validar antes de cravar o exemplo.
+
+### 5.6 Slug `{ente}`
 
 - União: `federal`
-- Estados: ISO 3166-2:BR sem o prefixo `BR-`, lowercase: `ro`, `sp`, `mg`, `rj`...
-- Municípios: `{uf}-{slug-kebab}` — exemplo: `ro-porto-velho`, `sp-sao-paulo`
+- Estados: ISO 3166-2:BR sem `BR-`, lowercase: `ro`, `sp`, `mg`, `rj`...
+- Municípios: `{uf}-{slug-kebab}`: `ro-porto-velho`, `sp-sao-paulo`
 - DF: `df`
 
-**Validação**: lista canônica em `src/leizilla/entes.py` (M1) com nome oficial, UF pai, e código IBGE.
+Lista canônica em `src/leizilla/entes.py` (M1) com nome oficial, UF pai, código IBGE.
 
-### Slug `{fonte}` — enum por ente
+### 5.7 Slug `{fonte}` — regra load-bearing
 
-**Regra de slug (load-bearing)**: `{fonte}` é um token único `[a-z]+` — **sem hífens nem underscores**. Toda referência (IA identifier, `raw_meta.json.fonte`, `parsed_meta.json.fonte_canonica` / `resolvido_por`, atributo `tipo` em LeiML `<fonte>` / `<divergencia>`, coluna Parquet `fonte_canonica`, enum `FONTES` Python) usa **exatamente o mesmo slug**. Hífens no slug quebrariam a parsing do identifier `leizilla-raw-{ente}-{fonte}-{chave}` por torná-lo ambíguo (e.g., `diario-oficial-2003-06-15` não tem fronteira reconhecível entre fonte e chave). Diff/join determinístico por fonte exige um único valor canônico em todas as camadas.
+`{fonte}` é token único `[a-z]+` — **sem hífens nem underscores**. Toda referência (IA identifier, `raw_meta.json.fonte`, `parsed_meta.json.fonte_consultadas`, atributo `<fonte-canonica>` em XML, coluna Parquet `fonte_canonica`, enum `FONTES` Python) usa **exatamente o mesmo slug**.
 
-Cada ente declara suas fontes oficiais em `src/leizilla/fontes/{ente}.py`. Exemplo:
+Hífens quebrariam parsing de `leizilla-raw-{ente}-{fonte}-{chave}` (sem fronteira reconhecível). Nomes longos (`diário oficial`, `casa civil`) ficam em campos `display_name` / metadata IA legível.
 
-```python
-# src/leizilla/fontes/ro.py
-FONTES = {
-    "casacivil": "https://ditel.casacivil.ro.gov.br/cotel/",
-    "assembleia": "https://sapl.al.ro.leg.br/",
-    "diario": "https://www.diof.ro.gov.br/",   # Diário Oficial — slug curto sem hífen
-}
-```
-
-Nomes longos (`diário oficial`, `casa civil`) ficam em campos `display_name` / metadata IA legível, nunca no slug.
+Slugs canônicos lockados: `casacivil`, `diario`, `assembleia`, `planalto`, `camara`, `senado`.
 
 ---
 
-## 6. Export LexML
+## 6. Export LexML — gate de CI, não constraint estrutural
 
-**Decisão (aprovada)**: LeiML é canônico; LexML é export sob demanda.
+**Decisão (aprovada, pós-review #6)**: Leizilla XML é o formato canônico. LexML é gerado sob demanda como **representação reduzida** para gov interop.
+
+**Perdas conhecidas no export** (documentadas no XSLT):
+- `<bloco-livre quality="low">` → vira `<Texto>` cru sem marcação.
+- `<anotacoes><divergencia>` e `<parse>` → descartados (não têm equivalente LexML).
+- Timeline `<versoes>` colapsa para `<TextoArticulado>` da versão vigente apenas; histórico vira `<Alteracao>` LexML quando possível.
 
 **Estratégia**:
-- XSLT `etl/leiml-to-lexml.xsl` realiza a conversão.
+- XSLT `scripts/leizilla-to-lexml.xsl` realiza conversão.
 - CLI `uv run leizilla export-lexml --ia-id leizilla-ro-lei-01234-2003` gera `law.lexml` localmente.
-- **Não** uploadamos `law.lexml` ao IA por padrão. Geração on-demand evita duplicação e mantém LexML sempre derivado de LeiML.
-- Quando um release oficial for solicitado (e.g., entrega para Senado/Câmara), gerar batch em ZIP separado: `leizilla-lexml-export-{ente}-{date}.zip`.
+- **Não** uploadamos `law.lexml` ao IA por padrão. Sob demanda para release oficial: ZIP separado `leizilla-lexml-export-{ente}-{date}.zip`.
 
-**CI round-trip**:
-- A cada PR, rodar `pytest tests/test_leiml_export.py` que:
-  1. Pega 3 fixtures LeiML em `tests/fixtures/leiml/`.
-  2. Aplica `leiml-to-lexml.xsl`.
-  3. Valida XML resultante contra XSD oficial LexML em `tests/fixtures/lexml.xsd`.
+**CI gate**:
+- A cada PR, `pytest tests/test_lexml_export.py`:
+  1. Pega 3 fixtures `tests/fixtures/leizilla_xml/`.
+  2. Aplica `leizilla-to-lexml.xsl`.
+  3. Valida XML contra XSD oficial LexML em `tests/fixtures/lexml.xsd` (bundle no repo — reviewer #6 ponto 6 + §9 resolvida: **bundle aprovada**).
+  4. Falha se LexML resultante não validar.
+
+CI **não** valida round-trip (LexML → Leizilla XML não é objetivo).
 
 ---
 
 ## 7. Versionamento — regras de bump
 
-| Coisa | Versão atual | Quando bumpar major |
+| Coisa | Versão atual | Bump major em |
 |---|---|---|
-| LeiML | `0.1` | mudança incompatível no schema XSD |
-| Parquet schema | `1` | coluna removida ou tipo alterado de forma breaking |
-| LeiML meta JSON | `0.1` | campo obrigatório adicionado ou removido |
-| `leizilla` CLI | `1.0` (após M5) | breaking change em subcomandos |
+| Leizilla XML | `0.1` | mudança incompatível no schema XSD |
+| Parquet schema | `0.1` (vira `1` em M5) | coluna removida ou tipo breaking |
+| Sidecar JSON | `0.1` | campo obrigatório add/remove |
+| `leizilla` CLI | `1.0` (após M5) | breaking em subcomandos |
 
-**Constraint CI**: ao bumpar major, `web/src/schemas/v{N}/` precisa existir e ser referenciado em `web/src/lib/queries.ts`. Build quebra se faltar.
+CI: ao bumpar major, `web/src/schemas/v{N}/` precisa existir + ser referenciado em `web/src/lib/queries.ts`. Build quebra se faltar.
 
 ---
 
 ## 8. Inspirações dos sister projects
 
-Onde nossa decisão foi influenciada por código existente em ficha/baliza/causaganha:
-
 ### Da ficha
-- **ZIP de raw bulk** (§1.2): ficha mirror dos 37 ZIPs RFB. Adotamos pattern análogo (ZIP semanal por ente+fonte).
-- **Parquet como camada canônica**: ficha tem `cnpjs.parquet`, `socios.parquet` etc. Nossa `leis-{ente}-v{N}.parquet` segue mesma filosofia.
-- **Footer KV `schema_version`**: ficha embute no Parquet; replicamos em §3.3.
+- ZIP de raw bulk (§1.2) ← ficha mirror dos 37 ZIPs RFB.
+- Parquet como camada canônica ← ficha tem `cnpjs.parquet`, `socios.parquet`. Nossa `leis-{ente}-v{N}.parquet` + `dispositivos-{ente}-v{N}.parquet` + `versoes-{ente}-v{N}.parquet` seguem mesma filosofia, normalizada em 3 tabelas.
+- Footer KV `schema_version` ← ficha embute; replicamos em §3.5.
 
 ### Da baliza
-- **Manifest CSV no IA como source of truth**: baliza usa `baliza-pncp-manifest/manifest.csv` com `parquet_url`, `parquet_uploaded_at`, `parquet_schema_version`, `sha256`. Nossa `manifest-{ente}.csv` segue mesma estrutura adaptada.
-- **`raw-YYYY-MM.zip` para forensics**: baliza guarda JSON cru opcionalmente. Nossa `leizilla-bundle-...zip` cumpre função similar.
+- Manifest CSV no IA como source of truth ← baliza usa `baliza-pncp-manifest/manifest.csv`. Nossa `manifest-{ente}.csv` segue mesma estrutura.
 
 ### Da causaganha
-- **Sync manifest por `(tribunal, date)`**: causaganha rastreia status de coleta granularmente. Nossa manifest rastreia `(ente, fonte, chave)` similarmente.
-- **Tribunais como subunit**: análogo aos nossos entes federativos.
+- Sync manifest por `(tribunal, date)` ← rastreio granular. Nossa rastreia `(ente, fonte, chave)`.
 
 ---
 
-## 9. Decisões pendentes (a fechar antes de M0 close)
+## 9. Decisões resolvidas em M0 (rastreio)
 
-- [ ] **Compressão Parquet**: SNAPPY (atual) vs ZSTD? ZSTD pode reduzir 20–30% mas DuckDB-WASM precisa suportar. Verificar em M0.
-- [ ] **Granularidade do bundle ZIP**: semanal (`YYYY-Www`) vs mensal (`YYYY-MM`)? Semanal melhor para frequência de scrape, mensal melhor para tamanho de download. **Provável**: semanal por enquanto, revisitar se tamanho ficar trivial.
-- [ ] **Onde armazenar `lexml.xsd` (validação CI)**: bundle no repo (~200KB) vs download em runtime do site oficial? **Provável**: bundle no repo para reprodutibilidade e isolamento de quebra do site gov.
-- [ ] **`leiml-meta-version` separado de `leiml-version`?**: meta JSON pode evoluir independente do XML. **Provável**: sim, separados.
+- ✅ **Granularidade IA raw**: individual por PDF (§1.1) + bundle ZIP semanal redundante (§1.2).
+- ✅ **Slug fonte é `[a-z]+` único** (§5.7).
+- ✅ **Bundle `lexml.xsd` no repo** (§6) — reprodutibilidade.
+- ✅ **`git_sha` SHA completo (40 chars)** (§3.5).
+- ✅ **Regex parsed aceita `\d{5,}`** (§5.3).
+- ✅ **Tipo Parquet usa `VARCHAR`** (§3.1–3.3), não `TEXT`.
+- ✅ **Fallback parsed inclui `{fonte}`** (§5.3).
+- ✅ **`id` Parquet sempre zero-padded** (§3.1).
+- ✅ **Dispositivo é unidade primária** (§0.1).
+- ✅ **Vigente compilado é canônico, histórico via timeline** (§0.2).
+- ✅ **Formato próprio (Leizilla XML), não fork LexML** (§0.3).
+- ✅ **SSR híbrido via Astro** (§0.4), softening do princípio 6 anterior.
+- ✅ **`urn_lex` Parquet é nullable** (§5.5).
+- ✅ **Schema Parquet é v0.1 durante M0–M4; promove a v1 em M5** (§3.6, §7).
 
----
+## 10. Decisões pendentes (resolver em M0.2)
 
-## 10. Open questions (não bloqueiam M0)
+- [ ] **Verificar URN LEX dialect** (§5.5) — separadores `;`/`,`/`:` contra spec CGPID atual.
+- [ ] **Compressão Parquet**: SNAPPY vs ZSTD. Verificar DuckDB-WASM 1.28 (ou versão atual) suporta ZSTD via teste real em M0.2.
+- [ ] **Granularidade bundle ZIP**: semanal (`YYYY-Www`) atual; revisitar se tamanho ficar trivial.
+- [ ] **XPath dialect em `diff-xpath`** (§4.5) — declarar "XPath 1.0 subset, atributos com aspas simples" (reviewer #6 ponto 9).
+- [ ] **Política de re-scrape**: PDF re-publicado pela fonte (hash diferente do anterior) vira novo raw item `{chave}-v2`? Ou substitui? (reviewer #6 ponto 11) — decidir antes de M2.
+- [ ] **Robots.txt + rate limiting** como princípio explícito no crawler (reviewer #6 ponto 12) — adicionar em ADR-0008 (pipeline) e `src/leizilla/crawler.py`.
+- [ ] **LGPD em leis antigas com nomes** (reviewer #6 ponto 8 da parecer) — triagem necessária? Política de redação? Adiar para v0.2 ou decidir agora?
+- [ ] **XSLT in-browser deprecation** (reviewer #6 ponto 4) — confirmar que primário é Astro SSR, XSLT é fallback opcional. Atualizar §4.6 se Astro SSR cobrir 100%.
+- [ ] **Estimativa custo LLM realista** (reviewer #6 ponto 6) — recalcular: 5.000 leis × 10k tokens × Haiku ≈ $40–100/ente. Atualizar IMPLEMENTATION.md se diferir muito.
 
-- Como lidar com **revogações e alterações** entre leis? LeiML v0.1 não captura essa relação. v0.2 poderia ter `<relacoes><revoga ref="urn:lex:..."/></relacoes>`.
-- Como **versionar a própria lei** quando o texto consolidado muda? Versão `latest` vs versão temporal? Adiar para v0.2.
-- **Multilíngua**: LexML cobre só pt-br oficial. Não precisa em v0.1.
+## 11. Open questions (v0.2 ou posterior)
+
+- **Catálogo de fontes federais** (Câmara, Senado, Planalto, DOU) — modelagem em §0.5 acomoda, mas vocabulário concreto fica para quando atacarmos `ente=federal`.
+- **Catálogo de fontes municipais** — ~5.570 estruturas distintas; modelo `src/leizilla/fontes/{ente}.py` escala, mas curadoria é desafio próprio.
+- **Versionamento de raw quando fonte republica** (overlap com §10) — política mais fina depois.
+- **Acessibilidade WCAG completa** — Astro SSR resolve maior parte; auditoria formal em M5.
+- **Multilíngua** — fora de escopo Leizilla.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,440 @@
+# SCHEMA.md — Design de dados do Leizilla
+
+> Decisões load-bearing sobre granularidade de IA items, layout de bundles, schema Parquet v1, schema LeiML v0.1, e naming. Este documento é editado quando uma decisão muda — a coluna **Status** indica se está `proposta`, `aprovada`, ou `superseded-by-#PR`.
+
+Companion docs:
+- `IMPLEMENTATION.md` (raiz) — status geral e log de decisões cronológico
+- `docs/adr/0005-ia-identifiers.md` (a criar em M1) — formalização normativa
+- `docs/schemas/leiml-v0.1.xsd` (a criar em M0) — schema XML
+
+---
+
+## 1. Granularidade dos IA items
+
+### 1.1 Raw items — individual por PDF (decisão primária)
+
+**Decisão (aprovada)**: cada PDF é um IA item separado.
+
+**Pattern**: `leizilla-raw-{ente}-{fonte}-{chave}`
+
+| ente | fonte | chave | Exemplo |
+|---|---|---|---|
+| `ro` | `casacivil` | `coddoc-{N:05d}` | `leizilla-raw-ro-casacivil-coddoc-00042` |
+| `ro` | `assembleia` | `coddoc-{N:05d}` | `leizilla-raw-ro-assembleia-coddoc-00042` |
+| `ro` | `diario` | `{YYYY-MM-DD}-p{pagina:04d}` | `leizilla-raw-ro-diario-2003-06-15-p0012` |
+| `federal` | `planalto` | `lei-{numero}-{ano}` | `leizilla-raw-federal-planalto-lei-12345-2024` |
+
+**Justificativa**:
+- Internet Archive faz OCR automático **apenas** em PDFs uploadados como item; PDFs dentro de ZIP não recebem OCR.
+- Permalink estável por PDF facilita citação e debugging.
+- Manifest CSV rastreia milhares de itens sem dificuldade (padrão causaganha).
+
+**Trade-off aceito**: muitos itens (~5.000 só para Rondônia). Acceptable — IA não cobra por número de itens.
+
+### 1.2 Raw items — bundle ZIP periódico (decisão secundária, redundância)
+
+**Decisão (aprovada)**: além dos PDFs individuais, gerar ZIPs semanais com o lote scrapeado, para arquivamento defensivo (padrão ficha).
+
+**Pattern**: `leizilla-bundle-{ente}-{fonte}-{periodo}` onde `{periodo}` segue ISO week: `YYYY-Www`.
+
+Exemplo: `leizilla-bundle-ro-casacivil-2026-W20`
+
+**Layout interno do ZIP**:
+```
+leizilla-bundle-ro-casacivil-2026-W20.zip
+├── manifest.csv
+│   columns: coddoc, ia_id, fonte_url, hash_pdf, data_captura
+├── pdfs/
+│   ├── 00042.pdf
+│   ├── 00043.pdf
+│   └── ...
+└── meta/
+    ├── 00042.json    ← cópia do raw_meta.json do item individual
+    ├── 00043.json
+    └── ...
+```
+
+**Justificativa**:
+- Redundância contra perda acidental de items individuais.
+- Permite download em lote (1 ZIP de N MB > N requests).
+- Mirror histórico das fontes (snapshot semanal).
+
+### 1.3 Parsed items — 1 lei = 1 item
+
+**Decisão (aprovada)**: cada lei canônica é um IA item permanente.
+
+**Pattern**: `leizilla-{ente}-{tipo}-{numero:05d}-{ano}`
+
+| Exemplo | Notas |
+|---|---|
+| `leizilla-ro-lei-01234-2003` | caso normal |
+| `leizilla-ro-decreto-00056-2024` | tipo = decreto |
+| `leizilla-federal-lc-00141-2012` | LC = lei complementar |
+
+**Fallback se `numero` ausente** (algumas leis antigas perderam numeração formal):
+- Pattern: `leizilla-{ente}-{tipo}-fallback-{chave}` onde `{chave}` é o coddoc da fonte primária.
+- Exemplo: `leizilla-ro-lei-fallback-casacivil-coddoc-00099`
+
+**Conteúdo do parsed item**:
+```
+leizilla-ro-lei-01234-2003/
+├── law.leiml          ← formato canônico (XML LeiML v0.1)
+├── parsed_meta.json   ← metadados estruturados
+└── provenance.json    ← rastreabilidade
+```
+
+Não inclui `law.html` (renderizado no browser via XSLT) nem `law.lexml` (export sob demanda; ver §6).
+
+### 1.4 Dataset items — versionados por schema
+
+**Decisão (aprovada)**: 1 IA item por `{ente}` × `{schema_version}`.
+
+**Pattern**: `leizilla-dataset-{ente}-v{N}`
+
+Exemplo: `leizilla-dataset-ro-v1` contém `leis-ro-v1.parquet` + `manifest-ro.csv` + `README.md`.
+
+Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado de forma incompatível). Adicionar coluna nullable não bumpa.
+
+---
+
+## 2. Layout dentro dos JSON sidecars
+
+### 2.1 `raw_meta.json` (sidecar do raw item)
+
+```json
+{
+  "leiml_meta_version": "0.1",
+  "ente": "ro",
+  "fonte": "casacivil",
+  "fonte_url": "https://ditel.casacivil.ro.gov.br/cotel/livros/Folder.aspx?coddoc=42",
+  "chave": "coddoc-00042",
+  "data_captura": "2026-05-20T14:30:00Z",
+  "hash_pdf": "sha256:abc123...",
+  "user_agent": "leizilla-crawler/1.0",
+  "ia_id_bundle": "leizilla-bundle-ro-casacivil-2026-W20"
+}
+```
+
+### 2.2 `parsed_meta.json` (sidecar do parsed item)
+
+```json
+{
+  "leiml_meta_version": "0.1",
+  "urn_lex": "urn:lex:br;estado:rondonia:lei:2003-06-15;1234",
+  "ente": "ro",
+  "tipo": "lei",
+  "numero": "1234",
+  "ano": 2003,
+  "data_publicacao": "2003-06-15",
+  "ementa": "Dispõe sobre...",
+  "fontes": [
+    "leizilla-raw-ro-casacivil-coddoc-00042",
+    "leizilla-raw-ro-diario-2003-06-15-p0012"
+  ],
+  "divergencias": [
+    {
+      "campo": "articulacao/artigo[@id='art-3']/caput",
+      "fonte_a": "leizilla-raw-ro-casacivil-coddoc-00042",
+      "fonte_b": "leizilla-raw-ro-diario-2003-06-15-p0012",
+      "diff_summary": "§2º ausente em casacivil; texto idêntico no resto",
+      "resolvido_por": "diario_oficial"
+    }
+  ],
+  "fonte_canonica": "diario_oficial",
+  "parse_method": "llm-haiku",
+  "parse_model": "claude-haiku-4-5-20251001",
+  "parse_timestamp": "2026-05-20T18:45:00Z",
+  "confianca_parse": 0.92,
+  "validacao_xsd": "passed"
+}
+```
+
+### 2.3 `provenance.json` (sidecar do parsed item)
+
+Audit trail mínimo separado para facilitar auditoria sem carregar `parsed_meta.json` completo.
+
+```json
+{
+  "fontes_raw": [
+    {
+      "ia_id": "leizilla-raw-ro-casacivil-coddoc-00042",
+      "ocr_url": "https://archive.org/download/leizilla-raw-ro-casacivil-coddoc-00042/law_djvu.txt",
+      "hash_pdf": "sha256:abc123...",
+      "consumed_at": "2026-05-20T18:45:00Z"
+    }
+  ],
+  "produced_by": {
+    "tool": "leizilla.etl.llm_parse",
+    "version": "0.1.0",
+    "git_sha": "abc1234"
+  }
+}
+```
+
+---
+
+## 3. Schema Parquet v1
+
+Tabela canônica `leis` no DuckDB e Parquet espelho.
+
+| coluna | tipo | nullable | nota |
+|---|---|---|---|
+| `id` | VARCHAR | NO | identifier IA do parsed item (`leizilla-{ente}-{tipo}-{numero}-{ano}`) |
+| `ente` | VARCHAR | NO | `ro`, `sp`, `federal`, `ro-porto-velho`... |
+| `tipo` | VARCHAR | NO | `lei`, `decreto`, `lc`, `resolucao`... |
+| `numero` | VARCHAR | YES | nullable porque fallback existe |
+| `ano` | INTEGER | NO | |
+| `data_publicacao` | DATE | YES | nullable se não extraível |
+| `urn_lex` | VARCHAR | NO | URN LEX canônico |
+| `titulo` | VARCHAR | YES | título informal se houver |
+| `ementa` | TEXT | YES | resumo oficial |
+| `texto_completo` | TEXT | YES | denormalizado: OCR concatenado da fonte canônica |
+| `texto_normalizado` | TEXT | YES | NFC + whitespace cleanup, busca client-side |
+| `url_raw_ia` | VARCHAR (JSON array) | NO | lista de raw IA ids consumidos |
+| `url_leiml_ia` | VARCHAR | NO | URL do `law.leiml` |
+| `url_ocr_ia` | VARCHAR (JSON array) | NO | lista de URLs `_djvu.txt` por fonte |
+| `url_pdf_ia` | VARCHAR (JSON array) | NO | lista de URLs PDF por fonte |
+| `fonte_canonica` | VARCHAR | NO | `diario_oficial`/`casacivil`/`assembleia` |
+| `num_fontes` | INTEGER | NO | quantidade de fontes capturadas |
+| `tem_divergencia` | BOOLEAN | NO | flag rápido frontend |
+| `divergencias` | TEXT (JSON) | YES | diff summary estruturado |
+| `parse_status` | VARCHAR | NO | `raw_only`/`parsed`/`failed` |
+| `parse_method` | VARCHAR | YES | `llm-haiku`/`llm-opus`/`manual`/`deterministic` |
+| `confianca_parse` | FLOAT | YES | 0.0–1.0 |
+| `hash_conteudo` | VARCHAR | YES | sha256 do `texto_completo` |
+| `created_at` | TIMESTAMP | NO | |
+| `updated_at` | TIMESTAMP | NO | |
+
+### 3.1 Representação de arrays
+
+**Decisão (aprovada)**: usar `VARCHAR` com JSON serializado, **não** Parquet LIST nativo.
+
+**Justificativa**:
+- DuckDB-WASM 1.28 lê LISTs nativos, mas TanStack Query + Svelte components ficam mais simples com JSON strings.
+- JSON é universal (compatível com qualquer ferramenta downstream).
+- Custo: ~5–10% maior em storage, irrelevante para Parquet (compressão SNAPPY).
+
+### 3.2 Representação de divergências
+
+**Decisão (aprovada)**: `divergencias` é JSON string única, não colunas separadas.
+
+**Justificativa**:
+- Cardinalidade variável (0–N divergências por lei).
+- Frontend renderiza apenas se `tem_divergencia=true` (flag rápido).
+- Drill-down é uso minoritário; full-table scan é tolerável.
+
+### 3.3 Footer KV metadata (PyArrow)
+
+```python
+{
+  "leizilla.schema_version": "1",
+  "leizilla.ente": "ro",
+  "leizilla.generated_at": "2026-05-20T19:00:00Z",
+  "leizilla.row_count": "4827",
+  "leizilla.git_sha": "abc1234",
+  "leizilla.leiml_version": "0.1"
+}
+```
+
+Escrita via `pyarrow.parquet.write_table` (não DuckDB `COPY` — esse não embute KV custom).
+
+### 3.4 Versioning
+
+- `schema_version` semver-ish: major bump apenas em break.
+- CI valida que o `v{N}` no caminho do arquivo bate com o footer KV.
+- Zod schema em `web/src/schemas/v1/lei.ts` deve ser bumped junto.
+
+---
+
+## 4. Schema LeiML v0.1
+
+Definição mínima v0.1. Schema XSD formal em `docs/schemas/leiml-v0.1.xsd` (a criar).
+
+### 4.1 Elementos raiz
+
+```xml
+<lei xmlns="https://leizilla.org/leiml/0.1" version="0.1">
+  <header>...</header>
+  <articulacao>...</articulacao>
+  <anotacoes>...</anotacoes>
+</lei>
+```
+
+### 4.2 `<header>` — metadados obrigatórios
+
+| Elemento | Obrigatório | Tipo | Nota |
+|---|---|---|---|
+| `<ente>` | sim | enum | slug do ente (`ro`, `federal`, `ro-porto-velho`) |
+| `<tipo>` | sim | enum | `lei`, `decreto`, `lc`, `resolucao`, `portaria` |
+| `<numero>` | não | string | nullable se fallback |
+| `<ano>` | sim | int | |
+| `<data-publicacao>` | não | date ISO | |
+| `<ementa>` | não | string | |
+| `<urn-lex>` | sim | string | `urn:lex:br;...` canônico |
+
+### 4.3 `<articulacao>` — corpo da lei
+
+Hierarquia (do mais externo para o mais interno):
+- `<artigo id="art-N">` ← rotulo + caput + paragrafos
+  - `<rotulo>` ← "Art. 1º"
+  - `<caput>` ← `<p>` com texto principal
+  - `<paragrafo id="art-N-par-M">` ← rotulo + p
+    - `<rotulo>` ← "§ 1º"
+    - `<p>` ← texto
+  - `<inciso id="art-N-inc-M">` ← rotulo + p (Roman: I, II, III...)
+  - `<alinea id="art-N-inc-M-ali-L">` ← rotulo + p (a, b, c...)
+
+Fallback se texto não puder ser estruturado:
+```xml
+<articulacao>
+  <bloco-livre quality="low"><p>...texto OCR cru...</p></bloco-livre>
+</articulacao>
+```
+
+### 4.4 `<anotacoes>` — metadados de processamento
+
+```xml
+<anotacoes>
+  <fontes>
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042" tipo="casa-civil"/>
+    <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012" tipo="diario-oficial"/>
+  </fontes>
+  <divergencia campo="articulacao/artigo[@id='art-3']/caput"
+               entre="casa-civil,diario-oficial"
+               resolvido-por="diario-oficial">
+    §2º ausente em casacivil
+  </divergencia>
+  <parse method="llm-haiku"
+         model="claude-haiku-4-5-20251001"
+         confianca="0.92"
+         timestamp="2026-05-20T18:45:00Z"/>
+</anotacoes>
+```
+
+### 4.5 Stylesheet processing instruction
+
+Todo `law.leiml` deve começar com:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://leizilla.org/leiml.xsl"?>
+```
+
+Permite abrir `law.leiml` diretamente no browser e ver HTML renderizado (XSLT nativo).
+
+---
+
+## 5. Naming completo — regex formal
+
+### Raw individual
+```
+^leizilla-raw-(?P<ente>[a-z][a-z0-9-]*)-(?P<fonte>[a-z]+)-(?P<chave>[a-z0-9-]+)$
+```
+
+### Raw bundle ZIP
+```
+^leizilla-bundle-(?P<ente>[a-z][a-z0-9-]*)-(?P<fonte>[a-z]+)-(?P<periodo>\d{4}-W\d{2})$
+```
+
+### Parsed canônico
+```
+^leizilla-(?P<ente>[a-z][a-z0-9-]*)-(?P<tipo>[a-z]+)-(?P<numero>\d{5})-(?P<ano>\d{4})$
+```
+
+### Parsed fallback (sem numero)
+```
+^leizilla-(?P<ente>[a-z][a-z0-9-]*)-(?P<tipo>[a-z]+)-fallback-(?P<fonte>[a-z]+)-(?P<chave>[a-z0-9-]+)$
+```
+
+### Dataset
+```
+^leizilla-dataset-(?P<ente>[a-z][a-z0-9-]*)-v(?P<version>\d+)$
+```
+
+### Slug `{ente}` — produção controlada
+
+- União: `federal`
+- Estados: ISO 3166-2:BR sem o prefixo `BR-`, lowercase: `ro`, `sp`, `mg`, `rj`...
+- Municípios: `{uf}-{slug-kebab}` — exemplo: `ro-porto-velho`, `sp-sao-paulo`
+- DF: `df`
+
+**Validação**: lista canônica em `src/leizilla/entes.py` (M1) com nome oficial, UF pai, e código IBGE.
+
+### Slug `{fonte}` — enum por ente
+
+Cada ente declara suas fontes oficiais em `src/leizilla/fontes/{ente}.py`. Exemplo:
+
+```python
+# src/leizilla/fontes/ro.py
+FONTES = {
+    "casacivil": "https://ditel.casacivil.ro.gov.br/cotel/",
+    "assembleia": "https://sapl.al.ro.leg.br/",
+    "diario": "https://www.diof.ro.gov.br/",
+}
+```
+
+---
+
+## 6. Export LexML
+
+**Decisão (aprovada)**: LeiML é canônico; LexML é export sob demanda.
+
+**Estratégia**:
+- XSLT `etl/leiml-to-lexml.xsl` realiza a conversão.
+- CLI `uv run leizilla export-lexml --ia-id leizilla-ro-lei-01234-2003` gera `law.lexml` localmente.
+- **Não** uploadamos `law.lexml` ao IA por padrão. Geração on-demand evita duplicação e mantém LexML sempre derivado de LeiML.
+- Quando um release oficial for solicitado (e.g., entrega para Senado/Câmara), gerar batch em ZIP separado: `leizilla-lexml-export-{ente}-{date}.zip`.
+
+**CI round-trip**:
+- A cada PR, rodar `pytest tests/test_leiml_export.py` que:
+  1. Pega 3 fixtures LeiML em `tests/fixtures/leiml/`.
+  2. Aplica `leiml-to-lexml.xsl`.
+  3. Valida XML resultante contra XSD oficial LexML em `tests/fixtures/lexml.xsd`.
+
+---
+
+## 7. Versionamento — regras de bump
+
+| Coisa | Versão atual | Quando bumpar major |
+|---|---|---|
+| LeiML | `0.1` | mudança incompatível no schema XSD |
+| Parquet schema | `1` | coluna removida ou tipo alterado de forma breaking |
+| LeiML meta JSON | `0.1` | campo obrigatório adicionado ou removido |
+| `leizilla` CLI | `1.0` (após M5) | breaking change em subcomandos |
+
+**Constraint CI**: ao bumpar major, `web/src/schemas/v{N}/` precisa existir e ser referenciado em `web/src/lib/queries.ts`. Build quebra se faltar.
+
+---
+
+## 8. Inspirações dos sister projects
+
+Onde nossa decisão foi influenciada por código existente em ficha/baliza/causaganha:
+
+### Da ficha
+- **ZIP de raw bulk** (§1.2): ficha mirror dos 37 ZIPs RFB. Adotamos pattern análogo (ZIP semanal por ente+fonte).
+- **Parquet como camada canônica**: ficha tem `cnpjs.parquet`, `socios.parquet` etc. Nossa `leis-{ente}-v{N}.parquet` segue mesma filosofia.
+- **Footer KV `schema_version`**: ficha embute no Parquet; replicamos em §3.3.
+
+### Da baliza
+- **Manifest CSV no IA como source of truth**: baliza usa `baliza-pncp-manifest/manifest.csv` com `parquet_url`, `parquet_uploaded_at`, `parquet_schema_version`, `sha256`. Nossa `manifest-{ente}.csv` segue mesma estrutura adaptada.
+- **`raw-YYYY-MM.zip` para forensics**: baliza guarda JSON cru opcionalmente. Nossa `leizilla-bundle-...zip` cumpre função similar.
+
+### Da causaganha
+- **Sync manifest por `(tribunal, date)`**: causaganha rastreia status de coleta granularmente. Nossa manifest rastreia `(ente, fonte, chave)` similarmente.
+- **Tribunais como subunit**: análogo aos nossos entes federativos.
+
+---
+
+## 9. Decisões pendentes (a fechar antes de M0 close)
+
+- [ ] **Compressão Parquet**: SNAPPY (atual) vs ZSTD? ZSTD pode reduzir 20–30% mas DuckDB-WASM precisa suportar. Verificar em M0.
+- [ ] **Granularidade do bundle ZIP**: semanal (`YYYY-Www`) vs mensal (`YYYY-MM`)? Semanal melhor para frequência de scrape, mensal melhor para tamanho de download. **Provável**: semanal por enquanto, revisitar se tamanho ficar trivial.
+- [ ] **Onde armazenar `lexml.xsd` (validação CI)**: bundle no repo (~200KB) vs download em runtime do site oficial? **Provável**: bundle no repo para reprodutibilidade e isolamento de quebra do site gov.
+- [ ] **`leiml-meta-version` separado de `leiml-version`?**: meta JSON pode evoluir independente do XML. **Provável**: sim, separados.
+
+---
+
+## 10. Open questions (não bloqueiam M0)
+
+- Como lidar com **revogações e alterações** entre leis? LeiML v0.1 não captura essa relação. v0.2 poderia ter `<relacoes><revoga ref="urn:lex:..."/></relacoes>`.
+- Como **versionar a própria lei** quando o texto consolidado muda? Versão `latest` vs versão temporal? Adiar para v0.2.
+- **Multilíngua**: LexML cobre só pt-br oficial. Não precisa em v0.1.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -13,17 +13,34 @@ Companion docs:
 
 ## 0. Princípios de modelagem (reescrita pós-review #6)
 
-### 0.1 Dispositivo é a unidade primária
+### 0.1 Dispositivo é a unidade primária e universal de texto
 
-A unidade básica de dado **não é a lei** — é o **dispositivo** (artigo, parágrafo, inciso, alínea, item). Justificativa:
+A unidade básica de dado **não é a lei** — é o **dispositivo**. E "dispositivo" é o tipo universal para **tudo que for texto que ajude a interpretar a norma**:
 
+**Normativos** (carregam texto normativo próprio em `<versoes><versao><texto>...`):
+- `titulo-lei`: nome oficial ("LEI Nº 14.133, DE 1º DE ABRIL DE 2021")
+- `ementa`: resumo oficial
+- `preambulo`: "O Presidente da República, faço saber..."
+- `artigo`, `paragrafo`, `inciso`, `alinea`, `item`: articulação
+- `anexo`: anexos com texto (tabelas, listas, fórmulas — estrutura interna em v0.2)
+- `disposicao-transitoria`, `disposicao-final`: blocos finais de disposições
+
+**Organizacionais** (agrupadores sem texto normativo, só `<rotulo>` versionável):
+- `livro`, `parte`, `titulo`, `capitulo`, `secao`, `subsecao`
+
+Tudo é `<dispositivo>` com `tipo` diferenciando. Blocos organizacionais ("TÍTULO I — Dos Princípios") são uma **espécie** de dispositivo, sem `<texto>` mas com `<rotulo>` versionável (renomear capítulo é alteração real).
+
+**Cada dispositivo declara seu pai explicitamente** (`parent` attribute obrigatório). Raiz: `parent=""`. Hierarquia explícita, navegável em ambas direções.
+
+Justificativa:
 - Lawyers citam dispositivos, não leis inteiras ("art. 5º, §2º, II, alínea b da CF/88").
-- Alterações legislativas operam sobre dispositivos individuais, não sobre a lei toda.
-- Revogações são parciais com frequência (revoga art. 3º mantém o resto).
-- Cross-references naturais ("Lei 14.133/2021 art. 3 alterou Lei 1.234/2003 art. 5 §2").
-- DuckDB-WASM consegue indexar e buscar dispositivos com SQL trivial; a lei é apenas o agregador.
+- Alterações operam sobre dispositivos individuais (caput, parágrafo isolado, anexo isolado).
+- Revogações são parciais com frequência (revoga art. 3º mantém o resto; revoga Anexo II mantém articulação).
+- Cross-references granulares ("Lei 14.133/2021 art. 3 alterou Lei 1.234/2003 art. 5 §2").
+- DuckDB-WASM indexa dispositivos com SQL trivial; lei é apenas o agregador.
+- **Uniformidade**: zero exceção. Todo texto da lei tem o mesmo molde de tratamento, mesma timeline temporal, mesmo padrão de divergência multi-fonte.
 
-Isso difere de LexML/Akoma Ntoso, que centram em document/work. Para nosso uso (busca jurídica + timeline temporal), dispositivo-cêntrico é mais expressivo.
+Isso difere de LexML/Akoma Ntoso, que centram em document/work com elementos separados (`<Ementa>`, `<Preambulo>`, `<Articulacao>`, `<Anexo>`). Para nosso uso (busca jurídica + timeline temporal + alterações granulares), dispositivo universal é mais expressivo.
 
 ### 0.2 Vigente compilado é o objeto canônico; histórico é timeline
 
@@ -282,10 +299,10 @@ Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet
 | `dispositivo_id` | VARCHAR | NO | composto: `{lei_id}#{path}` (e.g. `leizilla-ro-lei-01234-2003#art-3-par-2`) |
 | `lei_id` | VARCHAR | NO | FK para `leis.id` |
 | `urn_dispositivo` | VARCHAR | YES | `urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-3!par-2` (LexML dialect, ver §5.5). Regra: `urn_dispositivo` é `NULL` ⟺ `leis.urn_lex` da lei pai é `NULL` (lei sem data extraível) |
-| `tipo` | VARCHAR | NO | `artigo`/`paragrafo`/`inciso`/`alinea`/`item`/`caput` |
+| `tipo` | VARCHAR | NO | enum unificado (ver §0.1): normativos (`titulo-lei`, `ementa`, `preambulo`, `artigo`, `paragrafo`, `inciso`, `alinea`, `item`, `anexo`, `disposicao-transitoria`, `disposicao-final`) + organizacionais (`livro`, `parte`, `titulo`, `capitulo`, `secao`, `subsecao`). **Não inclui `caput`** — caput é índice 0 implícito (§4.3). Filtrar blocos vs normativos: `WHERE texto IS NOT NULL` (normativos têm texto) ou `WHERE tipo IN (...)` por enum. |
 | `rotulo` | VARCHAR | NO | "Art. 1º", "§ 2º", "II", "a)" |
 | `path` | VARCHAR | NO | hierárquico: `art-3` / `art-3-par-2` / `art-3-par-2-inc-1` / `art-3-par-2-inc-1-ali-a` |
-| `parent_path` | VARCHAR | YES | NULL para raiz; senão path do dispositivo pai |
+| `parent_path` | VARCHAR | NO | path do dispositivo pai. Raiz: string vazia `""`. Sempre declarado (§0.1: parent obrigatório). |
 | `ordem` | INTEGER | NO | ordem dentro do parent (1, 2, 3...) |
 | `texto_vigente` | VARCHAR | YES | texto da versão atualmente vigente (denormalizado para query rápida) |
 | `vigente_desde` | DATE | YES | data efeito da versão vigente |
@@ -302,8 +319,9 @@ Dispositivo-cêntrico exige três tabelas relacionadas. Cada uma vira um Parquet
 | `numero_versao` | INTEGER | NO | 1, 2, 3... cronológico |
 | `vigente_de` | DATE | NO | |
 | `vigente_ate` | DATE | YES | NULL = ainda vigente |
-| `texto` | VARCHAR | NO | |
-| `texto_normalizado` | VARCHAR | NO | NFC + cleanup, alimenta busca client-side. **Sempre gerado quando `texto` é NOT NULL** — nullable só faz sentido se `texto` também fosse null (não acontece). |
+| `texto` | VARCHAR | YES | NULL quando o dispositivo é organizacional (tipo ∈ {livro, parte, titulo, capitulo, secao, subsecao}); NOT NULL para normativos. |
+| `texto_normalizado` | VARCHAR | YES | NFC + cleanup, alimenta busca client-side. Mesmo padrão de nullability que `texto`. |
+| `rotulo` | VARCHAR | YES | rotulo na versão (override do `dispositivos.rotulo` estável). Útil quando rotulo muda entre versões (renomear capítulo). Normalmente NULL. |
 | `alterado_por_lei_id` | VARCHAR | YES | NULL na versão original; senão FK para `leis.id` da lei alteradora |
 | `fonte_canonica` | VARCHAR | NO | slug curto da fonte usada (`casacivil`, `diario`, `assembleia`...) |
 | `fontes_consultadas` | VARCHAR (JSON array) | NO | lista de raw IA ids usados |
@@ -367,13 +385,15 @@ Esboço. Definição XSD formal em `docs/schemas/leizilla-v0.1.xsd` (M0.2).
 ### 4.2 `<header>` — metadados da lei
 
 ```xml
+<!-- Header carrega APENAS metadados estruturais/bibliográficos.
+     Todo texto (título oficial, ementa, preâmbulo, articulação, anexos)
+     vive em <dispositivos> (§0.1). -->
 <header>
   <ente>ro</ente>
   <tipo>lei</tipo>
   <numero>1234</numero>
   <ano>2003</ano>
   <data-publicacao>2003-06-15</data-publicacao>
-  <ementa>Dispõe sobre...</ementa>
   <vigente-em>2026-05-20</vigente-em>
   <revogada>false</revogada>
 </header>
@@ -391,62 +411,144 @@ Esboço. Definição XSD formal em `docs/schemas/leizilla-v0.1.xsd` (M0.2).
 
 Cada dispositivo carrega sua própria **timeline de versões**. Nested para hierarquia.
 
-**Regra do caput (Opção D — aprovada)**: caput não é elemento separado. Todo `<dispositivo>` container (artigo, parágrafo, inciso) tem `<versoes>` opcional carregando **seu próprio texto intrínseco** — que corresponde ao "caput" na terminologia jurídica quando o dispositivo tem filhos. Conceitualmente o caput é o "índice 0" dos filhos do container. Implica:
+**Regra do caput (Opção D — aprovada)**: caput não é elemento separado nem tipo. Todo `<dispositivo>` normativo container (artigo, parágrafo, inciso) carrega `<texto>` na sua própria `<versao>` — isso **é** o caput quando o dispositivo tem filhos. Conceitualmente o caput é o "índice 0" dos filhos do container. Implica:
 
-- **Sem elemento `<dispositivo tipo="caput">`**. Caput é propriedade implícita do container.
+- **Sem `<dispositivo tipo="caput">`**. Caput é propriedade implícita do container normativo. `caput` **não está** no enum de `tipo` (§3.2).
 - **URN aponta para o container**: `urn:lex:...!art-5` resolve para o texto intrínseco (caput) do art-5. Sub-itens via `!art-5!par-1`, etc.
 - **Versionamento granular preservado**: alterar só o caput = nova `<versao>` no próprio `<dispositivo path="art-5">`. Alterar só o §1 = nova `<versao>` em `<dispositivo path="art-5-par-1">`. Independentes.
 - **Aplica recursivamente**: parágrafo com incisos também tem "caput" (seu próprio texto antes dos incisos), mesma regra.
 - **Parquet `dispositivos`**: 1 row por dispositivo. A row do container **é** o caput. Não há row extra "caput".
-- **Export LexML** (XSLT): wrap mecânico — `<dispositivo path="art-5"><versoes>{T}</versoes>...</dispositivo>` vira `<Artigo><Caput><Texto>{T}</Texto></Caput>...</Artigo>`.
+- **Export LexML** (XSLT): wrap mecânico — `<dispositivo path="art-5"><versoes><versao><texto>{T}</texto></versao></versoes>...` vira `<Artigo><Caput><Texto>{T}</Texto></Caput>...</Artigo>`.
 
 ```xml
+<!-- Exemplo cobrindo: título-lei + ementa + preâmbulo + blocos organizacionais
+     + articulação + anexo. Tudo é <dispositivo>; tipo discrimina o papel. -->
 <dispositivos>
-  <dispositivo tipo="artigo" path="art-1"
-               urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-1">
-    <rotulo>Art. 1º</rotulo>
+
+  <dispositivo tipo="titulo-lei" path="titulo-lei" parent=""
+               urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!titulo-lei">
+    <rotulo>Título</rotulo>
     <versoes>
-      <versao numero="1" vigente-de="2003-06-15" vigente-ate="2024-07-30"
-              alterado-por="urn:lex:br;estado:rondonia;lei:2024-06-30;5678">
-        <texto>Esta Lei dispõe sobre...</texto>
+      <versao numero="1" vigente-de="2003-06-15">
+        <texto>LEI Nº 1.234, DE 15 DE JUNHO DE 2003</texto>
         <fonte-canonica>casacivil</fonte-canonica>
         <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
-        <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
-      </versao>
-      <versao numero="2" vigente-de="2024-07-30">
-        <texto>Esta Lei dispõe sobre (redação dada pela Lei 5.678/2024)...</texto>
-        <fonte-canonica>casacivil</fonte-canonica>
-        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00187"/>
       </versao>
     </versoes>
-    <dispositivo tipo="paragrafo" path="art-1-par-1"
-                 urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-1!par-1">
-      <rotulo>§ 1º</rotulo>
+  </dispositivo>
+
+  <dispositivo tipo="ementa" path="ementa" parent="">
+    <rotulo>Ementa</rotulo>
+    <versoes>
+      <versao numero="1" vigente-de="2003-06-15">
+        <texto>Dispõe sobre a organização administrativa do Estado de Rondônia.</texto>
+        <fonte-canonica>casacivil</fonte-canonica>
+        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+      </versao>
+    </versoes>
+  </dispositivo>
+
+  <dispositivo tipo="preambulo" path="preambulo" parent="">
+    <rotulo>Preâmbulo</rotulo>
+    <versoes>
+      <versao numero="1" vigente-de="2003-06-15">
+        <texto>O GOVERNADOR DO ESTADO DE RONDÔNIA faço saber...</texto>
+        <fonte-canonica>casacivil</fonte-canonica>
+        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+      </versao>
+    </versoes>
+  </dispositivo>
+
+  <!-- Bloco organizacional: tem <rotulo> versionável, NÃO tem <texto> nas versões -->
+  <dispositivo tipo="titulo" path="tit-1" parent="">
+    <rotulo>TÍTULO I — Dos Princípios Fundamentais</rotulo>
+    <versoes>
+      <!-- Bloco pode ter versão se rotulo mudar; sem <texto> -->
+      <versao numero="1" vigente-de="2003-06-15">
+        <rotulo>TÍTULO I — Dos Princípios Fundamentais</rotulo>
+        <fonte-canonica>casacivil</fonte-canonica>
+      </versao>
+    </versoes>
+
+    <dispositivo tipo="capitulo" path="tit-1-cap-1" parent="tit-1">
+      <rotulo>CAPÍTULO I — Disposições Preliminares</rotulo>
       <versoes>
         <versao numero="1" vigente-de="2003-06-15">
-          <texto>...</texto>
+          <rotulo>CAPÍTULO I — Disposições Preliminares</rotulo>
           <fonte-canonica>casacivil</fonte-canonica>
-          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
         </versao>
       </versoes>
+
+      <!-- Path do artigo permanece GLOBAL (art-1), não tit-1-cap-1-art-1.
+           parent="tit-1-cap-1" declara o nesting. Citação "art. 1º" = lookup
+           direto por path. -->
+      <dispositivo tipo="artigo" path="art-1" parent="tit-1-cap-1"
+                   urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-1">
+        <rotulo>Art. 1º</rotulo>
+        <versoes>
+          <versao numero="1" vigente-de="2003-06-15" vigente-ate="2024-07-30"
+                  alterado-por="urn:lex:br;estado:rondonia;lei:2024-06-30;5678">
+            <texto>Esta Lei dispõe sobre...</texto>     <!-- caput do art-1 -->
+            <fonte-canonica>casacivil</fonte-canonica>
+            <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+            <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
+          </versao>
+          <versao numero="2" vigente-de="2024-07-30">
+            <texto>Esta Lei dispõe sobre (redação dada pela Lei 5.678/2024)...</texto>
+            <fonte-canonica>casacivil</fonte-canonica>
+            <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00187"/>
+          </versao>
+        </versoes>
+
+        <dispositivo tipo="paragrafo" path="art-1-par-1" parent="art-1"
+                     urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-1!par-1">
+          <rotulo>§ 1º</rotulo>
+          <versoes>
+            <versao numero="1" vigente-de="2003-06-15">
+              <texto>...</texto>                          <!-- caput do § -->
+              <fonte-canonica>casacivil</fonte-canonica>
+              <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+            </versao>
+          </versoes>
+        </dispositivo>
+      </dispositivo>
     </dispositivo>
   </dispositivo>
+
+  <dispositivo tipo="anexo" path="anexo-1" parent="">
+    <rotulo>ANEXO I — Tabela de Cargos</rotulo>
+    <versoes>
+      <versao numero="1" vigente-de="2003-06-15">
+        <texto>... conteúdo do anexo (estrutura interna em v0.2) ...</texto>
+        <fonte-canonica>casacivil</fonte-canonica>
+        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+      </versao>
+    </versoes>
+  </dispositivo>
+
 </dispositivos>
 ```
 
-**Mapping nesting XML ↔ `path` flat na tabela Parquet `dispositivos`** (§3.2): o `path` é determinístico, derivado do nesting da hierarquia. Exemplo: `<dispositivo tipo="artigo">` no índice 3 contendo `<dispositivo tipo="paragrafo">` no índice 2 → `path="art-3-par-2"`. Frontend e ETL usam o **mesmo gerador** (`src/leizilla/leiml/path.py` em M3).
+**Regras (todas obrigatórias)**:
+
+1. **`parent` attribute obrigatório** em todo `<dispositivo>`. Raiz: `parent=""`.
+2. **`<versoes>` obrigatório** com **no mínimo 1 `<versao>`** (a original). Sem exceção. Blocos organizacionais têm `<versao>` carregando só `<rotulo>` (sem `<texto>`); normativos têm `<texto>` (e opcionalmente `<rotulo>` override).
+3. **Path do dispositivo normativo é GLOBAL** (`art-5`, `art-5-par-1`, `art-5-par-1-inc-1`, `art-5-par-1-inc-1-ali-a`). Não namespaceia por bloco organizacional acima. Citação forense ("art. 5º") = lookup literal.
+4. **Path do dispositivo organizacional namespaceia internamente** (`tit-1`, `tit-1-cap-1`, `tit-1-cap-1-sec-2`). Hierarquia de blocos é própria.
+5. **Caput é implícito (índice 0)**: container normativo (`artigo`, `paragrafo`, `inciso`) carrega seu próprio `<texto>` no nível do container; filhos `<dispositivo>` são sub-itens. Sem `<dispositivo tipo="caput">`. Ver detalhes abaixo.
+
+**Mapping nesting XML ↔ `path` flat na tabela Parquet `dispositivos`** (§3.2): geração determinística do path. Frontend e ETL usam o **mesmo gerador** (`src/leizilla/leizilla_xml/path.py` em M3).
 
 ```
-artigo[3] > paragrafo[2] > inciso[1] > alinea[a]
-   └────────┬──────────────┬──────────┬─────────┘
-        art-3        art-3-par-2  art-3-par-2-inc-1  art-3-par-2-inc-1-ali-a
+TÍTULO I  >  CAPÍTULO I  >  Art. 1º  >  § 1º  >  inciso I  >  alínea a
+  tit-1     tit-1-cap-1     art-1     art-1-par-1   art-1-par-1-inc-1   art-1-par-1-inc-1-ali-a
+  (org)       (org)         (norm)     (norm)         (norm)               (norm)
 ```
 
-Regras:
-- Cada `<dispositivo>` tem **no mínimo 1** `<versao>` (a original).
+**Outras regras de versão**:
 - `vigente-ate` ausente = ainda vigente.
 - `alterado-por` aponta para URN da lei alteradora (não para versão específica).
-- Hierarquia via nesting; `path` é a chave determinística (gerada do nesting).
+- Hierarquia via nesting XML + `parent` attribute (redundância intencional para validação cruzada).
 
 ### 4.4 Fallback: `<bloco-livre>` para OCR ruim
 
@@ -643,6 +745,10 @@ CI: ao bumpar major, `web/src/schemas/v{N}/` precisa existir + ser referenciado 
 - ✅ **Custo LLM diluído no tempo** — estimativa de ~$40–100/ente (5k leis × 10k tokens × Haiku) é aceitável; ingestão é one-shot por lei, custo amortiza. Re-parsing pontual em fill-gaps é marginal. Não é fator de bloqueio do design.
 - ✅ **Re-scrape sob auditoria** — re-scrape NÃO é automático. Disparado só quando auditoria periódica conclui que qualidade do raw caiu (e.g., versão do PDF foi corrigida pela fonte, ou OCR muito ruim). Quando re-scrape acontece, novo raw item vira `{chave}-r{N}` (revisão); raw anterior permanece (imutabilidade §0.X). Documentado como processo em IMPLEMENTATION.md (auditoria periódica de qualidade).
 - ✅ **Auditoria de novas fontes por ente** — processo paralelo à re-scrape: auditoria periódica avalia se novas fontes oficiais devem ser adicionadas ao `src/leizilla/fontes/{ente}.py` (e.g., descobrir que estado X tem um portal de transparência que reúne consolidados). Não bloqueia M0.
+- ✅ **Dispositivo é unidade universal de texto** (§0.1) — `tipo` enum cobre normativos (titulo-lei, ementa, preambulo, artigo, paragrafo, inciso, alinea, item, anexo, disposicao-*) e organizacionais (livro, parte, titulo, capitulo, secao, subsecao). Tudo que é texto da lei é `<dispositivo>`. Header carrega só metadados bibliográficos.
+- ✅ **Path do dispositivo normativo é global** (§4.3 regra 3) — `art-5` permanece `art-5` independente do bloco. Citação forense direta.
+- ✅ **Parent attribute obrigatório** (§0.1) — todo `<dispositivo>` declara `parent="..."`. Raiz: `parent=""`. Redundante com nesting XML mas explicitude força clareza e permite validação cruzada.
+- ✅ **Sem `eh_bloco` column** — redundante com `tipo`. Filtros via `texto IS NOT NULL` (normativos) ou `tipo IN (...)`.
 
 ## 10. Decisões pendentes (resolver em M0.2)
 
@@ -652,7 +758,6 @@ CI: ao bumpar major, `web/src/schemas/v{N}/` precisa existir + ser referenciado 
 - [ ] **XPath dialect em `diff-xpath`** (§4.5) — declarar "XPath 1.0 subset, atributos com aspas simples" (reviewer #6 ponto 9).
 - [ ] **Robots.txt + rate limiting** como princípio explícito no crawler (reviewer #6 ponto 12) — adicionar em ADR-0008 (pipeline) e `src/leizilla/crawler.py`. Nota: com §0.5 (Wayback como fetch primário), bater na fonte original fica raro — robots.txt continua valendo, rate-limit do nosso crawler vira proteção do Wayback save endpoint (15 req/min sem auth, 100 com SavePageNow).
 - [ ] **XSLT in-browser deprecation** (reviewer #6 ponto 4) — confirmar que primário é Astro SSR, XSLT é fallback opcional. Atualizar §4.6 se Astro SSR cobrir 100%.
-- [ ] **Modelagem de blocos legislativos** (livro, parte, título, capítulo, seção, subseção, anexos) — agrupadores organizacionais sem texto normativo próprio. Atualmente fora do schema; CF e códigos não cabem sem isso. Decidir: hierarquia única com `<bloco>` aninhado com `<dispositivo>`, ou duas hierarquias paralelas (`<estrutura>` + `<dispositivos>` flat com `<dispositivo-ref>`). Path do dispositivo permanece global (`art-5`), não namespaceado por bloco.
 
 ## 11. Open questions (v0.2 ou posterior)
 


### PR DESCRIPTION
## Summary

First commit of the migration to the franklinbaldo stack (Astro 6.3 + Svelte 5.55 + Pico CSS 2.1 + DuckDB-WASM 1.28 + Internet Archive). Per the agreed plan, **the first milestone (M0) is documentation-only** — no production code is written until the schema design is locked.

- **`IMPLEMENTATION.md`** (root): living document. Tracks milestone status, decision log (chronological, append-only), problems encountered, how-to-run instructions. Updated in every PR going forward.
- **`docs/SCHEMA.md`**: deep design covering:
  - IA item granularity — individual PDF items (for IA auto-OCR) + redundant weekly ZIP bundles (ficha-style)
  - Parsed item layout (`law.leiml` + `parsed_meta.json` + `provenance.json`)
  - Parquet schema v1 with PyArrow KV footer (arrays as JSON strings, divergencias as JSON)
  - LeiML v0.1 element model (our LexML fork, with mandatory round-trip export)
  - Naming regex for raw / bundle / parsed / fallback / dataset identifiers
  - Slug rules for `{ente}` (federal, RO, RO-Porto-Velho, etc.) and `{fonte}` (per-ente enum)
  - LexML export strategy (on-demand XSLT, CI round-trip validation)
  - Influences traced back to ficha (ZIP+Parquet pattern), baliza (manifest CSV), causaganha (sync manifest)

## Architectural principles locked (see `IMPLEMENTATION.md` §Princípios)

1. Two stages in IA, always separated (raw immutable, parsed re-runnable)
2. OCR is IA's responsibility — never run locally
3. Stage 2 is pluggable (LLM Haiku default, Opus fallback, deterministic, manual)
4. Multiple sources per law are expected (Assembleia + Casa Civil + Diário Oficial reconciliation)
5. Generic per federal entity from day 1 (`{ente}` parameter everywhere)
6. LeiML canonical, HTML rendered client-side via XSLT/JS — never pre-generated
7. ZIP raw bulk + Parquet analytics + IA item distribution (ficha pattern)

## What's NOT in this PR

- No code changes (zero touched in `src/`)
- No `leiml-v0.1.xsd` schema file yet (M0.2 follow-up)
- No `tests/fixtures/leiml/` round-trip fixtures yet (M0.2 follow-up)
- No ADRs (those land in M1 alongside the package restructure)

## Test plan

- [ ] Reviewer confirms `IMPLEMENTATION.md` correctly captures the agreed plan and feels like a doc they would want to update during implementation
- [ ] Reviewer confirms `docs/SCHEMA.md` decisions are sound, especially:
  - Individual PDF items vs ZIP bundles (§1.1, §1.2)
  - Parquet array-as-JSON-string vs native LIST (§3.1)
  - LeiML element model is sufficient for v0.1 (§4)
  - Naming regex covers all anticipated identifier types (§5)
- [ ] Reviewer flags any of the §9 "Decisões pendentes" they want resolved before M0 closes
- [ ] Reviewer reviews §10 "Open questions" for v0.2 scope

Once approved, M0.2 finishes with the XSD + fixtures, then M1 opens (package restructure + ADRs).


---
_Generated by [Claude Code](https://claude.ai/code/session_0142QrK5n2k4bAzS7F5Vb8RR)_