### PR TITLE
docs(M0.2): leizilla-v0.1.xsd + first fixture (simple)

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -9,7 +9,7 @@
 | Milestone | Status | PR | Notas |
 |---|---|---|---|
 | **M0.1** — Documento vivo + SCHEMA.md design | 🟢 done | #6 | Aprovado em re-review; pronto para merge. |
-| **M0.2** — XSD + fixtures + lexml-export script | ⚪ todo | — | Próximo. Inclui `leizilla-v0.1.xsd`, 3 fixtures Leizilla XML, `scripts/leizilla-to-lexml.xsl`, teste CI de export, consistency-checker script, e resolução de 6 pendentes §10. |
+| **M0.2** — XSD + fixtures + lexml-export script | 🟡 in-progress | TBD | XSD v0.1 escrito; 1 de 4 fixtures (simple.xml); pendente: with-alterations, with-blocos-organizacionais, with-bloco-livre, leizilla-to-lexml.xsl, test_lexml_export.py, check_schema_consistency.py, resolver 6 pendentes §10. |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Leizilla XML v0.1 — schema canônico do Leizilla.
+
+  Consolida as decisões de docs/SCHEMA.md §4. Premissas load-bearing:
+
+  - Dispositivo é unidade universal de texto da lei (§0.1).
+  - Dispositivo recursivo: container <dispositivo> pode conter outros
+    <dispositivo> filhos. Caput é o próprio <texto> do container (sem
+    elemento separado).
+  - Atributo `parent` obrigatório em todo <dispositivo> (raiz parent="").
+  - <versoes> obrigatório com ≥1 <versao>. Normativos têm <texto>;
+    organizacionais têm só <rotulo_versao> (sem <texto>).
+  - Fallback <bloco-livre quality="..."> quando LLM não estrutura.
+
+  XSD propositalmente permissivo em alguns pontos para acomodar
+  iteração inicial. Endurece em v0.2 conforme M2-M4 expõem casos
+  reais que escapam.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="https://leizilla.org/lei/0.1"
+           xmlns:leizilla="https://leizilla.org/lei/0.1"
+           targetNamespace="https://leizilla.org/lei/0.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="0.1">
+
+  <!-- ==================================================================
+       Tipos enumerados
+       ================================================================== -->
+
+  <xs:simpleType name="TipoDispositivo">
+    <xs:annotation>
+      <xs:documentation>
+        Enum unificado para todos os tipos de dispositivo.
+
+        Normativos (carregam &lt;texto&gt; em &lt;versoes&gt;):
+        titulo-lei, ementa, preambulo, artigo, paragrafo, inciso, alinea,
+        item, anexo, disposicao-transitoria, disposicao-final.
+
+        Organizacionais (só &lt;rotulo_versao&gt;, sem &lt;texto&gt;):
+        livro, parte, titulo, capitulo, secao, subsecao.
+
+        NÃO inclui "caput" — caput é índice 0 implícito (SCHEMA.md §4.3).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <!-- normativos -->
+      <xs:enumeration value="titulo-lei"/>
+      <xs:enumeration value="ementa"/>
+      <xs:enumeration value="preambulo"/>
+      <xs:enumeration value="artigo"/>
+      <xs:enumeration value="paragrafo"/>
+      <xs:enumeration value="inciso"/>
+      <xs:enumeration value="alinea"/>
+      <xs:enumeration value="item"/>
+      <xs:enumeration value="anexo"/>
+      <xs:enumeration value="disposicao-transitoria"/>
+      <xs:enumeration value="disposicao-final"/>
+      <!-- organizacionais -->
+      <xs:enumeration value="livro"/>
+      <xs:enumeration value="parte"/>
+      <xs:enumeration value="titulo"/>
+      <xs:enumeration value="capitulo"/>
+      <xs:enumeration value="secao"/>
+      <xs:enumeration value="subsecao"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="TipoLei">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="lei"/>
+      <xs:enumeration value="decreto"/>
+      <xs:enumeration value="lc"/>
+      <xs:enumeration value="resolucao"/>
+      <xs:enumeration value="portaria"/>
+      <xs:enumeration value="medida-provisoria"/>
+      <xs:enumeration value="emenda-constitucional"/>
+      <xs:enumeration value="constituicao"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="SlugFonte">
+    <xs:annotation>
+      <xs:documentation>
+        Slug de fonte: token único [a-z]+ sem hífens nem underscores.
+        SCHEMA.md §5.7.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="SlugEnte">
+    <xs:annotation>
+      <xs:documentation>
+        Slug de ente federativo: [a-z][a-z0-9-]*. Inclui `federal`,
+        siglas UF (`ro`, `sp`), e `{uf}-{municipio}` (`ro-porto-velho`).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z][a-z0-9-]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="UrnLex">
+    <xs:annotation>
+      <xs:documentation>
+        URN LEX (dialect provisório — ver SCHEMA.md §10 e §5.5).
+        Formato esperado: urn:lex:br;{jurisdicao};{tipo}:{data};{numero}
+        opcionalmente seguido de !{path-de-dispositivo}.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="urn:lex:br;[^;]+;[^;]+:\d{4}-\d{2}-\d{2};[^!]+(![a-z0-9-]+)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="DispositivoPath">
+    <xs:annotation>
+      <xs:documentation>
+        Path do dispositivo. Normativos: global (art-5, art-5-par-1).
+        Organizacionais: namespaceado no nesting (tit-1, tit-1-cap-1).
+        Raiz: string vazia.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="|[a-z][a-z0-9-]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="BlocoLivreQuality">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="low"/>
+      <xs:enumeration value="medium"/>
+      <xs:enumeration value="high"/>
+      <xs:enumeration value="raw"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ParseMethod">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="llm-haiku"/>
+      <xs:enumeration value="llm-opus"/>
+      <xs:enumeration value="llm-sonnet"/>
+      <xs:enumeration value="manual"/>
+      <xs:enumeration value="deterministic"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ==================================================================
+       Tipos complexos
+       ================================================================== -->
+
+  <xs:complexType name="HeaderType">
+    <xs:annotation>
+      <xs:documentation>
+        Header carrega APENAS metadados estruturais/bibliográficos.
+        Texto (título oficial, ementa, preâmbulo) vive em &lt;dispositivos&gt;
+        como tipo="titulo-lei" / "ementa" / "preambulo". SCHEMA.md §4.2.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ente" type="SlugEnte"/>
+      <xs:element name="tipo" type="TipoLei"/>
+      <xs:element name="numero" type="xs:string" minOccurs="0"/>
+      <xs:element name="ano" type="xs:gYear"/>
+      <xs:element name="data-publicacao" type="xs:date" minOccurs="0"/>
+      <xs:element name="vigente-em" type="xs:date">
+        <xs:annotation>
+          <xs:documentation>
+            Data de referência da compilação. "Esta versão do law.xml
+            representa a lei como ela estava vigente em &lt;vigente-em&gt;."
+            Não confundir com &lt;versao vigente-de/vigente-ate&gt; (intervalo
+            de validade de uma redação específica).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="revogada" type="xs:boolean" default="false" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="FonteType">
+    <xs:attribute name="ia-id" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="VersaoType">
+    <xs:annotation>
+      <xs:documentation>
+        Uma redação histórica do dispositivo.
+
+        - Normativos: &lt;texto&gt; obrigatório.
+        - Organizacionais: &lt;texto&gt; ausente; &lt;rotulo_versao&gt; opcional
+          carrega o rótulo da época (útil quando capítulo é renomeado).
+
+        XSD não consegue expressar a regra "texto presente iff dispositivo
+        é normativo" via cardinalidade pura — validação semântica fica
+        no consistency checker (M0.2).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="texto" type="xs:string" minOccurs="0"/>
+      <xs:element name="rotulo_versao" type="xs:string" minOccurs="0"/>
+      <xs:element name="fonte-canonica" type="SlugFonte" minOccurs="0"/>
+      <xs:element name="fonte" type="FonteType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="numero" type="xs:positiveInteger" use="required"/>
+    <xs:attribute name="vigente-de" type="xs:date" use="required"/>
+    <xs:attribute name="vigente-ate" type="xs:date" use="optional">
+      <xs:annotation>
+        <xs:documentation>Ausente = ainda vigente.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="alterado-por" type="UrnLex" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          URN da lei alteradora (não da versão específica). Ausente na
+          versão original.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="VersoesType">
+    <xs:sequence>
+      <xs:element name="versao" type="VersaoType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Dispositivo recursivo. ComplexType nomeado para auto-referência. -->
+  <xs:complexType name="DispositivoType">
+    <xs:sequence>
+      <xs:element name="rotulo" type="xs:string" minOccurs="0"/>
+      <xs:element name="versoes" type="VersoesType" minOccurs="1"/>
+      <xs:element name="dispositivo" type="DispositivoType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="tipo" type="TipoDispositivo" use="required"/>
+    <xs:attribute name="path" type="DispositivoPath" use="required"/>
+    <xs:attribute name="parent" type="DispositivoPath" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Obrigatório em todo dispositivo. Raiz: parent="" (string vazia).
+          SCHEMA.md §0.1.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="urn" type="UrnLex" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          URN do dispositivo. Opcional — ausente quando o lei.urn-lex
+          é desconhecido (data_publicacao não extraível). Quando
+          presente, é {lei.urn-lex}!{path}.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="BlocoLivreType">
+    <xs:annotation>
+      <xs:documentation>
+        Fallback quando LLM não consegue estruturar o texto OCR em
+        dispositivos. Frontend renderiza com banner "texto não
+        estruturado". SCHEMA.md §4.4.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="p" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="quality" type="BlocoLivreQuality" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="DispositivosType">
+    <xs:annotation>
+      <xs:documentation>
+        Container de dispositivos OU fallback &lt;bloco-livre&gt;. Choice
+        exclusivo — uma lei é parseada (dispositivos) ou OCR-livre
+        (bloco-livre), nunca os dois.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="dispositivo" type="DispositivoType"
+                  minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="bloco-livre" type="BlocoLivreType"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="DivergenciaType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="dispositivo-path" type="DispositivoPath" use="required"/>
+        <xs:attribute name="versao-numero" type="xs:positiveInteger" use="required"/>
+        <xs:attribute name="entre" type="xs:string" use="required">
+          <xs:annotation>
+            <xs:documentation>
+              Lista de slugs de fonte separados por vírgula
+              (e.g. "casacivil,diario").
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="diff-xpath" type="xs:string" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="ParseType">
+    <xs:attribute name="method" type="ParseMethod" use="required"/>
+    <xs:attribute name="model" type="xs:string" use="optional"/>
+    <xs:attribute name="confianca" use="optional">
+      <xs:simpleType>
+        <xs:restriction base="xs:decimal">
+          <xs:minInclusive value="0.0"/>
+          <xs:maxInclusive value="1.0"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="timestamp" type="xs:dateTime" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="AnotacoesType">
+    <xs:sequence>
+      <xs:element name="divergencia" type="DivergenciaType"
+                  minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="parse" type="ParseType" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- ==================================================================
+       Elemento raiz
+       ================================================================== -->
+
+  <xs:element name="lei">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="header" type="HeaderType"/>
+        <xs:element name="dispositivos" type="DispositivosType"/>
+        <xs:element name="anotacoes" type="AnotacoesType" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attribute name="schema-version" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="0.1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="urn-lex" type="UrnLex" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            URN LEX da lei. Opcional porque data_publicacao pode ser
+            desconhecida em fallback. Quando presente, dispositivos
+            herdam via concatenação `{urn-lex}!{path}`.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -110,6 +110,11 @@
         URN LEX (dialect provisório — ver SCHEMA.md §10 e §5.5).
         Formato canônico: urn:lex:br;{jurisdicao};{tipo}:{data}[;{numero}][!{path}...]
 
+        Jurisdição pode conter segmentos separados por `;` internamente —
+        e.g. municípios usam `municipio:rondonia;porto-velho` (SCHEMA.md §5.5).
+        A âncora confiável é o `:{data}` no segmento de tipo. O pattern
+        admite qualquer jurisdição/tipo até encontrar `:YYYY-MM-DD`.
+
         O segmento ;{numero} é opcional — ausente em normas sem numeração
         (e.g. Constituição Federal: urn:lex:br;federal;constituicao:1988-10-05).
         Paths de dispositivo seguem como !{slug} repetíveis.
@@ -119,7 +124,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="urn:lex:br;[^;]+;[^;]+:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9-]+)*"/>
+      <xs:pattern value="urn:lex:br;[a-z][a-z0-9:;\-]*:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9\-]+)*"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -194,15 +199,22 @@
     <xs:sequence>
       <xs:element name="ente" type="SlugEnte"/>
       <xs:element name="tipo" type="TipoLei"/>
-      <xs:element name="numero" type="xs:string" minOccurs="0">
+      <xs:element name="numero" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
             Número da lei. Opcional — ausente em normas sem numeração
-            formal (e.g. Constituição Federal). Quando ausente, urn-lex
-            no elemento raiz também deve ser omitido ou usar formato
-            sem segmento de número.
+            formal (e.g. Constituição Federal). Quando presente, deve
+            ser não-vazio (xs:string com minLength=1) — string vazia
+            criaria ambiguidade entre "presente mas vazio" e "ausente",
+            o que polui geração de identifier/URN downstream. Para
+            normas sem número, omita o elemento.
           </xs:documentation>
         </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
       </xs:element>
       <xs:element name="ano" type="xs:gYear"/>
       <xs:element name="data-publicacao" type="xs:date" minOccurs="0"/>

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -124,7 +124,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="urn:lex:br;[a-z][a-z0-9:;\-]*:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9\-]+)*"/>
+      <xs:pattern value="urn:lex:br;[a-z][a-z0-9:;\-]*;[a-z][a-z0-9\-]*:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9\-]+)*"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -108,21 +108,44 @@
     <xs:annotation>
       <xs:documentation>
         URN LEX (dialect provisório — ver SCHEMA.md §10 e §5.5).
-        Formato esperado: urn:lex:br;{jurisdicao};{tipo}:{data};{numero}
-        opcionalmente seguido de !{path-de-dispositivo}.
+        Formato canônico: urn:lex:br;{jurisdicao};{tipo}:{data}[;{numero}][!{path}...]
+
+        O segmento ;{numero} é opcional — ausente em normas sem numeração
+        (e.g. Constituição Federal: urn:lex:br;federal;constituicao:1988-10-05).
+        Paths de dispositivo seguem como !{slug} repetíveis.
+
+        Zero-pad NÃO faz parte da URN — zero-pad é exclusivo do identifier IA
+        (SCHEMA.md §5.1). A URN representa o número legal (42, não 0042).
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="urn:lex:br;[^;]+;[^;]+:\d{4}-\d{2}-\d{2};[^!]+(![a-z0-9-]+)*"/>
+      <xs:pattern value="urn:lex:br;[^;]+;[^;]+:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9-]+)*"/>
     </xs:restriction>
   </xs:simpleType>
 
   <xs:simpleType name="DispositivoPath">
     <xs:annotation>
       <xs:documentation>
-        Path do dispositivo. Normativos: global (art-5, art-5-par-1).
+        Path do dispositivo (atributo `path`). Sempre não-vazio.
+        Normativos: global (art-5, art-5-par-1).
         Organizacionais: namespaceado no nesting (tit-1, tit-1-cap-1).
-        Raiz: string vazia.
+        Especiais: titulo-lei, ementa, preambulo, preambulo, anexo-1.
+
+        Deve ser não-vazio — apenas `parent` admite string vazia (raiz).
+        Ver ParentPath para o atributo `parent`.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z][a-z0-9-]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ParentPath">
+    <xs:annotation>
+      <xs:documentation>
+        Path do dispositivo pai (atributo `parent`). String vazia
+        significa "filho direto da lei" (sem pai dispositivo). Caso
+        contrário, mesmo formato de DispositivoPath.
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -140,10 +163,17 @@
   </xs:simpleType>
 
   <xs:simpleType name="ParseMethod">
+    <xs:annotation>
+      <xs:documentation>
+        Estratégia de parsing. llm-haiku = produção padrão; llm-opus =
+        fill-gaps routine (casos difíceis); manual = curadoria humana via PR;
+        deterministic = parser regex/grammar para fontes estruturadas.
+        SCHEMA.md §2.2 — histórico de reprocessamentos vive em provenance.json.
+      </xs:documentation>
+    </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="llm-haiku"/>
       <xs:enumeration value="llm-opus"/>
-      <xs:enumeration value="llm-sonnet"/>
       <xs:enumeration value="manual"/>
       <xs:enumeration value="deterministic"/>
     </xs:restriction>
@@ -164,7 +194,16 @@
     <xs:sequence>
       <xs:element name="ente" type="SlugEnte"/>
       <xs:element name="tipo" type="TipoLei"/>
-      <xs:element name="numero" type="xs:string" minOccurs="0"/>
+      <xs:element name="numero" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Número da lei. Opcional — ausente em normas sem numeração
+            formal (e.g. Constituição Federal). Quando ausente, urn-lex
+            no elemento raiz também deve ser omitido ou usar formato
+            sem segmento de número.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="ano" type="xs:gYear"/>
       <xs:element name="data-publicacao" type="xs:date" minOccurs="0"/>
       <xs:element name="vigente-em" type="xs:date">
@@ -177,11 +216,27 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="revogada" type="xs:boolean" default="false" minOccurs="0"/>
+      <xs:element name="revogada" type="xs:boolean">
+        <xs:annotation>
+          <xs:documentation>
+            Obrigatório. Falso para a grande maioria das leis vigentes.
+            Não usar XSD default — comportamento de default em elemento
+            (diferente de atributo) só aplica a texto vazio, não a
+            elemento ausente.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="FonteType">
+    <xs:annotation>
+      <xs:documentation>
+        Referência a um raw IA item. ia-id segue o padrão
+        leizilla-raw-{ente}-{fonte}-{chave} (SCHEMA.md §5.1).
+        Pattern não enforçado em v0.1 — será adicionado em v0.2.
+      </xs:documentation>
+    </xs:annotation>
     <xs:attribute name="ia-id" type="xs:string" use="required"/>
   </xs:complexType>
 
@@ -193,10 +248,15 @@
         - Normativos: &lt;texto&gt; obrigatório.
         - Organizacionais: &lt;texto&gt; ausente; &lt;rotulo_versao&gt; opcional
           carrega o rótulo da época (útil quando capítulo é renomeado).
+          Ausente quando rótulo não mudou — consumer aplica
+          COALESCE(rotulo_versao, rotulo) conforme SCHEMA.md §3.2.
 
         XSD não consegue expressar a regra "texto presente iff dispositivo
         é normativo" via cardinalidade pura — validação semântica fica
         no consistency checker (M0.2).
+
+        Dispositivos criados por lei posterior têm primeira versão com
+        vigente-de = data da lei criadora + alterado-por = URN da lei criadora.
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
@@ -230,6 +290,14 @@
 
   <!-- Dispositivo recursivo. ComplexType nomeado para auto-referência. -->
   <xs:complexType name="DispositivoType">
+    <xs:annotation>
+      <xs:documentation>
+        Paths de incisos usam Arabic ordinal em path (inc-1, inc-2) com
+        numeral romano em &lt;rotulo&gt; (I, II, III). Mesma convenção para
+        alíneas: path ali-1, ali-2; rotulo a, b, c. Decisão: ordenação
+        SQL/ASCII consistente; romano apenas na apresentação.
+      </xs:documentation>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="rotulo" type="xs:string" minOccurs="0"/>
       <xs:element name="versoes" type="VersoesType" minOccurs="1"/>
@@ -237,8 +305,12 @@
                   minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="tipo" type="TipoDispositivo" use="required"/>
-    <xs:attribute name="path" type="DispositivoPath" use="required"/>
-    <xs:attribute name="parent" type="DispositivoPath" use="required">
+    <xs:attribute name="path" type="DispositivoPath" use="required">
+      <xs:annotation>
+        <xs:documentation>Sempre não-vazio. Ver DispositivoPath.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="parent" type="ParentPath" use="required">
       <xs:annotation>
         <xs:documentation>
           Obrigatório em todo dispositivo. Raiz: parent="" (string vazia).
@@ -305,6 +377,12 @@
   </xs:complexType>
 
   <xs:complexType name="ParseType">
+    <xs:annotation>
+      <xs:documentation>
+        Registra o parse mais recente. Histórico completo de reprocessamentos
+        (e.g. Haiku → Opus) vive em provenance.json sidecar, não neste elemento.
+      </xs:documentation>
+    </xs:annotation>
     <xs:attribute name="method" type="ParseMethod" use="required"/>
     <xs:attribute name="model" type="xs:string" use="optional"/>
     <xs:attribute name="confianca" use="optional">
@@ -347,9 +425,11 @@
       <xs:attribute name="urn-lex" type="UrnLex" use="optional">
         <xs:annotation>
           <xs:documentation>
-            URN LEX da lei. Opcional porque data_publicacao pode ser
-            desconhecida em fallback. Quando presente, dispositivos
-            herdam via concatenação `{urn-lex}!{path}`.
+            URN LEX da lei. Opcional — ausente quando data_publicacao
+            é desconhecida (fallback) ou norma não tem número (e.g.
+            Constituição Federal pode usar urn:lex:br;federal;constituicao:1988-10-05
+            sem segmento de número). Quando presente, dispositivos herdam
+            via concatenação `{urn-lex}!{path}`.
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>

--- a/tests/fixtures/leizilla_xml/README.md
+++ b/tests/fixtures/leizilla_xml/README.md
@@ -1,0 +1,39 @@
+# Fixtures Leizilla XML v0.1
+
+Casos de teste representativos do schema definido em
+`docs/schemas/leizilla-v0.1.xsd`. Cada fixture cobre um cenário distinto
+e é validada via `tests/test_lexml_export.py` (M0.2).
+
+## Fixtures
+
+| Arquivo | Cenário | Cobertura |
+|---|---|---|
+| `simple.xml` | Lei curta sem alterações, sem blocos organizacionais. | Caso mais comum: lei estadual pequena com poucos artigos. Valida o caminho feliz. |
+| `with-alterations.xml` | Lei com timeline de versões: artigo alterado por lei posterior. | Valida `<versao numero=N>` com `vigente-de`/`vigente-ate` e `alterado-por`. |
+| `with-blocos-organizacionais.xml` | Lei estruturada com livro/título/capítulo/seção. | Valida path organizacional namespaceado e nesting de blocos com dispositivos normativos. |
+| `with-bloco-livre.xml` | Fallback de OCR ruim: `<bloco-livre quality="raw">`. | Valida o caminho de fallback quando LLM não consegue estruturar. |
+
+## Como validar localmente
+
+```bash
+xmllint --schema docs/schemas/leizilla-v0.1.xsd \
+        tests/fixtures/leizilla_xml/simple.xml \
+        --noout
+```
+
+Ou via pytest (M0.2):
+```bash
+uv run pytest tests/test_lexml_export.py -v
+```
+
+## Convenções nas fixtures
+
+- URN LEX em forma completa: `urn:lex:br;estado:rondonia;lei:YYYY-MM-DD;NNNNN`
+  (dialect provisório — ver `docs/SCHEMA.md` §5.5 / §10).
+- Datas históricas plausíveis (Rondônia: leis pós-1981 quando o estado foi
+  criado).
+- `<fonte ia-id="...">` referencia IA identifiers no padrão
+  `leizilla-raw-{ente}-{fonte}-{chave}` (não-existentes em IA real; são
+  exemplos sintéticos).
+- Conteúdo textual é fictício (LEI Nº 9.999/XXXX) para evitar confusão
+  com leis reais existentes.

--- a/tests/fixtures/leizilla_xml/simple.xml
+++ b/tests/fixtures/leizilla_xml/simple.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
+<!--
+  Fixture: lei curta sem alterações, sem blocos organizacionais.
+
+  Cobre:
+  - dispositivos top-level: titulo-lei, ementa, preambulo, artigo.
+  - artigo com paragrafo aninhado (caput implícito).
+  - todos os atributos obrigatórios: parent, path, tipo, schema-version.
+  - URN LEX no formato canônico (dialect provisório).
+  - <versao> única por dispositivo (sem alterações).
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:1999-06-15;9999">
+
+  <header>
+    <ente>ro</ente>
+    <tipo>lei</tipo>
+    <numero>9999</numero>
+    <ano>1999</ano>
+    <data-publicacao>1999-06-15</data-publicacao>
+    <vigente-em>2026-05-20</vigente-em>
+    <revogada>false</revogada>
+  </header>
+
+  <dispositivos>
+
+    <dispositivo tipo="titulo-lei" path="titulo-lei" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:1999-06-15;9999!titulo-lei">
+      <rotulo>Título</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1999-06-15">
+          <texto>LEI Nº 9.999, DE 15 DE JUNHO DE 1999</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+    <dispositivo tipo="ementa" path="ementa" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:1999-06-15;9999!ementa">
+      <rotulo>Ementa</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1999-06-15">
+          <texto>Institui o Dia Estadual do Servidor Público de Rondônia.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+    <dispositivo tipo="preambulo" path="preambulo" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:1999-06-15;9999!preambulo">
+      <rotulo>Preâmbulo</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1999-06-15">
+          <texto>O GOVERNADOR DO ESTADO DE RONDÔNIA faço saber que a Assembleia Legislativa decreta e eu sanciono a seguinte Lei:</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+    <dispositivo tipo="artigo" path="art-1" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:1999-06-15;9999!art-1">
+      <rotulo>Art. 1º</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1999-06-15">
+          <texto>Fica instituído o Dia Estadual do Servidor Público de Rondônia, a ser comemorado anualmente no dia 28 de outubro.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+    <dispositivo tipo="artigo" path="art-2" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:1999-06-15;9999!art-2">
+      <rotulo>Art. 2º</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1999-06-15">
+          <texto>O Poder Executivo poderá promover atividades alusivas à data, sem prejuízo do expediente normal das repartições públicas.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+        </versao>
+      </versoes>
+      <dispositivo tipo="paragrafo" path="art-2-par-unico" parent="art-2"
+                   urn="urn:lex:br;estado:rondonia;lei:1999-06-15;9999!art-2!par-unico">
+        <rotulo>Parágrafo único</rotulo>
+        <versoes>
+          <versao numero="1" vigente-de="1999-06-15">
+            <texto>As atividades de que trata o caput observarão o calendário oficial do Estado.</texto>
+            <fonte-canonica>casacivil</fonte-canonica>
+            <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+          </versao>
+        </versoes>
+      </dispositivo>
+    </dispositivo>
+
+    <dispositivo tipo="artigo" path="art-3" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:1999-06-15;9999!art-3">
+      <rotulo>Art. 3º</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1999-06-15">
+          <texto>Esta Lei entra em vigor na data de sua publicação.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+  </dispositivos>
+
+  <anotacoes>
+    <parse method="llm-haiku"
+           model="claude-haiku-4-5-20251001"
+           confianca="0.95"
+           timestamp="2026-05-20T18:45:00Z"/>
+  </anotacoes>
+
+</lei>

--- a/tests/fixtures/leizilla_xml/with-alterations.xml
+++ b/tests/fixtures/leizilla_xml/with-alterations.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
+<!--
+  Fixture: lei com timeline de alterações.
+
+  Cobre:
+  - Múltiplas <versao> no mesmo dispositivo, com vigente-de/vigente-ate.
+  - alterado-por apontando para URN de outra lei.
+  - rotulo_versao (override quando rótulo mudou entre versões).
+  - Cross-source reconciliation com <fonte> múltipla.
+  - Anotações com <divergencia>.
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:2003-06-15;1234">
+
+  <header>
+    <ente>ro</ente>
+    <tipo>lei</tipo>
+    <numero>1234</numero>
+    <ano>2003</ano>
+    <data-publicacao>2003-06-15</data-publicacao>
+    <vigente-em>2026-05-20</vigente-em>
+    <revogada>false</revogada>
+  </header>
+
+  <dispositivos>
+
+    <dispositivo tipo="ementa" path="ementa" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!ementa">
+      <rotulo>Ementa</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="2003-06-15">
+          <texto>Dispõe sobre a organização administrativa do Estado de Rondônia.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+    <!-- Artigo com TRÊS versões: original, alterado em 2018, alterado em 2024. -->
+    <dispositivo tipo="artigo" path="art-3" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-3">
+      <rotulo>Art. 3º</rotulo>
+      <versoes>
+        <versao numero="1"
+                vigente-de="2003-06-15"
+                vigente-ate="2018-04-10"
+                alterado-por="urn:lex:br;estado:rondonia;lei:2018-04-10;4321">
+          <texto>O Estado adotará política administrativa orientada pela eficiência e moralidade pública.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+          <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
+        </versao>
+        <versao numero="2"
+                vigente-de="2018-04-10"
+                vigente-ate="2024-07-30"
+                alterado-por="urn:lex:br;estado:rondonia;lei:2024-07-30;5678">
+          <texto>O Estado adotará política administrativa orientada pela eficiência, moralidade e transparência pública.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
+        </versao>
+        <versao numero="3"
+                vigente-de="2024-07-30">
+          <texto>O Estado adotará política administrativa orientada pela eficiência, moralidade, transparência e governança digital.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-05678"/>
+        </versao>
+      </versoes>
+
+      <!-- §1º só foi adicionado em 2018 (nova versão da lei). Versão 1 não existe. -->
+      <dispositivo tipo="paragrafo" path="art-3-par-1" parent="art-3"
+                   urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-3!par-1">
+        <rotulo>§ 1º</rotulo>
+        <versoes>
+          <versao numero="1"
+                  vigente-de="2018-04-10"
+                  alterado-por="urn:lex:br;estado:rondonia;lei:2018-04-10;4321">
+            <texto>A transparência será assegurada por meio de portal eletrônico atualizado mensalmente.</texto>
+            <fonte-canonica>casacivil</fonte-canonica>
+            <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
+          </versao>
+        </versoes>
+      </dispositivo>
+    </dispositivo>
+
+    <!-- Artigo com divergência entre fontes na versão 1. -->
+    <dispositivo tipo="artigo" path="art-5" parent=""
+                 urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-5">
+      <rotulo>Art. 5º</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="2003-06-15">
+          <texto>Os órgãos da administração direta funcionarão de acordo com regulamento próprio.</texto>
+          <fonte-canonica>casacivil</fonte-canonica>
+          <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+          <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
+          <fonte ia-id="leizilla-raw-ro-assembleia-coddoc-01234"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+  </dispositivos>
+
+  <anotacoes>
+    <divergencia dispositivo-path="art-5"
+                 versao-numero="1"
+                 entre="casacivil,assembleia"
+                 diff-xpath="/lei/dispositivos/dispositivo[@path='art-5']/versoes/versao[@numero='1']/texto">
+      Assembleia tem "regimento" em vez de "regulamento"; consolidado casacivil adotado conforme retificação posterior. Verificar.
+    </divergencia>
+    <parse method="llm-haiku"
+           model="claude-haiku-4-5-20251001"
+           confianca="0.88"
+           timestamp="2026-05-20T18:45:00Z"/>
+  </anotacoes>
+
+</lei>

--- a/tests/fixtures/leizilla_xml/with-bloco-livre.xml
+++ b/tests/fixtures/leizilla_xml/with-bloco-livre.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
+<!--
+  Fixture: fallback OCR ruim — <bloco-livre>.
+
+  Cobre:
+  - Caminho de fallback quando LLM não consegue estruturar dispositivos.
+  - quality="raw" (pior caso: OCR tão ruim que nem dá pra estimar qualidade).
+  - Header normal mas <dispositivos> contém <bloco-livre> em vez de <dispositivo>.
+  - Anotações documentam que parse falhou estruturadamente.
+  - URN da lei pode ainda existir se data_publicacao for extraível do PDF
+    cabeçalho mesmo com OCR ruim do corpo.
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:1985-11-20;0042">
+
+  <header>
+    <ente>ro</ente>
+    <tipo>lei</tipo>
+    <numero>42</numero>
+    <ano>1985</ano>
+    <data-publicacao>1985-11-20</data-publicacao>
+    <vigente-em>2026-05-20</vigente-em>
+    <revogada>false</revogada>
+  </header>
+
+  <dispositivos>
+    <bloco-livre quality="raw">
+      <p>LE| N° 42/8S - 20 DE NOVEMBRO DE 19BS</p>
+      <p>O G0VERNAD0R D0 ESTAD0 DE R0NDONIA, faç0 saber que a Assembleia Legislativa decret@ e eu sancion0 a seguinte Lei:</p>
+      <p>Art. 1° Fica criad0 0 Conselh0 Estadual de Cultura, vincu|ado à Secretaria d3 Educação e Cultura, c0m as seguintes atribuiçõe5:</p>
+      <p>I- pr0m0ver e incentivar 0 desenv0|vimento cu|tura| n0 Estad0;</p>
+      <p>I| - rea|izar 5tudos e pesquisas s0bre questões cu|turais re|evantes;</p>
+      <p>[trecho i|egível n0 OCR]</p>
+      <p>Art. 4° Esta Lei entra em vigor na data de 5ua publicação.</p>
+      <p>PA|ÁCIO D0 GOVERN0 - P0rto Vel|0/R0, 20 de n0vembr0 de 1985.</p>
+    </bloco-livre>
+  </dispositivos>
+
+  <anotacoes>
+    <parse method="llm-haiku"
+           model="claude-haiku-4-5-20251001"
+           confianca="0.12"
+           timestamp="2026-05-20T18:45:00Z"/>
+  </anotacoes>
+
+</lei>

--- a/tests/fixtures/leizilla_xml/with-bloco-livre.xml
+++ b/tests/fixtures/leizilla_xml/with-bloco-livre.xml
@@ -13,7 +13,7 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:1985-11-20;0042">
+     urn-lex="urn:lex:br;estado:rondonia;lei:1985-11-20;42">
 
   <header>
     <ente>ro</ente>

--- a/tests/fixtures/leizilla_xml/with-blocos-organizacionais.xml
+++ b/tests/fixtures/leizilla_xml/with-blocos-organizacionais.xml
@@ -4,21 +4,26 @@
   Fixture: lei estruturada com blocos organizacionais (livro/título/capítulo/seção).
 
   Cobre:
-  - Hierarquia nested: livro > titulo > capitulo > secao > artigo > parágrafo.
-  - Path organizacional namespaceado: liv-1, liv-1-tit-1, liv-1-tit-1-cap-1, etc.
+  - Hierarquia nested: titulo > capitulo > artigo > inciso/paragrafo.
+  - Path organizacional namespaceado: tit-1, tit-1-cap-1, etc.
   - Path normativo permanece global: art-1 (não tit-1-cap-1-art-1).
-  - Bloco com <versao> carregando só <rotulo_versao> (sem <texto>).
-  - parent declarando o nesting (paragrafo aponta para artigo, artigo aponta
-    para o capítulo, e assim por diante).
+  - Bloco com <versao> carregando só <rotulo_versao> APENAS quando difere
+    de <rotulo> (override real). Quando idêntico, omite-se e consumer
+    aplica COALESCE(rotulo_versao, rotulo) — SCHEMA.md §3.2.
+  - parent declarando o nesting (paragrafo aponta para artigo, artigo
+    aponta para o capítulo, e assim por diante).
+  - Constituição Federal sem <numero> — usa urn-lex sem segmento de
+    número: urn:lex:br;federal;constituicao:1988-10-05. Header omite
+    <numero> (xs:string vazio não permitido; minOccurs=0 cobre o caso).
+  - Path de inciso usa numeral arábico (inc-1) com romano em rotulo (I).
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;federal;constituicao:1988-10-05;0">
+     urn-lex="urn:lex:br;federal;constituicao:1988-10-05">
 
   <header>
     <ente>federal</ente>
     <tipo>constituicao</tipo>
-    <numero>0</numero>
     <ano>1988</ano>
     <data-publicacao>1988-10-05</data-publicacao>
     <vigente-em>2026-05-20</vigente-em>
@@ -49,21 +54,21 @@
       </versoes>
     </dispositivo>
 
-    <!-- Bloco organizacional: TÍTULO I (sem texto, só rotulo) -->
+    <!-- Bloco organizacional: TÍTULO I (sem texto, sem rotulo_versao — rótulo nunca mudou) -->
     <dispositivo tipo="titulo" path="tit-1" parent="">
       <rotulo>TÍTULO I — DOS PRINCÍPIOS FUNDAMENTAIS</rotulo>
       <versoes>
         <versao numero="1" vigente-de="1988-10-05">
-          <rotulo_versao>TÍTULO I — DOS PRINCÍPIOS FUNDAMENTAIS</rotulo_versao>
           <fonte-canonica>planalto</fonte-canonica>
           <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
         </versao>
       </versoes>
 
       <!-- Artigo normativo dentro do bloco. Path GLOBAL (art-1, não tit-1-art-1).
-           parent="tit-1" declara o nesting organizacional. -->
+           parent="tit-1" declara o nesting organizacional.
+           URN sem segmento de número (constituição): ...;1988-10-05!art-1 -->
       <dispositivo tipo="artigo" path="art-1" parent="tit-1"
-                   urn="urn:lex:br;federal;constituicao:1988-10-05;0!art-1">
+                   urn="urn:lex:br;federal;constituicao:1988-10-05!art-1">
         <rotulo>Art. 1º</rotulo>
         <versoes>
           <versao numero="1" vigente-de="1988-10-05">
@@ -74,7 +79,7 @@
         </versoes>
 
         <dispositivo tipo="inciso" path="art-1-inc-1" parent="art-1"
-                     urn="urn:lex:br;federal;constituicao:1988-10-05;0!art-1!inc-1">
+                     urn="urn:lex:br;federal;constituicao:1988-10-05!art-1!inc-1">
           <rotulo>I</rotulo>
           <versoes>
             <versao numero="1" vigente-de="1988-10-05">
@@ -86,7 +91,7 @@
         </dispositivo>
 
         <dispositivo tipo="paragrafo" path="art-1-par-unico" parent="art-1"
-                     urn="urn:lex:br;federal;constituicao:1988-10-05;0!art-1!par-unico">
+                     urn="urn:lex:br;federal;constituicao:1988-10-05!art-1!par-unico">
           <rotulo>Parágrafo único</rotulo>
           <versoes>
             <versao numero="1" vigente-de="1988-10-05">
@@ -99,22 +104,25 @@
       </dispositivo>
     </dispositivo>
 
-    <!-- Bloco organizacional aninhado: TÍTULO II > CAPÍTULO I > SEÇÃO I -->
+    <!-- Bloco organizacional aninhado: TÍTULO II > CAPÍTULO I.
+         rotulo_versao redundante removido (era idêntico ao rotulo). -->
     <dispositivo tipo="titulo" path="tit-2" parent="">
       <rotulo>TÍTULO II — DOS DIREITOS E GARANTIAS FUNDAMENTAIS</rotulo>
       <versoes>
         <versao numero="1" vigente-de="1988-10-05">
-          <rotulo_versao>TÍTULO II — DOS DIREITOS E GARANTIAS FUNDAMENTAIS</rotulo_versao>
           <fonte-canonica>planalto</fonte-canonica>
           <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
         </versao>
       </versoes>
 
+      <!-- DIVERGENT rotulo_versao: rótulo "vivo" expandido relativo à versão de 1988.
+           Demonstra o override real — bloco organizacional pode ser renomeado
+           (ou redenominado pelo consolidador) entre versões. -->
       <dispositivo tipo="capitulo" path="tit-2-cap-1" parent="tit-2">
         <rotulo>CAPÍTULO I — DOS DIREITOS E DEVERES INDIVIDUAIS E COLETIVOS</rotulo>
         <versoes>
           <versao numero="1" vigente-de="1988-10-05">
-            <rotulo_versao>CAPÍTULO I — DOS DIREITOS E DEVERES INDIVIDUAIS E COLETIVOS</rotulo_versao>
+            <rotulo_versao>CAPÍTULO I — DOS DIREITOS INDIVIDUAIS E COLETIVOS</rotulo_versao>
             <fonte-canonica>planalto</fonte-canonica>
             <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
           </versao>
@@ -122,7 +130,7 @@
 
         <!-- art-5 mora dentro de tit-2-cap-1, mas path permanece global -->
         <dispositivo tipo="artigo" path="art-5" parent="tit-2-cap-1"
-                     urn="urn:lex:br;federal;constituicao:1988-10-05;0!art-5">
+                     urn="urn:lex:br;federal;constituicao:1988-10-05!art-5">
           <rotulo>Art. 5º</rotulo>
           <versoes>
             <versao numero="1" vigente-de="1988-10-05">

--- a/tests/fixtures/leizilla_xml/with-blocos-organizacionais.xml
+++ b/tests/fixtures/leizilla_xml/with-blocos-organizacionais.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
+<!--
+  Fixture: lei estruturada com blocos organizacionais (livro/título/capítulo/seção).
+
+  Cobre:
+  - Hierarquia nested: livro > titulo > capitulo > secao > artigo > parágrafo.
+  - Path organizacional namespaceado: liv-1, liv-1-tit-1, liv-1-tit-1-cap-1, etc.
+  - Path normativo permanece global: art-1 (não tit-1-cap-1-art-1).
+  - Bloco com <versao> carregando só <rotulo_versao> (sem <texto>).
+  - parent declarando o nesting (paragrafo aponta para artigo, artigo aponta
+    para o capítulo, e assim por diante).
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;federal;constituicao:1988-10-05;0">
+
+  <header>
+    <ente>federal</ente>
+    <tipo>constituicao</tipo>
+    <numero>0</numero>
+    <ano>1988</ano>
+    <data-publicacao>1988-10-05</data-publicacao>
+    <vigente-em>2026-05-20</vigente-em>
+    <revogada>false</revogada>
+  </header>
+
+  <dispositivos>
+
+    <dispositivo tipo="titulo-lei" path="titulo-lei" parent="">
+      <rotulo>Título</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1988-10-05">
+          <texto>CONSTITUIÇÃO DA REPÚBLICA FEDERATIVA DO BRASIL DE 1988</texto>
+          <fonte-canonica>planalto</fonte-canonica>
+          <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+    <dispositivo tipo="preambulo" path="preambulo" parent="">
+      <rotulo>Preâmbulo</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1988-10-05">
+          <texto>Nós, representantes do povo brasileiro, reunidos em Assembléia Nacional Constituinte para instituir um Estado Democrático...</texto>
+          <fonte-canonica>planalto</fonte-canonica>
+          <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+    <!-- Bloco organizacional: TÍTULO I (sem texto, só rotulo) -->
+    <dispositivo tipo="titulo" path="tit-1" parent="">
+      <rotulo>TÍTULO I — DOS PRINCÍPIOS FUNDAMENTAIS</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1988-10-05">
+          <rotulo_versao>TÍTULO I — DOS PRINCÍPIOS FUNDAMENTAIS</rotulo_versao>
+          <fonte-canonica>planalto</fonte-canonica>
+          <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+        </versao>
+      </versoes>
+
+      <!-- Artigo normativo dentro do bloco. Path GLOBAL (art-1, não tit-1-art-1).
+           parent="tit-1" declara o nesting organizacional. -->
+      <dispositivo tipo="artigo" path="art-1" parent="tit-1"
+                   urn="urn:lex:br;federal;constituicao:1988-10-05;0!art-1">
+        <rotulo>Art. 1º</rotulo>
+        <versoes>
+          <versao numero="1" vigente-de="1988-10-05">
+            <texto>A República Federativa do Brasil, formada pela união indissolúvel dos Estados e Municípios e do Distrito Federal, constitui-se em Estado Democrático de Direito e tem como fundamentos:</texto>
+            <fonte-canonica>planalto</fonte-canonica>
+            <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+          </versao>
+        </versoes>
+
+        <dispositivo tipo="inciso" path="art-1-inc-1" parent="art-1"
+                     urn="urn:lex:br;federal;constituicao:1988-10-05;0!art-1!inc-1">
+          <rotulo>I</rotulo>
+          <versoes>
+            <versao numero="1" vigente-de="1988-10-05">
+              <texto>a soberania;</texto>
+              <fonte-canonica>planalto</fonte-canonica>
+              <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+            </versao>
+          </versoes>
+        </dispositivo>
+
+        <dispositivo tipo="paragrafo" path="art-1-par-unico" parent="art-1"
+                     urn="urn:lex:br;federal;constituicao:1988-10-05;0!art-1!par-unico">
+          <rotulo>Parágrafo único</rotulo>
+          <versoes>
+            <versao numero="1" vigente-de="1988-10-05">
+              <texto>Todo o poder emana do povo, que o exerce por meio de representantes eleitos ou diretamente, nos termos desta Constituição.</texto>
+              <fonte-canonica>planalto</fonte-canonica>
+              <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+            </versao>
+          </versoes>
+        </dispositivo>
+      </dispositivo>
+    </dispositivo>
+
+    <!-- Bloco organizacional aninhado: TÍTULO II > CAPÍTULO I > SEÇÃO I -->
+    <dispositivo tipo="titulo" path="tit-2" parent="">
+      <rotulo>TÍTULO II — DOS DIREITOS E GARANTIAS FUNDAMENTAIS</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1988-10-05">
+          <rotulo_versao>TÍTULO II — DOS DIREITOS E GARANTIAS FUNDAMENTAIS</rotulo_versao>
+          <fonte-canonica>planalto</fonte-canonica>
+          <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+        </versao>
+      </versoes>
+
+      <dispositivo tipo="capitulo" path="tit-2-cap-1" parent="tit-2">
+        <rotulo>CAPÍTULO I — DOS DIREITOS E DEVERES INDIVIDUAIS E COLETIVOS</rotulo>
+        <versoes>
+          <versao numero="1" vigente-de="1988-10-05">
+            <rotulo_versao>CAPÍTULO I — DOS DIREITOS E DEVERES INDIVIDUAIS E COLETIVOS</rotulo_versao>
+            <fonte-canonica>planalto</fonte-canonica>
+            <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+          </versao>
+        </versoes>
+
+        <!-- art-5 mora dentro de tit-2-cap-1, mas path permanece global -->
+        <dispositivo tipo="artigo" path="art-5" parent="tit-2-cap-1"
+                     urn="urn:lex:br;federal;constituicao:1988-10-05;0!art-5">
+          <rotulo>Art. 5º</rotulo>
+          <versoes>
+            <versao numero="1" vigente-de="1988-10-05">
+              <texto>Todos são iguais perante a lei, sem distinção de qualquer natureza, garantindo-se aos brasileiros e aos estrangeiros residentes no País a inviolabilidade do direito à vida, à liberdade, à igualdade, à segurança e à propriedade, nos termos seguintes:</texto>
+              <fonte-canonica>planalto</fonte-canonica>
+              <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+            </versao>
+          </versoes>
+        </dispositivo>
+      </dispositivo>
+    </dispositivo>
+
+    <!-- Anexo demonstrando que anexo é dispositivo normativo (com texto). -->
+    <dispositivo tipo="anexo" path="anexo-1" parent="">
+      <rotulo>ANEXO I — Bandeira Nacional</rotulo>
+      <versoes>
+        <versao numero="1" vigente-de="1988-10-05">
+          <texto>Descrição da Bandeira Nacional conforme Lei nº 5.700/1971...</texto>
+          <fonte-canonica>planalto</fonte-canonica>
+          <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+        </versao>
+      </versoes>
+    </dispositivo>
+
+  </dispositivos>
+
+  <anotacoes>
+    <parse method="llm-opus"
+           model="claude-opus-4-7"
+           confianca="0.97"
+           timestamp="2026-05-20T18:45:00Z"/>
+  </anotacoes>
+
+</lei>


### PR DESCRIPTION
## Summary

Opens **M0.2** — formal XSD + fixtures + LexML export + consistency checker. Builds on M0.1 (`#6`, merged).

This first commit lands:
- **`docs/schemas/leizilla-v0.1.xsd`** — formal XSD consolidating SCHEMA.md §4 (dispositivo universal, recursive nesting, parent obligatório, caput implícito, versoes ≥1, bloco-livre fallback, anotações).
- **`tests/fixtures/leizilla_xml/simple.xml`** — first of 4 fixtures: minimal lei without alterations or organizational blocks. Validates clean against XSD (`xmllint --schema ... --noout` returns "validates").
- **`tests/fixtures/leizilla_xml/README.md`** — documents the 4-fixture test matrix.

## What's coming in follow-up commits on this PR

- `with-alterations.xml` — lei with `<versao numero=N>` timeline + `alterado-por`.
- `with-blocos-organizacionais.xml` — livro/título/capítulo/seção nesting; validates path organizacional namespaceado.
- `with-bloco-livre.xml` — fallback for OCR-ruim, `quality="raw"`.
- `scripts/leizilla-to-lexml.xsl` — XSLT export.
- `tests/test_lexml_export.py` — CI test running XSLT against fixtures, validating output against bundled `tests/fixtures/lexml.xsd`.
- `scripts/check_schema_consistency.py` — catches XSD-uninexpressible invariants (e.g. "texto presente iff dispositivo é normativo"; "parent attribute points to existing path in document"; "schema_version no XML matches XSD version"; identifier examples in markdown match regex in §5).
- Resolution of 6 remaining `docs/SCHEMA.md` §10 pendentes (URN dialect contra CGPID, ZSTD×SNAPPY benchmark, granularidade bundle ZIP, XPath dialect, robots.txt principle, XSLT in-browser status).

## Architectural decisions (carried from M0.1)

- Single-table Parquet `versoes` with concrete revert triggers
- Dispositivo universal: 17 tipos (11 normativos + 6 organizacionais)
- Caput como índice 0 implícito
- Wayback Machine como caminho primário de fetch
- URN LEX dialect provisório (CGPID verification pending in §10)

## Test plan

- [ ] Reviewer confirms XSD encodes all 5 mandatory regras of §4.3 (parent obrigatório, versoes ≥1, path normativo global, path organizacional namespaceado, caput implícito).
- [ ] Reviewer flags any XSD types that are too permissive or too restrictive.
- [ ] `xmllint --schema docs/schemas/leizilla-v0.1.xsd tests/fixtures/leizilla_xml/simple.xml --noout` passes.
- [ ] Follow-up commits land the 3 remaining fixtures, XSLT, tests, consistency checker.

Once M0.2 closes, M1 opens (package restructure + ADRs + `origem`→`ente` migration).

---
_Generated by [Claude Code](https://claude.ai/code/session_0142QrK5n2k4bAzS7F5Vb8RR)_