### PR TITLE
docs(M0.2): redesign first-principles — dispositivo é a unidade

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -279,9 +279,9 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 - [x] `docs/schemas/leizilla-v0.1.xsd` enxuto (~235 linhas; 6 elementos).
 - [x] 6 fixtures cobrindo: caso simples (herança pura), alterações + divergência multi-fonte + vacatio, blocos organizacionais (CF/88), revogações parciais (4 tipos), revogação total da lei, OCR ruim.
 - [x] `tests/fixtures/leizilla_xml/README.md` com matriz de cobertura.
+- [ ] **🔴 Bloqueante para fechar M0.2**: `scripts/check_schema_consistency.py` validando as 14 invariantes do SCHEMA.md §7. XSD é propositalmente loose (permite `<fonte diverge="false"><texto>x</texto></fonte>`, `quality` em qualquer dispositivo, etc.); sem o checker em CI o "schema" é metade do contrato.
 - [ ] `scripts/leizilla-to-lexml.xsl` + teste CI `tests/test_lexml_export.py` validando contra `tests/fixtures/lexml.xsd` (bundle no repo).
-- [ ] `scripts/check_schema_consistency.py` validando as 12 invariantes do SCHEMA.md §7 (incluindo: `<fonte diverge>` requer `<texto>`, revogação total exclui parciais, herança de vigência consistente, ordenação de versões, token map cobre todos os paths).
-- [ ] Negative test cases (XML inválido proposital → validator deve rejeitar).
+- [ ] Negative test cases (XML inválido proposital → checker deve rejeitar).
 - [ ] Resolver pendentes §8.2: URN dialect contra CGPID spec, compressão Parquet (SNAPPY vs ZSTD em DuckDB-WASM), granularidade bundle ZIP, política de re-scrape, robots.txt rate-limit, custo LLM real.
 
 **M0.3 — Inspirações concretas** (paralelo a M0.2):

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -8,8 +8,9 @@
 
 | Milestone | Status | PR | Notas |
 |---|---|---|---|
-| **M0.1** — Documento vivo + SCHEMA.md design | 🟢 done | #6 | Aprovado em re-review; pronto para merge. |
-| **M0.2** — XSD + fixtures + lexml-export script | ⚪ todo | — | Próximo. Inclui `leizilla-v0.1.xsd`, 3 fixtures Leizilla XML, `scripts/leizilla-to-lexml.xsl`, teste CI de export, consistency-checker script, e resolução de 6 pendentes §10. |
+| **M0.1** — Documento vivo + SCHEMA.md design | 🟢 done | #6 | Aprovado em re-review; merged em main. |
+| **M0.2a** — Schema v1 (tentativa) | 🔴 superseded | #7 | XSD `header` + `rotulo` + `<bloco-livre>` + etc. Substituído pelo redesign first-principles. Fica como referência histórica. |
+| **M0.2b** — Redesign first-principles | 🟡 in-progress | TBD | Pivô: dispositivo é unidade, vigência herda, fonte é única tag, `<revogacao>` evento estruturado. SCHEMA.md reescrito + XSD enxuto (~235 linhas) + 6 fixtures cobrindo todos os cenários. Pendente: consistency checker, leizilla-to-lexml.xsl, test_lexml_export.py, resolver 6 pendentes §10. |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
@@ -70,6 +71,20 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-20 — Redesign first-principles do Leizilla XML (supersede #7)
+
+Auditoria a partir do princípio "dispositivo é a unidade básica" revelou que o XSD do PR #7 carregava ~10 conceitos derivados ou redundantes. Reescrita do zero. Diff radical:
+
+- **Cai do XML**: `<header>` (URN cobre tudo), `<rotulo>` e `<rotulo_versao>` (derivados de `(tipo, path)` via token map), atributo `tipo` no dispositivo (deriva do `path`), atributo `parent` (nesting XML é o parent), atributo `urn` no dispositivo (deriva de `lei.urn-lex + "!" + path`), `<versoes>` wrapper (`<versao>` filha direta), `<versao numero="N">` (`em` é chave natural), `<fonte-canonica>` separado (não existe "fonte canônica" — existe texto canônico no `<texto>` da versão + fontes que corroboram ou divergem), `<anotacoes>` no XML (processo de parse vai para `parsed_meta.json` sidecar), `<bloco-livre>` elemento separado (OCR ruim vira `<dispositivo path="ocr-ruim" quality="raw">`).
+
+- **Entra no XML**: herança de vigência implícita (`vigente-ate` é inferido, não armazenado; `em` herda do ancestral ou da `data-publicacao` da URN); `<inicio tipo="...">` com `<fonte>` filha quando proveniência da vigência é não-óbvia (vacatio, consolidacao, inferencia-llm, decisao-judicial); `<revogacao em em por? tipo>` rica como evento estruturado em vez de flag, com 5 tipos jurídicos (`expressa`, `tacita`, `caducidade`, `inconstitucionalidade`, `nao-recepcao`) e posição estrutural indicando escopo (raiz da `<lei>` = total; dentro de dispositivo = parcial); `<fonte>` como tag unificada em 4 contextos (versão, início, revogação na lei, revogação em dispositivo).
+
+- **Auditoria por embeddings substitui flag manual**: LLM não sabe quando errou. Comparação `embedding(raw_djvu)` × `embedding(texto parseado)` por dispositivo detecta drift automaticamente. Sem `revisao-pendente` no XML. Plano detalhado em arquivo separado (M3+).
+
+Resultado: XSD de ~235 linhas (vs. 359 do PR #7); 6 elementos (`<lei>`, `<dispositivo>`, `<versao>`, `<inicio>`, `<texto>`, `<fonte>`, `<revogacao>`); caso comum (lei pequena sem alterações) vira fixture de ~50 linhas com zero `em`/`vigente-ate`/`vigente-de`. Tabela de migração completa em `docs/SCHEMA.md` §9.
+
+PR #7 marcado como superseded.
 
 ### 2026-05-20 — Rewrite arquitetural pós-review #6 (3 blockers)
 
@@ -255,15 +270,19 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 ## Próximos passos imediatos
 
-**M0.1 — fechado** ✅ (PR #6 aprovado em re-review). Merge em sequência.
+**M0.1 — fechado** ✅ (PR #6 merged).
 
-**M0.2 — XSD + fixtures + export** (próximo PR):
-- [ ] Rascunhar `docs/schemas/leizilla-v0.1.xsd` consolidando todas decisões §4 do SCHEMA.md (dispositivo universal, caput implícito, parent obrigatório, path global/namespaceado, versoes ≥1).
-- [ ] Fixtures em `tests/fixtures/leizilla_xml/` (mínimo 3): (a) lei simples sem alterações, (b) lei com timeline de alterações e `<rotulo_versao>`, (c) lei com `<bloco-livre quality="raw">` (fallback OCR ruim).
+**M0.2a — superseded** 🔴 (PR #7). Design v1 do XSD foi abandonado após auditoria first-principles. Fica como referência histórica.
+
+**M0.2b — Redesign first-principles** (PR em curso):
+- [x] `docs/SCHEMA.md` reescrito do zero (princípio "dispositivo é a unidade").
+- [x] `docs/schemas/leizilla-v0.1.xsd` enxuto (~235 linhas; 6 elementos).
+- [x] 6 fixtures cobrindo: caso simples (herança pura), alterações + divergência multi-fonte + vacatio, blocos organizacionais (CF/88), revogações parciais (4 tipos), revogação total da lei, OCR ruim.
+- [x] `tests/fixtures/leizilla_xml/README.md` com matriz de cobertura.
 - [ ] `scripts/leizilla-to-lexml.xsl` + teste CI `tests/test_lexml_export.py` validando contra `tests/fixtures/lexml.xsd` (bundle no repo).
-- [ ] **Consistency checker script** (`scripts/check_schema_consistency.py`): extrai exemplos de identifier e schema_version do SCHEMA.md, valida contra regex §5, checa que `v{N}` no path bate com `int(major(schema_version))`. Reduz Codex catches futuros.
-- [ ] **FK invariant test** (no ETL M3 mas validação local em M0.2): com 1 tabela denormalizada, garantir que `(lei_id, dispositivo_path, dispositivo_parent_path)` permanece consistente entre todas as rows da mesma lei (não há outra forma de detectar inconsistência sem JOIN).
-- [ ] Resolver pendentes §10: URN dialect contra CGPID spec, compressão Parquet (SNAPPY vs ZSTD em DuckDB-WASM), granularidade bundle ZIP, XPath dialect, robots.txt rate-limit, XSLT in-browser deprecation status.
+- [ ] `scripts/check_schema_consistency.py` validando as 12 invariantes do SCHEMA.md §7 (incluindo: `<fonte diverge>` requer `<texto>`, revogação total exclui parciais, herança de vigência consistente, ordenação de versões, token map cobre todos os paths).
+- [ ] Negative test cases (XML inválido proposital → validator deve rejeitar).
+- [ ] Resolver pendentes §8.2: URN dialect contra CGPID spec, compressão Parquet (SNAPPY vs ZSTD em DuckDB-WASM), granularidade bundle ZIP, política de re-scrape, robots.txt rate-limit, custo LLM real.
 
 **M0.3 — Inspirações concretas** (paralelo a M0.2):
 - [ ] Aprofundar `docs/SCHEMA.md` §8 com paths exatos em ficha/baliza/causaganha (manifest CSV columns, naming patterns, footer KV examples).

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,114 +1,92 @@
 # SCHEMA.md — Design de dados do Leizilla
 
-> Decisões load-bearing sobre granularidade de IA items, modelo XML dispositivo-cêntrico, schema Parquet, naming, e export LexML. Editado quando uma decisão muda — coluna **Status** indica `proposta`, `aprovada`, ou `superseded-by-#PR`.
+> **v2 — redesign a partir de first principles.** Esta versão reescreve a v1 (PR #6) do zero, partindo do princípio "dispositivo é a unidade básica" e derivando o resto. PR #7 (XSD + fixtures sobre o desenho v1) fica como referência histórica do que aprendemos. Ver §0 para o pivô e §9 para a tabela de migração.
 
-**Histórico**: a v0 deste documento esboçava um formato "LeiML" como fork de LexML, com a lei como unidade primária. Reescrito após review do PR #6: (a) **dispositivo é a unidade primária**, não a lei; (b) formato próprio escrito do zero ("Leizilla XML"), com export LexML apenas como gate de CI — não como constraint estrutural; (c) timeline temporal nativa de dispositivos para tratar alterações legislativas; (d) parsed item = "vigente compilado" como objeto principal, histórico exposto via timeline. Ver §0.
+Decisões load-bearing — coluna **Status** indica se é `aprovada` ou `superseded-by-#PR`. Documento editado quando uma decisão muda.
 
 Companion docs:
-- `IMPLEMENTATION.md` (raiz) — status geral e log de decisões cronológico
-- `docs/adr/0005-ia-identifiers.md` (a criar em M1) — formalização normativa
-- `docs/schemas/leizilla-v0.1.xsd` (a criar em M0.2) — schema XML
+- `IMPLEMENTATION.md` (raiz) — status geral e log de decisões cronológico.
+- `docs/schemas/leizilla-v0.1.xsd` — schema XML formal.
+- `tests/fixtures/leizilla_xml/` — fixtures cobrindo todos os cenários.
 
 ---
 
-## 0. Princípios de modelagem (reescrita pós-review #6)
+## 0. Princípio e o que mudou
 
-### 0.1 Dispositivo é a unidade primária e universal de texto
+### 0.1 Dispositivo é a unidade. Tudo o mais é derivado ou herda.
 
-A unidade básica de dado **não é a lei** — é o **dispositivo**. E "dispositivo" é o tipo universal para **tudo que for texto que ajude a interpretar a norma**:
+Lei = árvore de dispositivos. Dispositivo = árvore de dispositivos + linha do tempo de redações. Redação = texto + lista de testemunhos (fontes). Esse é o modelo inteiro.
 
-**Normativos** (carregam texto normativo próprio em `<versoes><versao><texto>...`):
-- `titulo-lei`: nome oficial ("LEI Nº 14.133, DE 1º DE ABRIL DE 2021")
-- `ementa`: resumo oficial
-- `preambulo`: "O Presidente da República, faço saber..."
-- `artigo`, `paragrafo`, `inciso`, `alinea`, `item`: articulação
-- `anexo`: anexos com texto (tabelas, listas, fórmulas — estrutura interna em v0.2)
-- `disposicao-transitoria`, `disposicao-final`: blocos finais de disposições
+Tudo o que não cabe nessa frase **não pertence ao XML**:
 
-**Organizacionais** (agrupadores sem texto normativo, só `<rotulo>` versionável):
-- `livro`, `parte`, `titulo`, `capitulo`, `secao`, `subsecao`
+- **Rótulo** ("Art. 1º", "§ 2º", "I", "a)") é uma função pura de `(tipo, path)` aplicada em render-time. Token map (§4.2) é o contrato público. Sem `<rotulo>` armazenado, sem override por versão.
+- **Tipo do dispositivo** (`artigo`, `paragrafo`, `inciso`, `capitulo`...) é derivado do `path` via token map. Não há atributo `tipo` no XML.
+- **Parent estrutural** é o nesting XML. Sem atributo `parent` duplicado.
+- **URN do dispositivo** é `lei.urn-lex + "!" + path`. Consumer compõe. Sem atributo `urn` no dispositivo.
+- **Bloco organizacional** (livro/capítulo/seção) não é categoria separada — é um dispositivo cujo `path` começa com token organizacional. Token map define semântica.
+- **OCR ruim** não é elemento separado (`<bloco-livre>`); é um dispositivo com `path="ocr-ruim"` e atributo `quality`. Render decide formato.
+- **Texto é texto.** Não há distinção entre "texto normativo" e "nome de capítulo". Capítulo tem texto — o nome dele.
 
-Tudo é `<dispositivo>` com `tipo` diferenciando. Blocos organizacionais ("TÍTULO I — Dos Princípios") são uma **espécie** de dispositivo, sem `<texto>` mas com `<rotulo>` versionável (renomear capítulo é alteração real).
+### 0.2 Vigência herda; proveniência é declarada quando importa
 
-**Cada dispositivo declara seu pai explicitamente** (`parent` attribute obrigatório). Raiz: `parent=""`. Hierarquia explícita, navegável em ambas direções.
+Caso default: dispositivo vigora junto com a lei. Não declara nada — herda. Cadeia: `<versao>.em` → ancestral `<dispositivo>` mais próximo que declara → `data-publicacao` extraída da URN da `<lei>`.
 
-Justificativa:
-- Lawyers citam dispositivos, não leis inteiras ("art. 5º, §2º, II, alínea b da CF/88").
-- Alterações operam sobre dispositivos individuais (caput, parágrafo isolado, anexo isolado).
-- Revogações são parciais com frequência (revoga art. 3º mantém o resto; revoga Anexo II mantém articulação).
-- Cross-references granulares ("Lei 14.133/2021 art. 3 alterou Lei 1.234/2003 art. 5 §2").
-- DuckDB-WASM indexa dispositivos com SQL trivial; lei é apenas o agregador.
-- **Uniformidade**: zero exceção. Todo texto da lei tem o mesmo molde de tratamento, mesma timeline temporal, mesmo padrão de divergência multi-fonte.
+Quando um dispositivo tem múltiplas versões (foi alterado), cada `<versao em="X">` declara explicitamente. `vigente-ate` **não é armazenado** — é inferido (próxima versão, ou `<revogacao>` do dispositivo, ou `<revogacao>` da lei, cascateando).
 
-Isso difere de LexML/Akoma Ntoso, que centram em document/work com elementos separados (`<Ementa>`, `<Preambulo>`, `<Articulacao>`, `<Anexo>`). Para nosso uso (busca jurídica + timeline temporal + alterações granulares), dispositivo universal é mais expressivo.
+A informação "esta vigência veio de onde" tem qualidade variável:
 
-### 0.2 Vigente compilado é o objeto canônico; histórico é timeline
-
-O parsed item canônico representa a lei **como ela deve estar vigente hoje** (best-effort compilation). Versões anteriores são **acessíveis** mas não são objetos primários — são snapshots indexados na timeline de cada dispositivo (date picker → "como era em 2010-01-01?").
-
-A "hierarquia de autoridade DO > Casa Civil > Assembleia" do esboço anterior foi descartada. As fontes não competem por canonicidade — elas cross-verificam a compilação vigente:
-
-- Casa Civil/COTEL geralmente mantém o consolidado vigente — fonte primária para texto atual.
-- Diário Oficial dá fé da publicação original — fonte primária para snapshots históricos.
-- Assembleia Legislativa dá o texto legislativo original (pode diferir de DO por retificações tardias).
-- Divergências entre fontes indicam **possível erro de consolidação ou retificação não-aplicada**, não ranking. Frontend mostra como "verificar".
-
-### 0.3 Formato próprio (não fork), com export LexML como gate de CI
-
-O esboço anterior propunha "LeiML" como fork de LexML. Descartado: dispositivo-cêntrico + timeline + divergencias multi-fonte + parse-LLM-metadata + bloco-livre não cabem confortavelmente em LexML, e a regra de round-trip ficaria perdendo dados em todo PR.
-
-Em vez disso: **Leizilla XML v0.1 é escrito do zero**, otimizado para nossos casos de uso. Mantemos a **disciplina** de LexML/Akoma Ntoso (URN LEX para identificar dispositivos, semântica jurídica) e um **gate de CI**: a cada PR, rodar `scripts/lexml_export.py` que produz um LexML válido a partir do nosso XML para casos representativos. O LexML resultante é uma **representação reduzida** (perde divergencias, parse meta, bloco-livre quality) — isso é OK; o gate só garante que conseguimos exportar para gov interop quando preciso, sem amarrar nosso design.
-
-### 0.4 Granularidade na renderização — SSR híbrido
-
-O esboço anterior cravou "HTML renderizado no browser via XSLT/JS, nunca server-side". Suavizado: páginas de detalhe de lei (`/lei/{id}`) renderizam server-side via Astro (acessibilidade WCAG, SEO, no-JS funciona, LBI 13.146/2015). Busca/timeline interativa fica client-side com Svelte+DuckDB-WASM. XSLT in-browser é fallback opcional para quem abre `law.xml` diretamente.
-
-### 0.5 Wayback Machine como caminho primário de fetch (aprovada)
-
-**Decisão**: o crawler **não baixa direto da fonte oficial**. Em vez disso:
-
-1. Crawler descobre `fonte_url` (HTML que lista a lei) e `pdf_url`
-2. Dispara `POST https://web.archive.org/save/{url}` para ambos (com check prévio `/wayback/available?url=...` para reuso de snapshot recente <24h)
-3. **Fetcha o PDF de volta da Wayback Machine** (não da fonte original)
-4. Upload do PDF para nossa coleção IA (continua acionando OCR automático)
-5. Grava `provenance_wayback` em `raw_meta.json` com URLs de snapshot
-
-**Justificativa**:
-- Bate na fonte original **uma única vez** (via bot do Wayback), não centenas. Polite com sites .gov.br frágeis
-- Timestamp Wayback é testemunha independente para auditoria forense — terceiro confiável atesta "esta URL continha este PDF em T"
-- Wayback funciona como CDN/buffer: tira nosso crawler do caminho crítico da fonte
-- Nossa coleção IA + OCR pipeline continua intocada
-
-**Política de falha (detalhada)**:
-
-| Cenário Wayback | Ação |
+| `tipo` | Quando aplica |
 |---|---|
-| HTTP 200 + snapshot URL retornada | Caminho feliz. Fetch PDF do snapshot. `fetched_from="wayback"`. |
-| HTTP 429 (rate limit) | Backoff exponencial (1s, 2s, 4s, máx 30s). 3 tentativas, depois fallback. |
-| HTTP 5xx (server error) | Backoff curto (2s, 5s). 2 tentativas, depois fallback. |
-| HTTP 403/451 com body indicando robots.txt | **Permanente, não retry**. Wayback recusa-se a arquivar essa URL. Fallback imediato, gravar `fetched_from="source-fallback"` + `wayback_blocked_robots=true`. |
-| Timeout (>60s) | Fallback. Sem retry (Wayback save é lento por natureza, mas >60s indica problema). |
-| Snapshot existente < 24h via `/wayback/available` | Reusa, não dispara novo save. Economiza throttle quota. |
+| `data-publicacao` | Vigência = data da lei (regra default LINDB). |
+| `texto-lei-alteradora` | Declarado na lei que alterou (caso comum em alterações). |
+| `vacatio-legis` | Texto especifica prazo ("entrará em vigor 90 dias após publicação"); calculada. |
+| `consolidacao` | Casa Civil/COTEL adotou sem prova textual no ato original. |
+| `inferencia-llm` | Parser inferiu sem evidência textual direta. |
+| `decisao-judicial` | STF/STJ modulou efeitos. |
 
-**Rate limit Wayback público**: ~12 saves/min sem auth, ~120/min com chave SavePageNow ([docs IA](https://archive.org/details/spn-2)). Para scrape de Rondônia inteira (~5k leis × 2 URLs = 10k saves), throttle público leva ~14h. M2 inclui:
-- Token bucket no crawler para respeitar 12/min (worker pool size = 2).
-- Avaliar custo de SavePageNow paid API se 14h ficar inviável.
+Quando `tipo` é não-óbvio, `<versao>` carrega sub-elemento `<inicio tipo="...">` com `<fonte>` filha apontando para o IA item que materializa a prova. Caso óbvio (ato original ou alteração explícita), `<inicio>` é omitido — `tipo` deriva por default: `data-publicacao` se primeira versão sem `alterado-por`, `texto-lei-alteradora` se há `alterado-por`.
 
-**Frontend (M5)**: badge visível "fetched via source-fallback (Wayback indisponível)" quando `provenance_wayback.fetched_from = "source-fallback"`. Mantém transparência da garantia "external witness".
+### 0.3 Revogação é evento estruturado
 
-Quando o sistema cai inteiramente em fallback de download direto, log warning para auditoria; estatística agregada (% raws com `source-fallback`) é métrica de saúde do pipeline.
+`<revogada>true|false</revogada>` é insuficiente. Revogação tem 4 dimensões: **quem** (URN), **quando** (data de efeito), **tipo jurídico**, **escopo** (parcial vs total).
 
-**Não-decisão**: Wayback **não substitui** nossa coleção IA. Snapshots Wayback não geram `_djvu.txt` (OCR automático do IA só roda em items de coleção, não em snapshots). Etapa 2 depende do OCR — então o PDF tem que viver na nossa coleção IA.
+Elemento `<revogacao em="..." por="..." tipo="...">` com `<fonte>` filha. Posição estrutural indica escopo:
+- No root da `<lei>` → revogação total da lei.
+- Dentro de `<dispositivo>` → revogação parcial daquele dispositivo (e descendentes via cascata implícita).
 
-### 0.6 Genericidade real, não só de slug
+Tipos jurídicos:
 
-O esboço anterior afirmou "genérico por ente desde dia 1" mas o vocabulário era estadual. Realidade: cada nível federativo tem fontes diferentes (Federal: Câmara, Senado, Planalto, DOU; Municípios: ~5.570 estruturas distintas). O modelo Leizilla XML **não** assume estrutura de fonte — apenas que cada dispositivo tem `<fonte ia-id="..."/>` apontando para um raw item. O catálogo `src/leizilla/fontes/{ente}.py` declara fontes válidas por ente; o resto do código consome a lista sem hardcode.
+| `tipo` | `por` | Notas |
+|---|---|---|
+| `expressa` | URN da lei revogadora | "Fica revogado o art. X". |
+| `tacita` | URN da lei posterior | Incompatibilidade material; relação inferida. |
+| `caducidade` | (ausente) | Decurso de tempo, leis temporárias. |
+| `inconstitucionalidade` | URN da ADI/ADC/ADPF | STF/STJ declarou; tecnicamente não é revogação mas efeito equivalente. |
+| `nao-recepcao` | URN da CF | Norma pré-1988 não recepcionada. |
+
+### 0.4 Fonte é uma só; processo vai para sidecar
+
+`<fonte ia-id="...">` é a tag única usada em 4 contextos: testemunho do texto da `<versao>`, prova do `<inicio>` de vigência, prova da `<revogacao>`, e prova da `<revogacao>` total da lei. Sempre aponta para um IA item.
+
+Não existe "fonte canônica" — o texto canônico está no `<texto>` da `<versao>` (compilação best-effort do ETL). Fontes são testemunhos que corroboram (default) ou divergem (`diverge="true"`, carregam `<texto>` próprio inline).
+
+O **processo** que produziu o texto canônico (parse method, modelo LLM, confiança, regras de desempate, timestamp) **não pertence ao XML**. Vai para `parsed_meta.json` (sidecar do parsed item). XML carrega só estrutura normativa.
+
+### 0.5 Auditoria por embeddings (plano paralelo)
+
+Drift entre OCR raw e texto compilado é detectado por comparação de embeddings (`embedding(raw_djvu_txt)` × `embedding(versao.texto)` por dispositivo). Baixa similaridade dispara auditoria humana. Roda em batch periódico, fora do XML.
+
+Implica: **não há flag manual** tipo `revisao-pendente` no XML. LLM não sabe quando errou — pedir auto-flag é contraditório. Auditoria é externa, sistemática, e não polui o conteúdo.
+
+Plano detalhado em arquivo separado (M3+).
 
 ---
 
-## 1. Granularidade dos IA items
+## 1. Internet Archive — granularidade dos items
 
-### 1.1 Raw items — individual por PDF (aprovada)
+(Carregado da v1 — esta parte funciona inalterada.)
+
+### 1.1 Raw items — individual por PDF
 
 **Pattern**: `leizilla-raw-{ente}-{fonte}-{chave}`
 
@@ -119,24 +97,15 @@ O esboço anterior afirmou "genérico por ente desde dia 1" mas o vocabulário e
 | `ro` | `diario` | `{YYYY-MM-DD}-p{pagina:04d}` | `leizilla-raw-ro-diario-2003-06-15-p0012` |
 | `federal` | `planalto` | `lei-{numero:05d}-{ano}` | `leizilla-raw-federal-planalto-lei-12345-2024` |
 
-**Justificativa**: IA faz OCR **apenas** em PDFs individuais (não em PDFs dentro de ZIP). Permalink por PDF facilita citação e debugging. Manifest CSV escala para milhares de items.
+**Justificativa**: IA faz OCR **apenas** em PDFs individuais (não em PDFs dentro de ZIP). Permalink por PDF facilita citação. Manifest CSV escala para milhares de items.
 
-### 1.2 Raw items — bundle ZIP semanal (aprovada, redundância)
+### 1.2 Raw items — bundle ZIP semanal (redundância)
 
 **Pattern**: `leizilla-bundle-{ente}-{fonte}-{periodo}` onde `{periodo}` = ISO week (`YYYY-Www`).
 
-Exemplo: `leizilla-bundle-ro-casacivil-2026-W20`
+Layout interno: `manifest.csv` + `pdfs/{chave}.pdf` + `meta/{chave}.json`. Forensics + download em lote.
 
-**Layout interno**:
-```
-manifest.csv         columns: coddoc, ia_id, fonte_url, hash_pdf, data_captura
-pdfs/{chave}.pdf
-meta/{chave}.json
-```
-
-Forensics + download em lote. Mirror histórico das fontes.
-
-### 1.3 Parsed items — 1 lei = 1 IA item (aprovada)
+### 1.3 Parsed items — 1 lei = 1 IA item
 
 **Pattern canônico**: `leizilla-{ente}-{tipo}-{numero:05d}-{ano}`
 
@@ -148,34 +117,30 @@ Forensics + download em lote. Mirror histórico das fontes.
 
 **Pattern fallback** (lei antiga sem numeração formal): `leizilla-{ente}-{tipo}-fallback-{fonte}-{chave}`
 
-Exemplo: `leizilla-ro-lei-fallback-casacivil-coddoc-00099`
-
-> Codex P1 fix (PR #6): fallback **inclui obrigatoriamente** o segmento `{fonte}` para evitar colisão quando diferentes fontes compartilham a mesma chave.
-
-**Conteúdo do parsed item** (vigente compilado + histórico em timeline):
+**Conteúdo do parsed item**:
 ```
 leizilla-ro-lei-01234-2003/
-├── law.xml             ← Leizilla XML v0.1 (dispositivo-cêntrico, com timeline)
-├── parsed_meta.json    ← metadados estruturados de produção
-├── provenance.json     ← rastreabilidade raw items + parse method
-└── alteracoes.json     ← relações computadas (alteradoPor, altera, revogadoPor)
+├── law.xml             ← Leizilla XML v0.1 (canônico)
+├── parsed_meta.json    ← processo de parse (método, confiança, divergências)
+├── provenance.json     ← rastreabilidade raw items
+└── alteracoes.json     ← relações computadas (alterada_por, altera, revogada_por, revoga)
 ```
 
-Não inclui HTML pré-gerado (renderização SSR via Astro a partir de `law.xml`). Não inclui `law.lexml` (export sob demanda; ver §6).
+Sem HTML pré-gerado (Astro SSR renderiza a partir do `law.xml`). Sem `law.lexml` (export sob demanda; ver §6).
 
-### 1.4 Dataset items — versionados (aprovada)
+### 1.4 Dataset items — versionados
 
-**Pattern**: `leizilla-dataset-{ente}-v{N}`
+**Pattern**: `leizilla-dataset-{ente}-v{N}` onde `N = int(major(schema_version))`.
 
-Conteúdo: `versoes-{ente}-v{N}.parquet` (single table, ver §3), `manifest-{ente}.csv`, `README.md`.
+Pre-M5: `schema_version = "0.1"` → `v0`. Post-M5: `schema_version = "1"` → `v1`. `v0` é versão **válida e citável**, não draft/empty.
 
-Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado de forma incompatível).
+Conteúdo: `versoes-{ente}-v{N}.parquet` + `manifest-{ente}.csv` + `README.md`.
 
 ---
 
-## 2. Layout dos JSON sidecars
+## 2. JSON sidecars
 
-### 2.1 `raw_meta.json` (sidecar do raw item)
+### 2.1 `raw_meta.json`
 
 ```json
 {
@@ -183,63 +148,68 @@ Bump de `N` apenas em **breaking schema change** (coluna removida, tipo alterado
   "ente": "ro",
   "fonte": "casacivil",
   "fonte_url": "https://ditel.casacivil.ro.gov.br/cotel/livros/Folder.aspx?coddoc=42",
-  "pdf_url": "https://ditel.casacivil.ro.gov.br/.../doc-1234.pdf",
   "chave": "coddoc-00042",
   "data_captura": "2026-05-20T14:30:00Z",
   "hash_pdf": "sha256:abc123...",
   "user_agent": "leizilla-crawler/1.0",
   "ia_id_bundle": "leizilla-bundle-ro-casacivil-2026-W20",
   "provenance_wayback": {
-    "fonte_url_snapshot": "https://web.archive.org/web/20260520143000/https://ditel.casacivil.ro.gov.br/cotel/livros/Folder.aspx?coddoc=42",
-    "pdf_url_snapshot": "https://web.archive.org/web/20260520143015/https://ditel.casacivil.ro.gov.br/.../doc-1234.pdf",
-    "captured_at": "2026-05-20T14:30:15Z",
-    "fetched_from": "wayback"
+    "fetched_from": "wayback",
+    "wayback_url": "https://web.archive.org/web/20260520143000/https://ditel.casacivil.ro.gov.br/cotel/...",
+    "wayback_blocked_robots": false
   }
 }
 ```
 
-`provenance_wayback.fetched_from` é `"wayback"` quando o PDF foi baixado via Wayback (caminho primário, §0.5) ou `"source-fallback"` quando Wayback falhou e baixamos direto da fonte. `null` se Wayback falhou e o fallback ainda não rodou. Os snapshots ficam `null` individualmente em caso de falha por URL.
-
-### 2.2 `parsed_meta.json` (sidecar do parsed item)
+### 2.2 `parsed_meta.json` — agora carrega o processo
 
 ```json
 {
   "leizilla_meta_version": "0.1",
   "schema_xml_version": "0.1",
-  "urn_lex": "urn:lex:br;estado:rondonia:lei:2003-06-15;1234",
+  "urn_lex": "urn:lex:br;estado:rondonia;lei:2003-06-15;1234",
   "ente": "ro",
   "tipo": "lei",
   "numero": "1234",
   "ano": 2003,
   "data_publicacao": "2003-06-15",
-  "ementa": "Dispõe sobre...",
   "vigente_em": "2026-05-20",
-  "num_dispositivos": 27,
-  "num_versoes_total": 31,
+
   "fontes_consultadas": [
-    "leizilla-raw-ro-casacivil-coddoc-00042",
+    "leizilla-raw-ro-casacivil-coddoc-01234",
     "leizilla-raw-ro-diario-2003-06-15-p0012"
   ],
+
+  "num_dispositivos": 27,
+  "num_versoes_total": 31,
   "tem_divergencia": true,
   "num_divergencias": 1,
+
   "parse_method": "llm-haiku",
   "parse_model": "claude-haiku-4-5-20251001",
   "parse_timestamp": "2026-05-20T18:45:00Z",
-  "confianca_parse": 0.92,
-  "validacao_xsd": "passed"
+  "confianca_parse_global": 0.92,
+  "regras_desempate": ["voto-majoritario", "ocr-confianca"],
+  "validacao_xsd": "passed",
+
+  "auditoria_embeddings": {
+    "ultimo_check": "2026-05-21T03:00:00Z",
+    "min_similarity": 0.94,
+    "dispositivos_flagged": []
+  }
 }
 ```
 
 ### 2.3 `provenance.json`
 
-Audit trail mínimo separado para facilitar verificação sem carregar `parsed_meta.json` completo.
+Audit trail mínimo:
 
 ```json
 {
   "fontes_raw": [
     {
-      "ia_id": "leizilla-raw-ro-casacivil-coddoc-00042",
-      "ocr_url": "https://archive.org/download/leizilla-raw-ro-casacivil-coddoc-00042/law_djvu.txt",
+      "ia_id": "leizilla-raw-ro-casacivil-coddoc-01234",
+      "ocr_url": "https://archive.org/download/leizilla-raw-ro-casacivil-coddoc-01234/law_djvu.txt",
       "hash_pdf": "sha256:abc123...",
       "consumed_at": "2026-05-20T18:45:00Z"
     }
@@ -252,20 +222,18 @@ Audit trail mínimo separado para facilitar verificação sem carregar `parsed_m
 }
 ```
 
-### 2.4 `alteracoes.json` (novo, derivado)
+### 2.4 `alteracoes.json` (relações pré-computadas)
 
-Relações computadas com outras leis. Permite ao frontend mostrar "esta lei foi alterada por X" sem ter que escanear o `law.xml` inteiro.
-
-> **Derivado, não fonte primária**: source-of-truth é o atributo `alterado-por` de cada `<versao>` dentro de `law.xml`. Este sidecar é **regenerado** a cada update do `law.xml` (mesmo upload IA). Em caso de conflito, `law.xml` ganha. Não editar manualmente.
+Derivado do `law.xml`; regenerado a cada update. Conflito = `law.xml` é fonte de verdade.
 
 ```json
 {
   "leizilla_meta_version": "0.1",
   "alterada_por": [
     {
-      "urn_lex": "urn:lex:br;estado:rondonia:lei:2024-06-30;5678",
+      "urn_lex": "urn:lex:br;estado:rondonia;lei:2024-06-30;5678",
       "ia_id": "leizilla-ro-lei-05678-2024",
-      "dispositivos_afetados": ["art-3-par-2", "art-5"],
+      "dispositivos_afetados": ["art-3", "art-3-par-1"],
       "data_efeito": "2024-07-30"
     }
   ],
@@ -277,136 +245,93 @@ Relações computadas com outras leis. Permite ao frontend mostrar "esta lei foi
 
 ---
 
-## 3. Schema Parquet v0.1 — single table (transitório)
+## 3. Schema Parquet v0.1 — tabela única `versoes`
 
-> Schema é **v0.1 durante M0–M4**; promove a **v1 apenas no fechamento de M5** (ver §3.4 e §7). Identificadores `leizilla.schema_version` no footer KV e o `v{N}` no caminho do arquivo refletem isso.
+Tabela única denormalizada, grão `lei × dispositivo × versão`. Zero JOIN em DuckDB-WASM, dictionary encoding + SNAPPY compactam redundância. Decisão transicional com gatilhos concretos de revert em M5 (§3.4).
 
-**Decisão (aprovada): uma única tabela `versoes`** com grain (lei × dispositivo × versão). Metadados de lei e dispositivo denormalizados em cada row. Estrutura/listagem emerge via `SELECT DISTINCT`. Read-only Parquet servido estaticamente do IA — dictionary encoding + SNAPPY compress as repetições. Tradeoff explícito: simplicidade de query (zero JOIN no DuckDB-WASM) vs redundância de dados (compressão Parquet mitiga).
+### 3.1 Colunas
 
-Pode evoluir para 2 ou 3 tabelas se DuckDB-WASM ficar gargalo na prática — decisão revisitada em M5 com dados reais.
+Agrupadas por origem (lei / dispositivo / versão). Toda metadata de lei e dispositivo repete por row; emerge via `SELECT DISTINCT`.
 
-**Gatilhos de revert (qualquer um dispara discussão de split)**:
-- Parquet `versoes-{ente}-v0.parquet` excede **100 MB** comprimido (limite confortável de fetch HTTP em conexões ruins).
-- Cold DuckDB-WASM init + primeira query (single SELECT por `lei_id`) excede **5s P50** em laptop padrão (M1/M2 Air, conexão 50 Mbps).
-- Memória DuckDB-WASM durante query típica excede **500 MB** (afeta browsers em devices modestos).
-- Latência user-visible de search/filter (texto_normalizado LIKE) excede **1s P95** em dataset RO completo.
-- Cardinalidade real ultrapassa **2M rows** por ente (estimativa atual: ~1.5M para RO; >2M sugere que custos lineares começam a doer).
-
-Critério: 1 gatilho disparado abre RFC de split; 2+ obrigam split antes do M5 fechar. M4 inclui benchmark scripts para medir todos.
-
-### 3.1 Tabela `versoes` — single source of truth
-
-Cada row é uma versão de um dispositivo de uma lei. Colunas agrupadas por origem semântica:
-
-**Lei (denormalizado, repetido por row da mesma lei):**
+**Lei** (repete por linha):
 
 | coluna | tipo | nullable | nota |
 |---|---|---|---|
-| `lei_id` | VARCHAR | NO | identifier IA do parsed item, zero-padded (e.g. `leizilla-ro-lei-01234-2003`) |
+| `lei_id` | VARCHAR | NO | identifier IA do parsed item, zero-padded |
 | `ente` | VARCHAR | NO | `ro`, `sp`, `federal`, `ro-porto-velho`... |
-| `tipo_lei` | VARCHAR | NO | `lei`, `decreto`, `lc`, `resolucao`... |
-| `numero_lei` | VARCHAR | YES | nullable porque fallback existe |
-| `ano` | INTEGER | NO | |
-| `data_publicacao` | DATE | YES | |
-| `urn_lex` | VARCHAR | YES | nullable se `data_publicacao` desconhecida; URN LEX requer data — ver §5.5 |
-| `titulo_lei` | VARCHAR | YES | título oficial denormalizado (mesmo conteúdo do dispositivo `tipo_dispositivo='titulo-lei'`) |
-| `ementa` | VARCHAR | YES | ementa denormalizada (mesmo conteúdo do dispositivo `tipo_dispositivo='ementa'`) |
-| `url_law_xml_ia` | VARCHAR | NO | URL do `law.xml` no IA |
-| `vigente_em` | DATE | NO | data de referência da compilação (toda a lei) |
-| `revogada` | BOOLEAN | NO | a lei inteira foi revogada |
-| `parse_status` | VARCHAR | NO | `raw_only`/`parsed`/`failed` |
-| `parse_method` | VARCHAR | YES | `llm-haiku`/`llm-opus`/`manual`/`deterministic` |
-| `confianca_parse` | FLOAT | YES | 0.0–1.0 |
+| `tipo_lei` | VARCHAR | NO | `lei`, `decreto`, `lc`, `constituicao`... |
+| `numero_lei` | VARCHAR | YES | nullable em fallbacks |
+| `ano_lei` | INTEGER | NO | |
+| `data_publicacao` | DATE | YES | extraída da URN; nullable em fallbacks |
+| `urn_lex_lei` | VARCHAR | YES | nullable se `data_publicacao` desconhecida |
+| `vigente_em` | DATE | NO | data de referência da compilação |
+| `lei_revogada` | BOOLEAN | NO | true se `<revogacao>` na raiz |
+| `lei_revogada_em` | DATE | YES | data efeito |
+| `lei_revogada_por` | VARCHAR | YES | URN da revogadora |
+| `lei_revogada_tipo` | VARCHAR | YES | enum de revogação |
 
-**Dispositivo (denormalizado, repetido por versão do mesmo dispositivo):**
+**Dispositivo** (repete por versão):
 
 | coluna | tipo | nullable | nota |
 |---|---|---|---|
-| `dispositivo_path` | VARCHAR | NO | `art-3` / `art-3-par-2` / `tit-1-cap-1` / etc. Normativos = global; organizacionais = namespaceado (§4.3 regras 3 e 4) |
-| `dispositivo_parent_path` | VARCHAR | NO | path do pai; raiz = `""`; sempre declarado (§0.1) |
-| `tipo_dispositivo` | VARCHAR | NO | enum unificado (§0.1): normativos (`titulo-lei`, `ementa`, `preambulo`, `artigo`, `paragrafo`, `inciso`, `alinea`, `item`, `anexo`, `disposicao-transitoria`, `disposicao-final`) + organizacionais (`livro`, `parte`, `titulo`, `capitulo`, `secao`, `subsecao`). **Não inclui `caput`** — caput é índice 0 implícito (§4.3). |
-| `rotulo` | VARCHAR | NO | "Art. 1º", "§ 2º", "II", "a)", "TÍTULO I — Dos Princípios"... estável; override por versão fica em `rotulo_versao` |
-| `ordem` | INTEGER | NO | ordem dentro do parent (1, 2, 3...) |
-| `urn_dispositivo` | VARCHAR | YES | NULL ⟺ `urn_lex` é NULL |
+| `dispositivo_path` | VARCHAR | NO | global p/ normativos, namespaceado p/ organizacionais |
+| `dispositivo_tipo` | VARCHAR | NO | derivado do path via token map |
+| `dispositivo_ordem` | INTEGER | NO | ordem dentro do parent estrutural |
+| `dispositivo_parent_path` | VARCHAR | YES | NULL para top-level |
+| `dispositivo_revogado` | BOOLEAN | NO | |
+| `dispositivo_revogado_em` | DATE | YES | |
+| `dispositivo_revogado_por` | VARCHAR | YES | |
+| `dispositivo_revogado_tipo` | VARCHAR | YES | |
+| `urn_dispositivo` | VARCHAR | YES | `urn_lex_lei + "!" + path`; NULL se `urn_lex_lei` é NULL |
 
-**Versão (único por row):**
+**Versão** (unique por row):
 
 | coluna | tipo | nullable | nota |
 |---|---|---|---|
-| `versao_id` | VARCHAR | NO | `{lei_id}#{dispositivo_path}#v{N}` — PK |
-| `numero_versao` | INTEGER | NO | 1, 2, 3... cronológico dentro do dispositivo |
-| `vigente_de` | DATE | NO | |
-| `vigente_ate` | DATE | YES | NULL = ainda vigente |
-| `texto` | VARCHAR | YES | NULL quando dispositivo é organizacional (tipo ∈ {livro, parte, titulo, capitulo, secao, subsecao}); NOT NULL para normativos |
-| `texto_normalizado` | VARCHAR | YES | NFC + cleanup p/ busca client-side. NULL nas mesmas condições de `texto` |
-| `rotulo_versao` | VARCHAR | YES | override do `rotulo` estável; útil quando rotulo muda entre versões (renomear capítulo). Normalmente NULL |
-| `alterado_por_lei_id` | VARCHAR | YES | NULL na versão original; senão lei_id da lei alteradora |
-| `fonte_canonica` | VARCHAR | NO | slug curto da fonte (`casacivil`, `diario`, `assembleia`...) |
-| `fontes_consultadas` | VARCHAR (JSON array) | NO | lista de raw IA ids usados nesta versão |
-| `tem_divergencia` | BOOLEAN | NO | |
-| `divergencias` | VARCHAR (JSON) | YES | diff summary entre fontes para esta versão |
-| `hash_texto` | VARCHAR | YES | sha256 de `texto`; NULL quando `texto` é NULL |
-| `bloco_livre_quality` | VARCHAR | YES | `null` (parsing OK) / `low` / `medium` / `high` / `raw` se `<bloco-livre>` foi usado (§4.4) |
-| `created_at` | TIMESTAMP | NO | |
-| `updated_at` | TIMESTAMP | NO | |
+| `versao_id` | VARCHAR | NO | `{dispositivo_path}#{em}` |
+| `em` | DATE | NO | data de início da versão (chave natural) |
+| `ate` | DATE | YES | inferido; NULL = ainda vigente |
+| `alterado_por` | VARCHAR | YES | URN da lei alteradora |
+| `inicio_tipo` | VARCHAR | NO | enum: `data-publicacao` (default) / `texto-lei-alteradora` / `vacatio-legis` / `consolidacao` / `inferencia-llm` / `decisao-judicial` |
+| `texto` | VARCHAR | YES | texto canônico estabelecido |
+| `texto_normalizado` | VARCHAR | YES | NFC + cleanup; NOT NULL quando `texto` NOT NULL |
+| `fontes` | VARCHAR (JSON) | NO | array de `{ia_id, diverge?, texto_divergente?}` |
+| `num_fontes` | INTEGER | NO | |
+| `tem_divergencia` | BOOLEAN | NO | true se alguma fonte tem `diverge=true` |
+| `hash_texto` | VARCHAR | YES | sha256 |
+| `quality` | VARCHAR | YES | NULL (parse OK) / `low` / `medium` / `high` / `raw` (OCR ruim) |
 
 ### 3.2 Padrões de query
 
+Vigente em data X:
 ```sql
--- Texto vigente de art-5 da Lei 1234/2003 hoje
-SELECT texto FROM versoes
-WHERE lei_id = 'leizilla-ro-lei-01234-2003'
-  AND dispositivo_path = 'art-5'
-  AND vigente_ate IS NULL;
-
--- Texto de art-5 como estava em 2010-01-01
-SELECT texto FROM versoes
-WHERE lei_id = 'leizilla-ro-lei-01234-2003'
-  AND dispositivo_path = 'art-5'
-  AND vigente_de <= DATE '2010-01-01'
-  AND (vigente_ate > DATE '2010-01-01' OR vigente_ate IS NULL);
-
--- Estrutura/TOC de uma lei (rotulo vigente por dispositivo)
--- Regra: rotulo mostrado no TOC = COALESCE(rotulo_versao, rotulo) da versão atualmente vigente
-SELECT DISTINCT
-  dispositivo_path,
-  tipo_dispositivo,
-  dispositivo_parent_path,
-  COALESCE(rotulo_versao, rotulo) AS rotulo_tos,
-  ordem
-FROM versoes
-WHERE lei_id = 'leizilla-ro-lei-01234-2003'
-  AND vigente_ate IS NULL   -- versão vigente apenas
-ORDER BY ordem;
-
--- Busca por nome de capítulo/título (texto_normalizado é NULL em blocos
--- organizacionais; busca em rotulo)
-SELECT DISTINCT lei_id, dispositivo_path, rotulo
-FROM versoes
-WHERE ente = 'ro'
-  AND tipo_dispositivo IN ('livro', 'parte', 'titulo', 'capitulo', 'secao', 'subsecao')
-  AND rotulo ILIKE '%direitos fundamentais%';
-
--- Listagem de todas as leis de um ente
-SELECT DISTINCT lei_id, titulo_lei, ementa, ano, parse_status, confianca_parse
-FROM versoes
-WHERE ente = 'ro'
-ORDER BY ano DESC, numero_lei;
-
--- Busca full-text em texto normalizado
-SELECT lei_id, dispositivo_path, texto FROM versoes
-WHERE ente = 'ro'
-  AND vigente_ate IS NULL
-  AND texto_normalizado LIKE '%servidor publico%';
+SELECT * FROM versoes
+WHERE lei_id = ?
+  AND em <= '2020-01-01'
+  AND (ate IS NULL OR ate > '2020-01-01')
+  AND NOT dispositivo_revogado
+ORDER BY dispositivo_path;
 ```
 
-### 3.3 Representação de arrays e JSON
+TOC (estrutura da lei):
+```sql
+-- token_map(dispositivo_tipo, dispositivo_path) → rotulo deriva em código,
+-- não em SQL (rotulo não é armazenado).
+SELECT DISTINCT dispositivo_path, dispositivo_tipo, dispositivo_parent_path, dispositivo_ordem
+FROM versoes
+WHERE lei_id = ?
+ORDER BY dispositivo_ordem;
+```
 
-Arrays **no Parquet** como `VARCHAR` com JSON serializado, **não** Parquet LIST nativo. Justificativa: simplifica TanStack Query + Svelte components; JSON universal; custo storage irrelevante com SNAPPY.
+Busca full-text:
+```sql
+SELECT lei_id, dispositivo_path, em
+FROM versoes
+WHERE texto_normalizado LIKE '%transparência%'
+  AND ate IS NULL;
+```
 
-**Sidecars JSON** (`raw_meta.json`, `parsed_meta.json`, `provenance.json`, `alteracoes.json`) usam arrays JSON nativos — a restrição é específica do Parquet.
-
-### 3.4 Footer KV metadata (PyArrow)
+### 3.3 Footer KV metadata (PyArrow ou DuckDB COPY)
 
 ```python
 {
@@ -415,256 +340,269 @@ Arrays **no Parquet** como `VARCHAR` com JSON serializado, **não** Parquet LIST
   "leizilla.ente": "ro",
   "leizilla.table": "versoes",
   "leizilla.generated_at": "2026-05-20T19:00:00Z",
-  "leizilla.row_count": "298473",
+  "leizilla.row_count": "12483",
   "leizilla.git_sha": "abc1234def5678901234567890abcdef12345678"
 }
 ```
 
-Escrita preferida via `pyarrow.parquet.write_table` (controle granular do KV + interop com Arrow ecosystem). DuckDB também suporta KV custom via `COPY (...) TO 'file.parquet' (FORMAT parquet, KV_METADATA {...})` — ambos os paths são válidos; escolha do writer fica para M4 baseada em complexidade do ETL. `git_sha` é o SHA completo (40 chars), não truncado.
+Writer choice (PyArrow `write_table` vs DuckDB `COPY ... (KV_METADATA ...)`) deferido para M4.
 
-### 3.5 Versioning
+### 3.4 Gatilhos de revert para schema multi-tabela
 
-- `schema_version` semver-ish na coluna `leizilla.schema_version`: major bump apenas em break.
-- **Mapping `schema_version` → identifier `v{N}`**: `N` é o **major** do `schema_version`. Pré-M5: `schema_version="0.1"` → identifier `v0` (e.g. `leizilla-dataset-ro-v0`, `versoes-ro-v0.parquet`). Pós-M5: `schema_version="1"` → identifier `v1`. Identifier IA permanece inteiro `v\d+` por compatibilidade com regex de naming (§5.4); versão pré-release fica codificada no major `0`. Minor/patch (`0.1`, `0.2`) atualizam o footer KV sem novo identifier.
-- **Nota interpretativa**: `v0` **não** significa "empty/draft/abandonado" — é o major do `schema_version="0.1"`, indicando design pré-MVP. Dataset `v0` é válido, citável, e tem garantias formais de schema (XSD validado, footer KV preenchido). Promove-se a `v1` quando o MVP M5 fechar e o schema for considerado estável.
-- CI valida que `int(N)` no caminho do arquivo bate com `int(schema_version.split('.')[0])` do footer KV.
-- Zod schema único em `web/src/schemas/v0/versao.ts` (matches single table) durante M0–M4; movido para `v1/` quando schema_version promover para `1`.
-- v1 só é cravado depois do MVP rodar (reviewer #6 ponto 13). Durante M0–M4 o schema é **v0.1** (identifier `v0`); promove para v1 no fechamento de M5.
+Single-table é decisão transicional. Revisita em M5 com dados reais. Gatilhos concretos:
+
+- `file > 100 MB`
+- `cold-fetch > 5s P50` em DuckDB-WASM
+- `DuckDB-WASM memory > 500 MB`
+- `search > 1s P95`
+- `rows > 2M`
+
+**1 gatilho → RFC** discutindo split. **2+ gatilhos → split obrigatório** antes de M5 close. M4 inclui benchmark scripts medindo todos.
 
 ---
 
 ## 4. Leizilla XML v0.1 — formato canônico
 
-Esboço. Definição XSD formal em `docs/schemas/leizilla-v0.1.xsd` (M0.2).
+### 4.1 Estrutura
 
-### 4.1 Estrutura raiz
+```
+<lei> [xmlns, schema-version, urn-lex, vigente-em]
+  <revogacao>?              [em, por?, tipo]
+    <fonte/>+               [ia-id]
+  <dispositivo>+ [path, quality?]
+    <versao>+               [em?, alterado-por?]
+      <inicio>?             [tipo]
+        <fonte/>+           [ia-id]
+      <texto/>
+      <fonte/>+             [ia-id, diverge?]
+        <texto/>?           (só quando diverge="true")
+    <dispositivo>*          (recursivo)
+    <revogacao>?            [em, por?, tipo]
+      <fonte/>+
+```
+
+**6 elementos** (`<lei>`, `<dispositivo>`, `<versao>`, `<inicio>`, `<texto>`, `<fonte>`, `<revogacao>`). `<texto>` e `<fonte>` são folhas com semântica contextual (`<fonte>` em `<versao>` testemunha texto; em `<inicio>` testemunha vigência; em `<revogacao>` testemunha revogação — mesma tag, contexto distinto).
+
+### 4.2 Token map — contrato público
+
+Path determina tipo. Token map é a fonte única de verdade.
+
+**Tokens normativos** (dispositivos com texto):
+
+| Token (path prefix) | Tipo | Rótulo derivado |
+|---|---|---|
+| `titulo-lei` | titulo-lei | "Título" |
+| `ementa` | ementa | "Ementa" |
+| `preambulo` | preambulo | "Preâmbulo" |
+| `art-N` | artigo | "Art. Nº" (1º–9º com ordinal; Nº a partir de 10) |
+| `par-N` ou `par-unico` | paragrafo | "§ Nº" ou "Parágrafo único" |
+| `inc-N` | inciso | numeral romano de N |
+| `ali-X` (a, b, c...) | alinea | "X)" |
+| `item-N` | item | "N." |
+| `anexo-N` | anexo | "Anexo N" (romanos) |
+| `disp-transitoria-N` | disposicao-transitoria | "Art. N (Disposições Transitórias)" |
+| `disp-final-N` | disposicao-final | "Art. N (Disposições Finais)" |
+| `ocr-ruim` | bloco-ocr-ruim | (sem rótulo; render mostra banner) |
+
+**Tokens organizacionais** (agrupadores; texto = nome do bloco):
+
+| Token | Tipo | Rótulo derivado |
+|---|---|---|
+| `liv-N` | livro | "LIVRO Nº" |
+| `parte-N` | parte | "PARTE Nº" |
+| `tit-N` | titulo | "TÍTULO Nº" |
+| `cap-N` | capitulo | "CAPÍTULO Nº" |
+| `sec-N` | secao | "Seção Nº" |
+| `subsec-N` | subsecao | "Subseção Nº" |
+
+**Regras de path**:
+- Normativos têm path **global**: `art-5` é sempre `art-5`, independente de onde está aninhado.
+- Sub-dispositivos normativos compõem o path do ancestral normativo: `art-5-par-2`, `art-5-par-2-inc-3`, `art-5-par-2-inc-3-ali-a`.
+- Organizacionais têm path **namespaceado pelo nesting**: `tit-2`, `tit-2-cap-1`, `tit-2-cap-1-sec-3`.
+- Quando normativo está dentro de organizacional, path permanece global mas o nesting XML preserva o agrupamento. Não há duplicação de path.
+
+Adicionar novo tipo de dispositivo no futuro = adicionar entrada no token map. XSD não muda (path pattern é genérico).
+
+### 4.3 Herança de vigência
+
+Cadeia de resolução para `versao.em`:
+
+1. Se `<versao em="X">` declarado → usa X.
+2. Senão → herda do ancestral `<dispositivo>` mais próximo que tem uma `<versao>` com `em` declarado.
+3. Senão → herda da `<lei>.data-publicacao` extraída da URN.
+
+**`vigente-ate` não é armazenado**. Fim de uma versão é inferido por (em ordem):
+1. Próxima `<versao em="...">` no mesmo dispositivo.
+2. `<revogacao em="...">` filho do mesmo dispositivo.
+3. `<revogacao em="...">` filho da `<lei>` (cascateia para todos os dispositivos).
+4. Caso contrário → ainda vigente.
+
+Caso comum (lei pequena sem alterações, todo dispositivo herda):
 
 ```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
-<!-- ⚠️ Todos URN LEX nos exemplos são dialect provisório — ver §10 pendentes (verificar contra spec CGPID). -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:2003-06-15;1234">
-  <header>...</header>
-  <dispositivos>...</dispositivos>
-  <anotacoes>...</anotacoes>
+     urn-lex="urn:lex:br;estado:rondonia;lei:1999-06-15;9999"
+     vigente-em="2026-05-20">
+
+  <dispositivo path="ementa">
+    <versao>
+      <texto>Institui o Dia Estadual do Servidor Público.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-1">
+    <versao>
+      <texto>Fica instituído...</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+    </versao>
+  </dispositivo>
+
 </lei>
 ```
 
-### 4.2 `<header>` — metadados da lei
+Zero `em`, zero `vigente-ate`, zero ruído. Tudo herda.
+
+### 4.4 `<inicio>` — proveniência da vigência
+
+Sub-elemento opcional de `<versao>`. Carrega `tipo` enum + `<fonte>` filha(s) apontando para o IA item que materializa a prova.
 
 ```xml
-<!-- Header carrega APENAS metadados estruturais/bibliográficos.
-     Todo texto (título oficial, ementa, preâmbulo, articulação, anexos)
-     vive em <dispositivos> (§0.1). -->
-<header>
-  <ente>ro</ente>
-  <tipo>lei</tipo>
-  <numero>1234</numero>
-  <ano>2003</ano>
-  <data-publicacao>2003-06-15</data-publicacao>
-  <vigente-em>2026-05-20</vigente-em>
-  <revogada>false</revogada>
-</header>
-<!--
-  Semântica das datas:
-  - <vigente-em> (header) = data de referência da compilação. "Esta versão
-    do law.xml representa a lei como ela estava vigente em 2026-05-20."
-    Update sempre que reprocessar.
-  - <versao vigente-de="..." vigente-ate="..."> (dispositivo) = intervalo
-    de validade daquela redação específica do dispositivo. Não confundir.
--->
+<!-- Vacatio: lei publicada em 15/06, vigora 90 dias depois -->
+<versao em="2003-09-13">
+  <inicio tipo="vacatio-legis">
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+  </inicio>
+  <texto>...</texto>
+  <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+</versao>
+
+<!-- Inferência LLM (baixa confiança) -->
+<versao em="2015-03-15">
+  <inicio tipo="inferencia-llm">
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-07777"/>
+  </inicio>
+  <texto>...</texto>
+  <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-07777"/>
+</versao>
+
+<!-- Consolidacao sem prova textual no ato original -->
+<versao em="2010-01-01">
+  <inicio tipo="consolidacao">
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-03333"/>
+  </inicio>
+  <texto>...</texto>
+  <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-03333"/>
+</versao>
 ```
 
-### 4.3 `<dispositivos>` — corpo dispositivo-cêntrico
+**Defaults implícitos** (`<inicio>` omitido):
+- Primeira versão (sem `alterado-por`) com `em` herdado da `<lei>` → `tipo = data-publicacao`.
+- Versão com `alterado-por` → `tipo = texto-lei-alteradora`.
 
-Cada dispositivo carrega sua própria **timeline de versões**. Nested para hierarquia.
+**Obrigatório** quando: `em` declarado, `em ≠ data-publicacao` da lei, e sem `alterado-por`. Consistency checker (§7) valida.
 
-**Regra do caput (Opção D — aprovada)**: caput não é elemento separado nem tipo. Todo `<dispositivo>` normativo container (artigo, parágrafo, inciso) carrega `<texto>` na sua própria `<versao>` — isso **é** o caput quando o dispositivo tem filhos. Conceitualmente o caput é o "índice 0" dos filhos do container. Implica:
+### 4.5 `<revogacao>` — evento estruturado
 
-- **Sem `<dispositivo tipo="caput">`**. Caput é propriedade implícita do container normativo. `caput` **não está** no enum de `tipo_dispositivo` (§3.1).
-- **URN aponta para o container**: `urn:lex:...!art-5` resolve para o texto intrínseco (caput) do art-5. Sub-itens via `!art-5!par-1`, etc.
-- **Versionamento granular preservado**: alterar só o caput = nova `<versao>` no próprio `<dispositivo path="art-5">`. Alterar só o §1 = nova `<versao>` em `<dispositivo path="art-5-par-1">`. Independentes.
-- **Aplica recursivamente**: parágrafo com incisos também tem "caput" (seu próprio texto antes dos incisos), mesma regra.
-- **Parquet `dispositivos`**: 1 row por dispositivo. A row do container **é** o caput. Não há row extra "caput".
-- **Export LexML** (XSLT): wrap mecânico — `<dispositivo path="art-5"><versoes><versao><texto>{T}</texto></versao></versoes>...` vira `<Artigo><Caput><Texto>{T}</Texto></Caput>...</Artigo>`.
+Posição estrutural indica escopo:
+
+**Revogação total da lei** (no root, antes de `<dispositivo>`):
 
 ```xml
-<!-- Exemplo cobrindo: título-lei + ementa + preâmbulo + blocos organizacionais
-     + articulação + anexo. Tudo é <dispositivo>; tipo discrimina o papel. -->
-<dispositivos>
-
-  <dispositivo tipo="titulo-lei" path="titulo-lei" parent=""
-               urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!titulo-lei">
-    <rotulo>Título</rotulo>
-    <versoes>
-      <versao numero="1" vigente-de="2003-06-15">
-        <texto>LEI Nº 1.234, DE 15 DE JUNHO DE 2003</texto>
-        <fonte-canonica>casacivil</fonte-canonica>
-        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
-      </versao>
-    </versoes>
-  </dispositivo>
-
-  <dispositivo tipo="ementa" path="ementa" parent="">
-    <rotulo>Ementa</rotulo>
-    <versoes>
-      <versao numero="1" vigente-de="2003-06-15">
-        <texto>Dispõe sobre a organização administrativa do Estado de Rondônia.</texto>
-        <fonte-canonica>casacivil</fonte-canonica>
-        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
-      </versao>
-    </versoes>
-  </dispositivo>
-
-  <dispositivo tipo="preambulo" path="preambulo" parent="">
-    <rotulo>Preâmbulo</rotulo>
-    <versoes>
-      <versao numero="1" vigente-de="2003-06-15">
-        <texto>O GOVERNADOR DO ESTADO DE RONDÔNIA faço saber...</texto>
-        <fonte-canonica>casacivil</fonte-canonica>
-        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
-      </versao>
-    </versoes>
-  </dispositivo>
-
-  <!-- Bloco organizacional: tem <rotulo> versionável, NÃO tem <texto> nas versões -->
-  <dispositivo tipo="titulo" path="tit-1" parent="">
-    <rotulo>TÍTULO I — Dos Princípios Fundamentais</rotulo>
-    <versoes>
-      <!-- Bloco pode ter versão se rotulo mudar; sem <texto> -->
-      <versao numero="1" vigente-de="2003-06-15">
-        <rotulo>TÍTULO I — Dos Princípios Fundamentais</rotulo>
-        <fonte-canonica>casacivil</fonte-canonica>
-      </versao>
-    </versoes>
-
-    <dispositivo tipo="capitulo" path="tit-1-cap-1" parent="tit-1">
-      <rotulo>CAPÍTULO I — Disposições Preliminares</rotulo>
-      <versoes>
-        <versao numero="1" vigente-de="2003-06-15">
-          <rotulo>CAPÍTULO I — Disposições Preliminares</rotulo>
-          <fonte-canonica>casacivil</fonte-canonica>
-        </versao>
-      </versoes>
-
-      <!-- Path do artigo permanece GLOBAL (art-1), não tit-1-cap-1-art-1.
-           parent="tit-1-cap-1" declara o nesting. Citação "art. 1º" = lookup
-           direto por path. -->
-      <dispositivo tipo="artigo" path="art-1" parent="tit-1-cap-1"
-                   urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-1">
-        <rotulo>Art. 1º</rotulo>
-        <versoes>
-          <versao numero="1" vigente-de="2003-06-15" vigente-ate="2024-07-30"
-                  alterado-por="urn:lex:br;estado:rondonia;lei:2024-06-30;5678">
-            <texto>Esta Lei dispõe sobre...</texto>     <!-- caput do art-1 -->
-            <fonte-canonica>casacivil</fonte-canonica>
-            <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
-            <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
-          </versao>
-          <versao numero="2" vigente-de="2024-07-30">
-            <texto>Esta Lei dispõe sobre (redação dada pela Lei 5.678/2024)...</texto>
-            <fonte-canonica>casacivil</fonte-canonica>
-            <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00187"/>
-          </versao>
-        </versoes>
-
-        <dispositivo tipo="paragrafo" path="art-1-par-1" parent="art-1"
-                     urn="urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-1!par-1">
-          <rotulo>§ 1º</rotulo>
-          <versoes>
-            <versao numero="1" vigente-de="2003-06-15">
-              <texto>...</texto>                          <!-- caput do § -->
-              <fonte-canonica>casacivil</fonte-canonica>
-              <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
-            </versao>
-          </versoes>
-        </dispositivo>
-      </dispositivo>
-    </dispositivo>
-  </dispositivo>
-
-  <dispositivo tipo="anexo" path="anexo-1" parent="">
-    <rotulo>ANEXO I — Tabela de Cargos</rotulo>
-    <versoes>
-      <versao numero="1" vigente-de="2003-06-15">
-        <texto>... conteúdo do anexo (estrutura interna em v0.2) ...</texto>
-        <fonte-canonica>casacivil</fonte-canonica>
-        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
-      </versao>
-    </versoes>
-  </dispositivo>
-
-</dispositivos>
+<lei urn-lex="..." vigente-em="..." schema-version="0.1">
+  <revogacao em="2025-01-01" tipo="expressa"
+             por="urn:lex:br;estado:rondonia;lei:2024-12-01;9999">
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+  </revogacao>
+  <dispositivo path="...">...</dispositivo>
+</lei>
 ```
 
-**Regras (todas obrigatórias)**:
-
-1. **`parent` attribute obrigatório** em todo `<dispositivo>`. Raiz: `parent=""`.
-2. **`<versoes>` obrigatório** com **no mínimo 1 `<versao>`** (a original). Sem exceção. Blocos organizacionais têm `<versao>` carregando só `<rotulo>` (sem `<texto>`); normativos têm `<texto>` (e opcionalmente `<rotulo>` override).
-3. **Path do dispositivo normativo é GLOBAL** (`art-5`, `art-5-par-1`, `art-5-par-1-inc-1`, `art-5-par-1-inc-1-ali-a`). Não namespaceia por bloco organizacional acima. Citação forense ("art. 5º") = lookup literal.
-4. **Path do dispositivo organizacional namespaceia internamente** (`tit-1`, `tit-1-cap-1`, `tit-1-cap-1-sec-2`, `liv-2-tit-3-cap-1`). Hierarquia de blocos namespaceia o próprio bloco; normativos contidos não herdam o prefix. Token map: `liv-N` (livro), `parte-N` (parte), `tit-N` (titulo), `cap-N` (capitulo), `sec-N` (secao), `subsec-N` (subsecao), `anexo-N` (anexo). Numeração sequential dentro do parent.
-5. **Caput é implícito (índice 0)**: container normativo (`artigo`, `paragrafo`, `inciso`) carrega seu próprio `<texto>` no nível do container; filhos `<dispositivo>` são sub-itens. Sem `<dispositivo tipo="caput">`. Ver detalhes abaixo.
-
-**Mapping nesting XML ↔ `dispositivo_path` flat na tabela Parquet `versoes`** (§3.1): geração determinística do path. Frontend e ETL usam o **mesmo gerador** (`src/leizilla/leizilla_xml/path.py` em M3).
-
-```
-TÍTULO I  >  CAPÍTULO I  >  Art. 1º  >  § 1º  >  inciso I  >  alínea a
-  tit-1     tit-1-cap-1     art-1     art-1-par-1   art-1-par-1-inc-1   art-1-par-1-inc-1-ali-a
-  (org)       (org)         (norm)     (norm)         (norm)               (norm)
-```
-
-**Outras regras de versão**:
-- `vigente-ate` ausente = ainda vigente.
-- `alterado-por` aponta para URN da lei alteradora (não para versão específica).
-- Hierarquia via nesting XML + `parent` attribute (redundância intencional para validação cruzada).
-
-### 4.4 Fallback: `<bloco-livre>` para OCR ruim
-
-Se o LLM não conseguir estruturar dispositivos:
+**Revogação parcial** (dentro de um `<dispositivo>`, depois das `<versao>`s e dos sub-dispositivos):
 
 ```xml
-<dispositivos>
-  <bloco-livre quality="low">
-    <p>...texto OCR cru, possivelmente fragmentado...</p>
-  </bloco-livre>
-</dispositivos>
+<dispositivo path="art-5">
+  <versao>
+    <texto>...</texto>
+    <fonte ia-id="..."/>
+  </versao>
+  <revogacao em="2020-01-01" tipo="expressa"
+             por="urn:lex:br;estado:rondonia;lei:2020-01-01;9999">
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+  </revogacao>
+</dispositivo>
 ```
 
-Atributo `quality` é extensível: `low` / `medium` / `high` / `raw` (reviewer #6 ponto 🟢). Frontend renderiza com banner "texto não estruturado".
-
-### 4.5 `<anotacoes>` — metadados de processamento
+**Inconstitucionalidade**:
 
 ```xml
-<anotacoes>
-  <divergencia
-      dispositivo-path="art-3-par-2"
-      versao-numero="1"
-      entre="casacivil,diario"
-      diff-xpath="/dispositivo/versoes/versao[@numero='1']/texto">
-    §2º está ausente em casacivil; presente em diario. Texto vigente
-    adotado de casacivil (consolidado oficial); inconsistência marcada
-    para verificação manual.
-  </divergencia>
-  <parse
-      method="llm-haiku"
-      model="claude-haiku-4-5-20251001"
-      confianca="0.92"
-      timestamp="2026-05-20T18:45:00Z"/>
-</anotacoes>
+<dispositivo path="art-7">
+  <versao>
+    <texto>...</texto>
+    <fonte ia-id="..."/>
+  </versao>
+  <revogacao em="2018-05-10" tipo="inconstitucionalidade"
+             por="urn:lex:br;federal;adi:2017-03-15;5678">
+    <fonte ia-id="leizilla-raw-federal-stf-adi-5678-2018"/>
+  </revogacao>
+</dispositivo>
 ```
 
-> **Confiança baixa exibida explicitamente**: reviewer #6 ponto 5. Frontend mostra banner no card de detalhe da lei se `confianca_parse < 0.8` ou `parse_method = "llm-*"`: "Este texto foi compilado por LLM a partir de OCR — para texto oficial, consulte: [links das fontes raw]".
+**Caducidade** (sem `por`):
 
-### 4.6 Stylesheet processing instruction
-
-Todo `law.xml` começa com:
 ```xml
-<?xml-stylesheet type="text/xsl" href="https://leizilla.org/render/0.1/lei.xsl"?>
+<dispositivo path="art-9">
+  <versao em="1990-01-01">
+    <texto>Esta Lei vigora por 5 anos a partir de sua publicação.</texto>
+    <fonte ia-id="..."/>
+  </versao>
+  <revogacao em="1995-01-01" tipo="caducidade">
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01111"/>
+  </revogacao>
+</dispositivo>
 ```
 
-Abrir o XML direto no browser exibe HTML (XSLT in-browser). **Não** é o caminho de renderização primário (esse é Astro SSR — reviewer #6 ponto 12). É fallback opcional.
+### 4.6 `<fonte>` — testemunhas
+
+Mesma tag em 4 contextos. Atributos:
+
+- `ia-id` (obrigatório): identifier do IA raw item.
+- `diverge` (opcional, só no contexto `<versao>`): `true` se esta fonte tem texto diferente do `<texto>` canônico. Carrega `<texto>` filho inline.
+
+```xml
+<versao em="2003-06-15">
+  <texto>Texto canônico estabelecido pelo ETL.</texto>
+  <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+  <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
+  <fonte ia-id="leizilla-raw-ro-assembleia-coddoc-01234" diverge="true">
+    <texto>Texto alternativo desta fonte que discorda.</texto>
+  </fonte>
+</versao>
+```
+
+Caso comum (uma ou várias fontes que concordam): só `<fonte ia-id="..."/>`. Sem `canonica`. Texto canônico está no `<texto>` da versão.
+
+### 4.7 OCR ruim — sem elemento especial
+
+OCR irrecuperável vira dispositivo regular com `path="ocr-ruim"` e atributo `quality`. Render mostra banner; sem `<bloco-livre>` separado no XSD.
+
+```xml
+<dispositivo path="ocr-ruim" quality="raw">
+  <versao>
+    <texto>LE| N° 42/8S - 20 DE NOVEMBR0 DE 19BS
+
+O G0VERNAD0R D0 ESTAD0 DE R0NDONIA, faç0 saber que a A55embleia Legislativa decret@ e eu sancion0 a seguinte Lei:
+
+Art. 1° Fica criad0 0 Conselh0 Estadual de Cultura...
+[trecho i|egível n0 OCR]
+Art. 4° Esta Lei entra em vigor na data de 5ua publicação.</texto>
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+  </versao>
+</dispositivo>
+```
+
+`quality` enum: `low` / `medium` / `high` / `raw`. Atributo só aparece quando `path == "ocr-ruim"` (consistency checker valida).
 
 ---
 
@@ -680,160 +618,147 @@ Abrir o XML direto no browser exibe HTML (XSLT in-browser). **Não** é o caminh
 ^leizilla-bundle-(?P<ente>[a-z][a-z0-9-]*)-(?P<fonte>[a-z]+)-(?P<periodo>\d{4}-W\d{2})$
 ```
 
-### 5.3 Parsed
-**Canônico**:
+### 5.3 Parsed canônico
 ```
 ^leizilla-(?P<ente>[a-z][a-z0-9-]*)-(?P<tipo>[a-z]+)-(?P<numero>\d{5,})-(?P<ano>\d{4})$
 ```
 
-> Reviewer #6 ponto 4 fix: `\d{5,}` em vez de `\d{5}` — leis federais já passam de 5 dígitos por extenso; zero-pad mínimo de 5 mantém ordenação lexicográfica para a maioria.
+`numero` em `id` é **sempre zero-padded** (mínimo 5 dígitos). Numero não-numérico (raro em leis antigas) → fallback pattern.
 
-> Codex P2 fix: o `lei_id` no Parquet (§3.1) **sempre** usa o `numero` zero-padded para bater com o IA identifier. Lookup `lei_id → IA item` é literal, sem normalização extra.
-
-**Numero não-numérico** (algumas leis antigas: "Lei A-12", romanos): tratar como caso de fallback. Não tentar normalizar para inteiro. O identifier vai para o pattern fallback abaixo, com `chave` derivado da fonte primária.
-
-**Fallback**:
+### 5.4 Parsed fallback
 ```
 ^leizilla-(?P<ente>[a-z][a-z0-9-]*)-(?P<tipo>[a-z]+)-fallback-(?P<fonte>[a-z]+)-(?P<chave>[a-z0-9-]+)$
 ```
 
-> Codex P1 fix: `{fonte}` é obrigatório no fallback, evitando colisão quando fontes diferentes compartilham `chave`.
+`{fonte}` obrigatório evita colisão entre fontes com mesma `chave`.
 
-### 5.4 Dataset
+### 5.5 Dataset
 ```
 ^leizilla-dataset-(?P<ente>[a-z][a-z0-9-]*)-v(?P<version>\d+)$
 ```
 
-### 5.5 URN LEX
+`v0` (pre-M5, schema_version "0.1") é válido e citável.
 
-> ⚠️ **Dialect provisório**: todos os exemplos URN abaixo (e em §4) usam separadores que ainda precisam ser validados contra a especificação oficial CGPID — ver §10. Se o dialect mudar, todos os exemplos do doc precisam refresh em PR único.
+### 5.6 URN LEX
 
-**Lei**: `urn:lex:br;{jurisdicao};lei:{YYYY-MM-DD};{numero}`
+**Lei**: `urn:lex:br;{jurisdicao};{tipo}:{YYYY-MM-DD};{numero}`
 - `{jurisdicao}` para estados: `estado:rondonia` / `estado:sao-paulo`
 - `{jurisdicao}` para federal: `federal`
 - `{jurisdicao}` para municípios: `municipio:rondonia;porto-velho`
 
-**Dispositivo**: `{urn-lei}!art-N` ou `{urn-lei}!art-N!par-M!inc-K!ali-L` (separador `!` cf. extensão LexML para sub-document addressing).
+**Dispositivo**: `{urn-lei}!{path}` — exemplo: `urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-5!par-2`.
 
-**Fallback URN quando `data_publicacao` desconhecida** (reviewer #6 ponto 3): `urn_lex` na coluna Parquet é nullable. Quando data não é extraível, gravar `NULL` (não falsificar). Identifier IA usa fallback `leizilla-{ente}-{tipo}-fallback-{fonte}-{chave}` (§5.3) que não depende de URN.
+**Constituição** (sem número): `urn:lex:br;federal;constituicao:1988-10-05` (sem `;numero` final).
 
-> **Pendente M0.2**: verificar contra a especificação oficial CGPID se o separador interno é `;`, `,` ou `:` em casos como `urn:lex:br;rondonia:estadual:lei,2003-06-15;1234`. Reviewer #6 sugeriu que CGPID usa vírgulas em alguns campos. Validar antes de cravar o exemplo.
+**Lei sem numero** (fallback): omitir o `;{numero}` final OU registrar `urn_lex` como NULL no Parquet. Identifier IA usa pattern fallback (§5.4).
 
-### 5.6 Slug `{ente}`
+> Dialect provisório — pendente verificação contra spec CGPID atual. Ver §8.
+
+### 5.7 Slug `{ente}`
 
 - União: `federal`
-- Estados: ISO 3166-2:BR sem `BR-`, lowercase: `ro`, `sp`, `mg`, `rj`...
+- Estados: ISO 3166-2:BR sem `BR-`, lowercase: `ro`, `sp`, `mg`...
 - Municípios: `{uf}-{slug-kebab}`: `ro-porto-velho`, `sp-sao-paulo`
 - DF: `df`
 
-Lista canônica em `src/leizilla/entes.py` (M1) com nome oficial, UF pai, código IBGE.
+Lista canônica em `src/leizilla/entes.py` (M1).
 
-### 5.7 Slug `{fonte}` — regra load-bearing
+### 5.8 Slug `{fonte}`
 
-`{fonte}` é token único `[a-z]+` — **sem hífens nem underscores**. Toda referência (IA identifier, `raw_meta.json.fonte`, `parsed_meta.json.fontes_consultadas[]`, atributo `<fonte-canonica>` em XML, coluna Parquet `fonte_canonica` e `versoes.fontes_consultadas`, enum `FONTES` Python) usa **exatamente o mesmo slug**.
+Token único `[a-z]+` (sem hífens, sem underscores). Hífen quebraria parsing de `leizilla-raw-{ente}-{fonte}-{chave}`. Slugs canônicos: `casacivil`, `diario`, `assembleia`, `planalto`, `camara`, `senado`, `stf`.
 
-Hífens quebrariam parsing de `leizilla-raw-{ente}-{fonte}-{chave}` (sem fronteira reconhecível). Nomes longos (`diário oficial`, `casa civil`) ficam em campos `display_name` / metadata IA legível.
-
-Slugs canônicos lockados: `casacivil`, `diario`, `assembleia`, `planalto`, `camara`, `senado`.
-
-**Slug `diario` cobre todo Diário Oficial** (estadual, municipal, federal/DOU). A distinção entre DO-RO e DOU é resolvida pelo `{ente}` no identifier: `leizilla-raw-ro-diario-...` vs `leizilla-raw-federal-diario-...`. O slug `{fonte}` é orientado a **tipo de fonte**, não a instituição específica.
+Display names longos (`Diário Oficial do Estado`) ficam em `display_name` / metadata IA legível, nunca no slug.
 
 ---
 
-## 6. Export LexML — gate de CI, não constraint estrutural
+## 6. Export LexML — gate de CI
 
-**Decisão (aprovada, pós-review #6)**: Leizilla XML é o formato canônico. LexML é gerado sob demanda como **representação reduzida** para gov interop.
+LexML é representação reduzida, gerada sob demanda para gov interop. Não é round-trip.
 
-**Perdas conhecidas no export** (documentadas no XSLT):
-- `<bloco-livre quality="low">` → vira `<Texto>` cru sem marcação.
-- `<anotacoes><divergencia>` e `<parse>` → descartados (não têm equivalente LexML).
-- Timeline `<versoes>` colapsa para `<TextoArticulado>` da versão vigente apenas; histórico vira `<Alteracao>` LexML quando possível.
-
-**Estratégia**:
-- XSLT `scripts/leizilla-to-lexml.xsl` realiza conversão.
-- CLI `uv run leizilla export-lexml --ia-id leizilla-ro-lei-01234-2003` gera `law.lexml` localmente.
-- **Não** uploadamos `law.lexml` ao IA por padrão. Sob demanda para release oficial: ZIP separado `leizilla-lexml-export-{ente}-{date}.zip`.
+**Perdas conhecidas** (documentadas no XSLT):
+- `quality="raw"` (OCR ruim) → vira `<Texto>` cru sem marcação.
+- `<fonte diverge="true">` → descartado (LexML não modela divergência multi-fonte).
+- Atributos `<inicio tipo>` e `<revogacao tipo>` → mapeados em LexML quando equivalente existe, descartados caso contrário.
+- Timeline `<versao>` colapsa para `<TextoArticulado>` da versão vigente em `vigente-em`; histórico mapeia para `<Alteracao>` LexML quando possível.
 
 **CI gate**:
 - A cada PR, `pytest tests/test_lexml_export.py`:
-  1. Pega 3 fixtures `tests/fixtures/leizilla_xml/`.
-  2. Aplica `leizilla-to-lexml.xsl`.
-  3. Valida XML contra XSD oficial LexML em `tests/fixtures/lexml.xsd` (bundle no repo — reviewer #6 ponto 6 + §9 resolvida: **bundle aprovada**).
-  4. Falha se LexML resultante não validar.
+  1. Lê fixtures `tests/fixtures/leizilla_xml/*.xml`.
+  2. Aplica `scripts/leizilla-to-lexml.xsl`.
+  3. Valida XML resultante contra `tests/fixtures/lexml.xsd` (bundle no repo, reprodutibilidade).
+  4. Falha se LexML não validar.
 
 CI **não** valida round-trip (LexML → Leizilla XML não é objetivo).
 
 ---
 
-## 7. Versionamento — regras de bump
+## 7. Invariantes do consistency checker
 
-| Coisa | Versão atual | Bump major em |
+XSD não consegue expressar tudo. `scripts/check_schema_consistency.py` (M0.2) valida:
+
+1. **`<fonte diverge="true">` requer `<texto>` filho**; `<fonte>` sem `diverge` não pode ter `<texto>` filho.
+2. **`<revogacao>` na raiz da `<lei>` exclui** qualquer `<revogacao>` em dispositivo descendente (revogação total cascateia).
+3. **`<revogacao tipo="caducidade">` não tem atributo `por`**; demais tipos têm.
+4. **`path` casa com token map** (§4.2). Tokens desconhecidos → erro.
+5. **Herança de vigência**: `<versao>` sem `em` resolve para ancestral declarado ou `data-publicacao` da URN.
+6. **`<inicio>` obrigatório** quando `<versao em="X">` com `X ≠ data-publicacao(<lei>)` e sem `alterado-por`.
+7. **Ordenação de versões** num dispositivo: `em` estritamente crescente.
+8. **`<fonte ia-id>`** casa com regex de IA identifier (§5.1).
+9. **`quality` atributo** só aparece em `<dispositivo path="ocr-ruim">`.
+10. **`urn-lex` da `<lei>`** (se presente) decompõe corretamente: ente, tipo, data, numero recuperados batem com o `id` do parsed item.
+11. **Exemplos no markdown** (`docs/SCHEMA.md`, `IMPLEMENTATION.md`) que aparentam ser IA identifiers casam com regex em §5.
+12. **`schema_version`** no XSD, no footer KV do Parquet, e no `schema-version` attribute do `<lei>` root concordam.
+
+---
+
+## 8. Decisões resolvidas / pendentes / abertas
+
+### 8.1 Resolvidas em M0.2 (este redesign)
+
+- ✅ **Dispositivo é unidade universal**; tipo, parent, urn, rotulo todos derivados.
+- ✅ **Vigência herda do pai**; `vigente-ate` é inferido, não armazenado.
+- ✅ **`<inicio>` com `tipo` enum + `<fonte>` filha** documenta proveniência da vigência.
+- ✅ **`<revogacao>` rica**: `em`, `por`, `tipo` enum, `<fonte>` filha; posição estrutural = escopo (total vs parcial).
+- ✅ **`<fonte>` é uma só** em 4 contextos; sem `canonica`; `diverge="true"` carrega texto inline.
+- ✅ **`<bloco-livre>` desaparece**: OCR ruim vira `<dispositivo path="ocr-ruim" quality="...">`.
+- ✅ **Processo (parse method, confiança, divergências detalhadas)** vai 100% para `parsed_meta.json`; XML carrega só estrutura normativa.
+- ✅ **Token map** é fonte única de verdade para tipo de dispositivo.
+- ✅ **Auditoria por embeddings raw vs parseado** substitui flags manuais de "revisão pendente".
+
+### 8.2 Pendentes (resolver em M0.3 antes de fechar M0)
+
+- [ ] **URN LEX dialect**: verificar contra spec CGPID atual se separadores são `;`/`,`/`:` em casos como `urn:lex:br;rondonia:estadual:lei,2003-06-15;1234`.
+- [ ] **Compressão Parquet**: SNAPPY vs ZSTD. Verificar suporte em DuckDB-WASM via benchmark real.
+- [ ] **Granularidade bundle ZIP**: semanal vs mensal — revisitar se tamanho ficar trivial em M2.
+- [ ] **Política de re-scrape**: PDF re-publicado pela fonte (hash diferente) vira `{chave}-r{N}`? Só sob auditoria, nunca automático.
+- [ ] **Robots.txt + rate limiting** como princípio explícito do crawler (ADR-0008 em M1).
+- [ ] **Estimativa real de custo LLM** após M2 expor casos reais.
+
+### 8.3 Open questions (v0.2+)
+
+- **Catálogo de fontes federais** (Câmara, Senado, Planalto, DOU) — modelo acomoda, vocabulário concreto quando atacarmos `ente=federal`.
+- **Catálogo de fontes municipais** — 5.570 estruturas distintas; modelo escala, curadoria é desafio próprio.
+- **Auditoria por embeddings** detalhada em plano separado (M3+).
+
+---
+
+## 9. Migração desde a v1 do schema (PR #6/#7)
+
+| v1 (PR #6/#7) | v2 (este PR) | Razão |
 |---|---|---|
-| Leizilla XML | `0.1` | mudança incompatível no schema XSD |
-| Parquet schema | `0.1` (vira `1` em M5) | coluna removida ou tipo breaking |
-| Sidecar JSON | `0.1` | campo obrigatório add/remove |
-| `leizilla` CLI | `1.0` (após M5) | breaking em subcomandos |
+| `<header>` com `<ente>`, `<tipo>`, `<numero>`, `<ano>`, `<data-publicacao>`, `<vigente-em>`, `<revogada>` | Atributos do root `<lei>` (`urn-lex`, `vigente-em`); revogada vira `<revogacao>` elemento; o resto é derivado da URN | Header inteiro era 90% derivável da URN LEX |
+| `<rotulo>` armazenado | Derivado de `(tipo, path)` via token map em render-time | Apresentação, não dado |
+| `<rotulo_versao>` para override | Eliminado | Cai junto com `<rotulo>` |
+| Atributo `tipo` no dispositivo | Derivado do `path` via token map | Redundante |
+| Atributo `parent` no dispositivo | Nesting XML é o parent | Duplicação = bug surface |
+| Atributo `urn` no dispositivo | `lei.urn-lex + "!" + path` em render-time | Derivado |
+| `<versoes>` wrapper | `<versao>` filha direta de `<dispositivo>` | XML-academic |
+| `<versao numero="N">` | `<versao em="...">` (data é chave natural) | Mais self-documenting |
+| `<fonte-canonica>` elemento separado + `<fonte>` lista | `<fonte>` única tag; texto canônico está em `<texto>` da versão | "Fonte canônica" não existe — texto canônico existe |
+| `<anotacoes>` no XML (`<divergencia>`, `<parse>`) | Vai para `parsed_meta.json` sidecar | Processo, não conteúdo |
+| `<bloco-livre>` elemento separado | `<dispositivo path="ocr-ruim" quality="...">` | Tudo é dispositivo |
+| `<revogada>true/false</revogada>` | `<revogacao em="..." por="..." tipo="...">` com `<fonte>` filha | Revogação é evento estruturado |
+| `vigente-de` / `vigente-ate` em toda versão | Herança implícita; `em` só onde difere; `vigente-ate` é inferido | Caso comum não declara nada |
+| Flag manual de auditoria/revisão | Auditoria por embeddings (sistema externo) | LLM não sabe quando errou |
 
-CI: ao bumpar major, `web/src/schemas/v{N}/` precisa existir + ser referenciado em `web/src/lib/queries.ts`. Build quebra se faltar.
-
----
-
-## 8. Inspirações dos sister projects
-
-### Da ficha
-- ZIP de raw bulk (§1.2) ← ficha mirror dos 37 ZIPs RFB.
-- Parquet como camada canônica ← ficha tem `cnpjs.parquet`, `socios.parquet`. Nossa `versoes-{ente}-v{N}.parquet` segue mesma filosofia (single table denormalizada por grain, ver §3).
-- Footer KV `schema_version` ← ficha embute; replicamos em §3.4.
-
-### Da baliza
-- Manifest CSV no IA como source of truth ← baliza usa `baliza-pncp-manifest/manifest.csv`. Nossa `manifest-{ente}.csv` segue mesma estrutura.
-
-### Da causaganha
-- Sync manifest por `(tribunal, date)` ← rastreio granular. Nossa rastreia `(ente, fonte, chave)`.
-
----
-
-## 9. Decisões resolvidas em M0 (rastreio)
-
-- ✅ **Granularidade IA raw**: individual por PDF (§1.1) + bundle ZIP semanal redundante (§1.2).
-- ✅ **Slug fonte é `[a-z]+` único** (§5.7).
-- ✅ **Bundle `lexml.xsd` no repo** (§6) — reprodutibilidade.
-- ✅ **`git_sha` SHA completo (40 chars)** (§3.4).
-- ✅ **Regex parsed aceita `\d{5,}`** (§5.3).
-- ✅ **Tipo Parquet usa `VARCHAR`** (§3.1), não `TEXT`.
-- ✅ **Fallback parsed inclui `{fonte}`** (§5.3).
-- ✅ **`lei_id` Parquet sempre zero-padded** (§3.1).
-- ✅ **Dispositivo é unidade primária** (§0.1).
-- ✅ **Vigente compilado é canônico, histórico via timeline** (§0.2).
-- ✅ **Formato próprio (Leizilla XML), não fork LexML** (§0.3).
-- ✅ **SSR híbrido via Astro** (§0.4), softening do princípio 6 anterior.
-- ✅ **`urn_lex` Parquet é nullable** (§5.5).
-- ✅ **Schema Parquet é v0.1 durante M0–M4; promove a v1 em M5** (§3.5, §7).
-- ✅ **Single table `versoes` (denormalizada)** (§3) — substitui 3 tabelas relacionais. Decisão revisitável em M5 com dados reais.
-- ✅ **Caput é índice 0 implícito** (§4.3) — Opção D: container carrega `<versoes>` próprio; sem `<dispositivo tipo="caput">` separado. Aplica recursivamente a todos containers.
-- ✅ **Wayback Machine como caminho primário de fetch** (§0.5) — buffer/CDN entre nós e a fonte; fail-open para fallback de download direto.
-- ✅ **LGPD: leis publicadas, sem despublicação** — Leis estaduais e federais são atos públicos (CF art. 5º LX, art. 84 IV, art. 37 caput). LGPD (Lei 13.709/2018) não autoriza despublicação de norma pública e não está acima da Constituição. Citação de pessoas físicas em leis antigas (nomeações, aposentadorias, concessões) faz parte do ato administrativo público — indexar e republicar é continuidade do ato original, não tratamento novo. Documentar em ADR-0009 (Claude routines + ética) em M1.
-- ✅ **Custo LLM diluído no tempo** — estimativa de ~$40–100/ente (5k leis × 10k tokens × Haiku) é aceitável; ingestão é one-shot por lei, custo amortiza. Re-parsing pontual em fill-gaps é marginal. Não é fator de bloqueio do design.
-- ✅ **Re-scrape sob auditoria** — re-scrape NÃO é automático. Disparado só quando auditoria periódica conclui que qualidade do raw caiu (e.g., versão do PDF foi corrigida pela fonte, ou OCR muito ruim). Quando re-scrape acontece, novo raw item vira `{chave}-r{N}` (revisão); raw anterior permanece (imutabilidade §0.X). Documentado como processo em IMPLEMENTATION.md (auditoria periódica de qualidade).
-- ✅ **Auditoria de novas fontes por ente** — processo paralelo à re-scrape: auditoria periódica avalia se novas fontes oficiais devem ser adicionadas ao `src/leizilla/fontes/{ente}.py` (e.g., descobrir que estado X tem um portal de transparência que reúne consolidados). Não bloqueia M0.
-- ✅ **Dispositivo é unidade universal de texto** (§0.1) — `tipo` enum cobre normativos (titulo-lei, ementa, preambulo, artigo, paragrafo, inciso, alinea, item, anexo, disposicao-*) e organizacionais (livro, parte, titulo, capitulo, secao, subsecao). Tudo que é texto da lei é `<dispositivo>`. Header carrega só metadados bibliográficos.
-- ✅ **Path do dispositivo normativo é global** (§4.3 regra 3) — `art-5` permanece `art-5` independente do bloco. Citação forense direta.
-- ✅ **Parent attribute obrigatório** (§0.1) — todo `<dispositivo>` declara `parent="..."`. Raiz: `parent=""`. Redundante com nesting XML mas explicitude força clareza e permite validação cruzada.
-- ✅ **Sem `eh_bloco` column** — redundante com `tipo`. Filtros via `texto IS NOT NULL` (normativos) ou `tipo IN (...)`.
-
-## 10. Decisões pendentes (resolver em M0.2)
-
-- [ ] **Verificar URN LEX dialect** (§5.5) — separadores `;`/`,`/`:` contra spec CGPID atual.
-- [ ] **Compressão Parquet**: SNAPPY vs ZSTD. Verificar DuckDB-WASM 1.28 (ou versão atual) suporta ZSTD via teste real em M0.2.
-- [ ] **Granularidade bundle ZIP**: semanal (`YYYY-Www`) atual; revisitar se tamanho ficar trivial.
-- [ ] **XPath dialect em `diff-xpath`** (§4.5) — declarar "XPath 1.0 subset, atributos com aspas simples" (reviewer #6 ponto 9).
-- [ ] **Robots.txt + rate limiting** como princípio explícito no crawler (reviewer #6 ponto 12) — adicionar em ADR-0008 (pipeline) e `src/leizilla/crawler.py`. Nota: com §0.5 (Wayback como fetch primário), bater na fonte original fica raro — robots.txt continua valendo, rate-limit do nosso crawler vira proteção do Wayback save endpoint (15 req/min sem auth, 100 com SavePageNow).
-- [ ] **XSLT in-browser deprecation** (reviewer #6 ponto 4) — confirmar que primário é Astro SSR, XSLT é fallback opcional. Atualizar §4.6 se Astro SSR cobrir 100%.
-
-## 11. Open questions (v0.2 ou posterior)
-
-- **Catálogo de fontes federais** (Câmara, Senado, Planalto, DOU) — modelagem em §0.6 acomoda, mas vocabulário concreto fica para quando atacarmos `ente=federal`.
-- **Catálogo de fontes municipais** — ~5.570 estruturas distintas; modelo `src/leizilla/fontes/{ente}.py` escala, mas curadoria é desafio próprio.
-- **Versionamento de raw quando fonte republica** (overlap com §10) — política mais fina depois.
-- **Acessibilidade WCAG completa** — Astro SSR resolve maior parte; auditoria formal em M5.
-- **Multilíngua** — fora de escopo Leizilla.
+**Status do PR #7**: superseded. Fica como referência histórica do design v1.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -402,7 +402,7 @@ Path determina tipo. Token map é a fonte única de verdade.
 | `anexo-N` | anexo | "Anexo N" (romanos) |
 | `disp-transitoria-N` | disposicao-transitoria | "Art. N (Disposições Transitórias)" |
 | `disp-final-N` | disposicao-final | "Art. N (Disposições Finais)" |
-| `ocr-ruim` | bloco-ocr-ruim | (sem rótulo; render mostra banner) |
+| `ocr-ruim` ou `ocr-ruim-N` | bloco-ocr-ruim | (sem rótulo; render mostra banner) |
 
 **Tokens organizacionais** (agrupadores; texto = nome do bloco):
 
@@ -420,6 +420,7 @@ Path determina tipo. Token map é a fonte única de verdade.
 - Sub-dispositivos normativos compõem o path do ancestral normativo: `art-5-par-2`, `art-5-par-2-inc-3`, `art-5-par-2-inc-3-ali-a`.
 - Organizacionais têm path **namespaceado pelo nesting**: `tit-2`, `tit-2-cap-1`, `tit-2-cap-1-sec-3`.
 - Quando normativo está dentro de organizacional, path permanece global mas o nesting XML preserva o agrupamento. Não há duplicação de path.
+- **Renumeração por emenda** (e.g., "Art. 5º-A" inserido por emenda entre art. 5 e art. 6): path usa sufixo letra → `art-5-a`. Token map mapeia `art-N` e `art-N-X` (X = letra) para tipo `artigo` com rótulo derivado "Art. Nº" ou "Art. Nº-X". Validação real desse padrão fica para M3 quando expusermos leis com emendas.
 
 Adicionar novo tipo de dispositivo no futuro = adicionar entrada no token map. XSD não muda (path pattern é genérico).
 
@@ -602,7 +603,9 @@ Art. 4° Esta Lei entra em vigor na data de 5ua publicação.</texto>
 </dispositivo>
 ```
 
-`quality` enum: `low` / `medium` / `high` / `raw`. Atributo só aparece quando `path == "ocr-ruim"` (consistency checker valida).
+`quality` enum: `low` / `medium` / `high` / `raw`. Atributo só aparece quando `path` começa com `ocr-ruim` (consistency checker valida).
+
+**Múltiplos blocos OCR-ruim**: quando uma lei tem várias seções ilegíveis intercaladas com dispositivos parseados, usar `path="ocr-ruim-1"`, `path="ocr-ruim-2"`, ... — token `ocr-ruim-N` é parte do token map (§4.2). Path único na árvore continua sendo invariante (`xs:unique` no XSD).
 
 ---
 
@@ -704,10 +707,12 @@ XSD não consegue expressar tudo. `scripts/check_schema_consistency.py` (M0.2) v
 6. **`<inicio>` obrigatório** quando `<versao em="X">` com `X ≠ data-publicacao(<lei>)` e sem `alterado-por`.
 7. **Ordenação de versões** num dispositivo: `em` estritamente crescente.
 8. **`<fonte ia-id>`** casa com regex de IA identifier (§5.1).
-9. **`quality` atributo** só aparece em `<dispositivo path="ocr-ruim">`.
-10. **`urn-lex` da `<lei>`** (se presente) decompõe corretamente: ente, tipo, data, numero recuperados batem com o `id` do parsed item.
+9. **`quality` atributo** só aparece em `<dispositivo>` com `path` começando por `ocr-ruim`.
+10. **`urn-lex` da `<lei>`** (se presente) decompõe corretamente: ente, tipo, data, numero recuperados batem com o `id` do parsed item. **`urn-lex` ausente**: ente e tipo recuperados via decomposição do `id` do parsed item (regex §5.3 ou §5.4), e a fonte canônica de identidade vira o IA identifier.
 11. **Exemplos no markdown** (`docs/SCHEMA.md`, `IMPLEMENTATION.md`) que aparentam ser IA identifiers casam com regex em §5.
 12. **`schema_version`** no XSD, no footer KV do Parquet, e no `schema-version` attribute do `<lei>` root concordam.
+13. **Path único** em toda a árvore de dispositivos da lei (validado pelo `xs:unique` no XSD; checker confirma como duplo-check).
+14. **URN LEX sem zero-pad**: número da lei na URN é o número legal raw (`;1234`, `;42`). Zero-pad é exclusivo do identifier IA (`leizilla-ro-lei-00042-1985`); checker rejeita URNs com `;0+\d+` quando o número subjacente tem &lt; 5 dígitos.
 
 ---
 

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -60,7 +60,7 @@
         Jurisdição aceita 1 ou 2 segmentos (federal/estadual usam 1; municipal
         usa 2: municipio:UF;slug). Bang-path opcional referencia dispositivos.
       -->
-      <xs:pattern value="urn:lex:br;([^;]+;)?[^;]+;[^;]+:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9-]+)*"/>
+      <xs:pattern value="urn:lex:br;([^;]+;)?[^;]+;[^;]+:\d{4}-\d{2}-\d{2}(;[^!;]+)?(![a-z0-9-]+)*"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -23,6 +23,7 @@
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="https://leizilla.org/lei/0.1"
+           xmlns:leizilla="https://leizilla.org/lei/0.1"
            targetNamespace="https://leizilla.org/lei/0.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
@@ -55,7 +56,11 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="urn:lex:br;[^;]+;[^;]+:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9-]+)*"/>
+      <!--
+        Jurisdição aceita 1 ou 2 segmentos (federal/estadual usam 1; municipal
+        usa 2: municipio:UF;slug). Bang-path opcional referencia dispositivos.
+      -->
+      <xs:pattern value="urn:lex:br;([^;]+;)?[^;]+;[^;]+:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9-]+)*"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -230,6 +235,15 @@
       <xs:attribute name="urn-lex" type="UrnLex" use="optional"/>
       <xs:attribute name="vigente-em" type="xs:date" use="required"/>
     </xs:complexType>
+
+    <!--
+      Path do dispositivo é identificador lógico (deriva urn_dispositivo,
+      versao_id). Deve ser único em toda a árvore de dispositivos da lei.
+    -->
+    <xs:unique name="dispositivoPathUnique">
+      <xs:selector xpath=".//leizilla:dispositivo"/>
+      <xs:field xpath="@path"/>
+    </xs:unique>
   </xs:element>
 
 </xs:schema>

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Leizilla XML v0.1 — schema canônico (redesign first-principles).
+
+  Premissas load-bearing (ver docs/SCHEMA.md §0):
+
+  - Lei = árvore de dispositivos. Dispositivo = árvore de dispositivos +
+    linha do tempo de redações. Redação = texto + testemunhos (fontes).
+  - Tipo do dispositivo deriva do path via token map (SCHEMA.md §4.2).
+    XSD não conhece o token map; pattern de path é genérico.
+  - Vigência herda do pai (ancestral dispositivo, depois data-publicacao
+    da URN). vigente-ate não é armazenado — é inferido.
+  - A tag fonte é única em 4 contextos (versao, inicio, revogacao na
+    lei, revogacao no dispositivo). Atributo diverge só faz sentido
+    em versao; consistency checker valida.
+  - Atributo quality só faz sentido quando path=ocr-ruim;
+    consistency checker valida.
+  - Processo de parse (método LLM, confiança, divergências detalhadas)
+    vai para parsed_meta.json sidecar — não está no XML.
+
+  Invariantes não-expressáveis em XSD ficam no consistency checker
+  (scripts/check_schema_consistency.py, M0.2). Ver SCHEMA.md §7.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="https://leizilla.org/lei/0.1"
+           targetNamespace="https://leizilla.org/lei/0.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="0.1">
+
+  <!-- ==================================================================
+       Tipos simples
+       ================================================================== -->
+
+  <xs:simpleType name="DispositivoPath">
+    <xs:annotation>
+      <xs:documentation>
+        Path do dispositivo. Tokens normativos globais (art-N, par-N,
+        inc-N, ali-X) ou organizacionais namespaceados (tit-N, cap-N,
+        sec-N). Pattern genérico — semântica é dada pelo token map e
+        validada pelo consistency checker.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z][a-z0-9-]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="UrnLex">
+    <xs:annotation>
+      <xs:documentation>
+        URN LEX (dialect provisório — ver SCHEMA.md secao 5.6 e 8).
+        Aceita lei (com numero), constituicao (sem numero), e
+        referencias a dispositivos via sufixo bang-path.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="urn:lex:br;[^;]+;[^;]+:\d{4}-\d{2}-\d{2}(;[^!]+)?(![a-z0-9-]+)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="IaId">
+    <xs:annotation>
+      <xs:documentation>
+        Identifier IA de raw item. Pattern casa com SCHEMA.md secao 5.1.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="leizilla-raw-[a-z][a-z0-9-]*-[a-z]+-[a-z0-9-]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="InicioTipo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="data-publicacao"/>
+      <xs:enumeration value="texto-lei-alteradora"/>
+      <xs:enumeration value="vacatio-legis"/>
+      <xs:enumeration value="consolidacao"/>
+      <xs:enumeration value="inferencia-llm"/>
+      <xs:enumeration value="decisao-judicial"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="RevogacaoTipo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="expressa"/>
+      <xs:enumeration value="tacita"/>
+      <xs:enumeration value="caducidade"/>
+      <xs:enumeration value="inconstitucionalidade"/>
+      <xs:enumeration value="nao-recepcao"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="OcrQuality">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="low"/>
+      <xs:enumeration value="medium"/>
+      <xs:enumeration value="high"/>
+      <xs:enumeration value="raw"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ==================================================================
+       Tipos complexos
+       ================================================================== -->
+
+  <xs:complexType name="FonteType">
+    <xs:annotation>
+      <xs:documentation>
+        Testemunha que aponta para um IA raw item. Em uma versao, pode
+        carregar elemento texto filho quando diverge=true. Em inicio e
+        revogacao, nunca tem texto filho (consistency checker).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="texto" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="ia-id" type="IaId" use="required"/>
+    <xs:attribute name="diverge" type="xs:boolean" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="InicioType">
+    <xs:annotation>
+      <xs:documentation>
+        Proveniencia da vigencia. Sub-elemento opcional de versao.
+        Obrigatorio quando em difere de data-publicacao da lei e
+        nao ha alterado-por (consistency checker valida).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="fonte" type="FonteType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="tipo" type="InicioTipo" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="RevogacaoType">
+    <xs:annotation>
+      <xs:documentation>
+        Evento de revogacao. Posicao estrutural indica escopo: filho
+        da lei = revogacao total; filho de dispositivo = revogacao
+        parcial. Consistency checker valida exclusividade (revogacao
+        total exclui parciais descendentes).
+
+        tipo=caducidade nao tem por (validado por consistency checker;
+        XSD permite ambos para nao engessar).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="fonte" type="FonteType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="em" type="xs:date" use="required"/>
+    <xs:attribute name="por" type="UrnLex" use="optional"/>
+    <xs:attribute name="tipo" type="RevogacaoTipo" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="VersaoType">
+    <xs:annotation>
+      <xs:documentation>
+        Uma redacao historica do dispositivo. em opcional — quando
+        omitido, herda do ancestral (consistency checker resolve).
+
+        Multiplas fontes sao permitidas (testemunhas multiplas).
+        Quando alguma fonte tem diverge=true, carrega elemento texto
+        proprio inline; o texto da versao e o canonico (compilacao
+        ETL).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="inicio" type="InicioType" minOccurs="0"/>
+      <xs:element name="texto" type="xs:string"/>
+      <xs:element name="fonte" type="FonteType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="em" type="xs:date" use="optional"/>
+    <xs:attribute name="alterado-por" type="UrnLex" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="DispositivoType">
+    <xs:annotation>
+      <xs:documentation>
+        Dispositivo recursivo. Tipo deriva do path via token map.
+
+        Cardinalidade:
+        - 1+ versao obrigatoria.
+        - 0+ dispositivo filhos (recursao).
+        - 0..1 revogacao (revogacao parcial deste dispositivo;
+          cascateia para descendentes).
+
+        Atributo quality so e semanticamente valido quando
+        path=ocr-ruim (consistency checker valida).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="versao" type="VersaoType" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="dispositivo" type="DispositivoType" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="revogacao" type="RevogacaoType" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="path" type="DispositivoPath" use="required"/>
+    <xs:attribute name="quality" type="OcrQuality" use="optional"/>
+  </xs:complexType>
+
+  <!-- ==================================================================
+       Elemento raiz
+       ================================================================== -->
+
+  <xs:element name="lei">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation>
+          Raiz do Leizilla XML.
+
+          - urn-lex opcional: ausente em fallbacks (lei sem data
+            extraivel).
+          - revogacao opcional na raiz: presenca = lei totalmente
+            revogada; exclui revogacao em dispositivos descendentes
+            (consistency checker valida).
+          - 1+ dispositivo filhos.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+        <xs:element name="revogacao" type="RevogacaoType" minOccurs="0"/>
+        <xs:element name="dispositivo" type="DispositivoType" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="schema-version" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="0.1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="urn-lex" type="UrnLex" use="optional"/>
+      <xs:attribute name="vigente-em" type="xs:date" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/tests/fixtures/leizilla_xml/README.md
+++ b/tests/fixtures/leizilla_xml/README.md
@@ -1,0 +1,57 @@
+# Fixtures Leizilla XML v0.1
+
+Casos de teste representativos do schema definido em
+`docs/schemas/leizilla-v0.1.xsd`. Cada fixture cobre um cenário distinto
+e exercita uma parte específica do design (ver `docs/SCHEMA.md`).
+
+## Matriz de cobertura
+
+| Arquivo | Cenário | Cobre |
+|---|---|---|
+| `simple.xml` | Lei pequena sem alterações, sem blocos organizacionais. | Caminho feliz: herança de vigência pura (zero `em`, zero `vigente-ate`). `<fonte>` única por versão. Tokens normativos básicos (`ementa`, `art-N`, `art-N-par-unico`). |
+| `with-alteracoes.xml` | Lei com múltiplas alterações + dispositivo inserido por lei posterior + divergência multi-fonte. | Versões com `em` + `alterado-por`. `<fonte diverge="true">` com `<texto>` filho inline. Prova explícita de `<inicio tipo="vacatio-legis">` num dispositivo. |
+| `with-blocos-organizacionais.xml` | CF/88 como exemplo pedagógico. | Path organizacional namespaceado (`tit-1`, `tit-2`, `tit-2-cap-1`) vs path normativo global (`art-1`, `art-5`) aninhado em blocos. URN LEX de constituição sem `;numero`. "Texto" do bloco organizacional é o nome do bloco. |
+| `with-revogacoes.xml` | Revogações parciais em todas as formas estruturadas. | 4 `<revogacao>` parciais: `expressa`, `inconstitucionalidade` (URN de ADI), `caducidade` (sem `por`), `tacita` (URN da lei posterior). |
+| `with-revogacao-total.xml` | Revogação total da lei. | `<revogacao>` no root, antes de `<dispositivo>`. Demonstra posição estrutural = escopo. |
+| `with-ocr-ruim.xml` | Fallback OCR irrecuperável. | `<dispositivo path="ocr-ruim" quality="raw">`. Lei sem `urn-lex` (data não-extraível). Convivência: ementa parseada + corpo ilegível na mesma lei. |
+
+## Como validar localmente
+
+XSD bem-formedness e validação contra fixtures:
+
+```bash
+# Bem-formedness do schema
+xmllint --noout docs/schemas/leizilla-v0.1.xsd
+
+# Validação de cada fixture contra o schema
+for f in tests/fixtures/leizilla_xml/*.xml; do
+  xmllint --noout --schema docs/schemas/leizilla-v0.1.xsd "$f"
+done
+```
+
+Ou via pytest (M0.2 — script ainda não escrito):
+
+```bash
+uv run pytest tests/test_leizilla_xml.py -v
+```
+
+## Convenções nas fixtures
+
+- **URN LEX em forma completa**: `urn:lex:br;{jurisdicao};{tipo}:{YYYY-MM-DD};{numero}` para leis ordinárias; sem `;numero` final para constituições. Dialect provisório — ver `docs/SCHEMA.md` §5.6 e §8.
+- **Datas históricas plausíveis** (Rondônia: leis pós-1981 quando o estado foi criado; CF/88 datada de 1988-10-05).
+- **`<fonte ia-id>`** segue `leizilla-raw-{ente}-{fonte}-{chave}` (SCHEMA.md §5.1). IA identifiers são exemplos sintéticos — não existem em IA real.
+- **Conteúdo textual** é fictício ou trecho público notório (CF/88 art. 1º, par. único). Leis fictícias usam numeração improvável (Lei 9.999/1999, Lei 1.234/2003, Lei 500/1990) para evitar confusão com leis reais existentes.
+- **OCR ruim** em `with-ocr-ruim.xml` simula erros comuns (0→0, 1→|, 5→5/S) presentes em PDFs digitalizados pré-2000.
+
+## O que estes fixtures NÃO cobrem (M0.3+)
+
+- Invariantes do consistency checker (§7 do SCHEMA.md) — `scripts/check_schema_consistency.py` pendente em M0.2.
+- Round-trip Leizilla XML → LexML — `scripts/leizilla-to-lexml.xsl` pendente em M0.2.
+- Negative test cases (XML inválido propositalmente para garantir que o validador pega) — pendente em M0.2.
+- Lei muito grande com 100+ dispositivos — performance/scaling fica para M4 benchmarks.
+
+## Histórico
+
+Versão atual (v2) é o redesign first-principles. A versão v1 foi proposta no PR #7 com modelagem dispositivo-cêntrica mas ainda carregando `<header>`, `<rotulo>`, atributo `tipo`/`parent`/`urn`, `<versoes>` wrapper, `<bloco-livre>` separado, etc. PR #7 está superseded — fica como referência histórica.
+
+Migração detalhada na tabela em `docs/SCHEMA.md` §9.

--- a/tests/fixtures/leizilla_xml/simple.xml
+++ b/tests/fixtures/leizilla_xml/simple.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture: caso comum — lei pequena sem alterações, sem blocos
+  organizacionais. Demonstra herança de vigência pura: nenhum
+  dispositivo declara `em`; todos herdam de data-publicacao
+  extraída da URN da <lei>.
+
+  Cobre:
+  - Tokens normativos: ementa, art-N, art-N-par-unico.
+  - <fonte> única por versão (caso típico: só Casa Civil disponível).
+  - Sem <inicio>, sem <revogacao>, sem `em`, sem `alterado-por`.
+  - Validação: deve passar xmllint contra o XSD com zero warnings.
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:1999-06-15;9999"
+     vigente-em="2026-05-20">
+
+  <dispositivo path="ementa">
+    <versao>
+      <texto>Institui o Dia Estadual do Servidor Público de Rondônia.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-1">
+    <versao>
+      <texto>Fica instituído o Dia Estadual do Servidor Público de Rondônia, a ser comemorado anualmente no dia 28 de outubro.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-2">
+    <versao>
+      <texto>O Poder Executivo poderá promover atividades alusivas à data, sem prejuízo do expediente normal das repartições públicas.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+    </versao>
+    <dispositivo path="art-2-par-unico">
+      <versao>
+        <texto>As atividades de que trata o caput observarão o calendário oficial do Estado.</texto>
+        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+      </versao>
+    </dispositivo>
+  </dispositivo>
+
+  <dispositivo path="art-3">
+    <versao>
+      <texto>Esta Lei entra em vigor na data de sua publicação.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+    </versao>
+  </dispositivo>
+
+</lei>

--- a/tests/fixtures/leizilla_xml/with-alteracoes.xml
+++ b/tests/fixtures/leizilla_xml/with-alteracoes.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture: lei com timeline de alterações + cross-source com divergência.
+
+  Cobre:
+  - Versão 1 herda `em` da lei (data-publicacao), sem declarar.
+  - Versão 2 e 3 declaram `em` + `alterado-por` (prova implícita
+    texto-lei-alteradora; <inicio> omitido).
+  - <fonte diverge="true"> com <texto> filho inline.
+  - Dispositivo inserido por lei posterior (par-1 só tem versão a
+    partir de 2018, com `em` declarado e `alterado-por`).
+  - Sub-dispositivo herdando vigência do pai mesmo quando o pai
+    tem múltiplas versões — par-1 não declara vigência das próprias
+    sub-redações.
+  - Versão com prova explícita de vacatio-legis (art-7).
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:2003-06-15;1234"
+     vigente-em="2026-05-20">
+
+  <dispositivo path="ementa">
+    <versao>
+      <texto>Dispõe sobre a organização administrativa do Estado de Rondônia.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-3">
+    <versao>
+      <texto>O Estado adotará política administrativa orientada pela eficiência e moralidade pública.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+      <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
+      <fonte ia-id="leizilla-raw-ro-assembleia-coddoc-01234" diverge="true">
+        <texto>O Estado adotará política administrativa orientada pela eficiência e moralidade.</texto>
+      </fonte>
+    </versao>
+    <versao em="2018-04-10" alterado-por="urn:lex:br;estado:rondonia;lei:2018-04-10;4321">
+      <texto>O Estado adotará política administrativa orientada pela eficiência, moralidade e transparência pública.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
+    </versao>
+    <versao em="2024-07-30" alterado-por="urn:lex:br;estado:rondonia;lei:2024-07-30;5678">
+      <texto>O Estado adotará política administrativa orientada pela eficiência, moralidade, transparência e governança digital.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-05678"/>
+    </versao>
+
+    <dispositivo path="art-3-par-1">
+      <versao em="2018-04-10" alterado-por="urn:lex:br;estado:rondonia;lei:2018-04-10;4321">
+        <texto>A transparência será assegurada por meio de portal eletrônico atualizado mensalmente.</texto>
+        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
+      </versao>
+    </dispositivo>
+  </dispositivo>
+
+  <dispositivo path="art-5">
+    <versao>
+      <texto>Os órgãos da administração direta funcionarão de acordo com regulamento próprio.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+      <fonte ia-id="leizilla-raw-ro-diario-2003-06-15-p0012"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-7">
+    <versao em="2003-09-13">
+      <inicio tipo="vacatio-legis">
+        <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+      </inicio>
+      <texto>Disposições sobre o regime de afastamento entrarão em vigor 90 dias após a publicação desta Lei.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+    </versao>
+  </dispositivo>
+
+</lei>

--- a/tests/fixtures/leizilla_xml/with-blocos-organizacionais.xml
+++ b/tests/fixtures/leizilla_xml/with-blocos-organizacionais.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture: blocos organizacionais (CF/88 como exemplo pedagógico).
+
+  Cobre:
+  - Path organizacional namespaceado: tit-1, tit-2, tit-2-cap-1.
+  - Path normativo global mesmo aninhado em organizacional:
+    art-1 dentro de tit-1, art-5 dentro de tit-2-cap-1.
+  - urn-lex de constituição sem ;numero final.
+  - vigente-em fora do intervalo de criação (mostra que a CF está
+    sendo lida como "vigente em 2026").
+  - "Texto" do bloco organizacional é o nome do bloco (sem
+    distinção entre texto normativo e nome de capítulo).
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;federal;constituicao:1988-10-05"
+     vigente-em="2026-05-20">
+
+  <dispositivo path="titulo-lei">
+    <versao>
+      <texto>CONSTITUIÇÃO DA REPÚBLICA FEDERATIVA DO BRASIL DE 1988</texto>
+      <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="preambulo">
+    <versao>
+      <texto>Nós, representantes do povo brasileiro, reunidos em Assembleia Nacional Constituinte para instituir um Estado Democrático, destinado a assegurar o exercício dos direitos sociais e individuais...</texto>
+      <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="tit-1">
+    <versao>
+      <texto>TÍTULO I — DOS PRINCÍPIOS FUNDAMENTAIS</texto>
+      <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+    </versao>
+
+    <dispositivo path="art-1">
+      <versao>
+        <texto>A República Federativa do Brasil, formada pela união indissolúvel dos Estados e Municípios e do Distrito Federal, constitui-se em Estado Democrático de Direito e tem como fundamentos:</texto>
+        <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+      </versao>
+
+      <dispositivo path="art-1-inc-1">
+        <versao>
+          <texto>a soberania;</texto>
+          <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+        </versao>
+      </dispositivo>
+
+      <dispositivo path="art-1-par-unico">
+        <versao>
+          <texto>Todo o poder emana do povo, que o exerce por meio de representantes eleitos ou diretamente, nos termos desta Constituição.</texto>
+          <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+        </versao>
+      </dispositivo>
+    </dispositivo>
+  </dispositivo>
+
+  <dispositivo path="tit-2">
+    <versao>
+      <texto>TÍTULO II — DOS DIREITOS E GARANTIAS FUNDAMENTAIS</texto>
+      <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+    </versao>
+
+    <dispositivo path="tit-2-cap-1">
+      <versao>
+        <texto>CAPÍTULO I — DOS DIREITOS E DEVERES INDIVIDUAIS E COLETIVOS</texto>
+        <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+      </versao>
+
+      <dispositivo path="art-5">
+        <versao>
+          <texto>Todos são iguais perante a lei, sem distinção de qualquer natureza, garantindo-se aos brasileiros e aos estrangeiros residentes no País a inviolabilidade do direito à vida, à liberdade, à igualdade, à segurança e à propriedade, nos termos seguintes:</texto>
+          <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+        </versao>
+      </dispositivo>
+    </dispositivo>
+  </dispositivo>
+
+  <dispositivo path="anexo-1">
+    <versao>
+      <texto>ANEXO I — Bandeira Nacional (descrição conforme Lei nº 5.700/1971).</texto>
+      <fonte ia-id="leizilla-raw-federal-planalto-constituicao-1988"/>
+    </versao>
+  </dispositivo>
+
+</lei>

--- a/tests/fixtures/leizilla_xml/with-ocr-ruim.xml
+++ b/tests/fixtures/leizilla_xml/with-ocr-ruim.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture: OCR irrecuperável.
+
+  Cobre:
+  - Dispositivo com path="ocr-ruim" e atributo quality="raw".
+  - Sem estruturação interna — todo o texto vai num único <texto>.
+  - Lei sem urn-lex (atributo opcional ausente): data extraível do
+    PDF era ambígua/ilegível, ETL decidiu não inferir.
+  - Demonstra que o fallback OCR-ruim convive com dispositivos
+    estruturados na mesma lei (ementa parseada + corpo ilegível).
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     vigente-em="2026-05-20">
+
+  <dispositivo path="ementa">
+    <versao>
+      <texto>Cria o Conselho Estadual de Cultura de Rondônia.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="ocr-ruim" quality="raw">
+    <versao>
+      <texto>LE| N° 42/8S - 20 DE NOVEMBR0 DE 19BS
+
+O G0VERNAD0R D0 ESTAD0 DE R0NDONIA, faç0 saber que a A55embleia Legislativa decret@ e eu sancion0 a seguinte Lei:
+
+Art. 1° Fica criad0 0 Conselh0 Estadual de Cultura, vincu|ado à Secretaria d3 Educação e Cultura, c0m as seguintes atribuiçõe5:
+
+I- pr0m0ver e incentivar 0 desenv0|vimento cu|tura| n0 Estad0;
+I| - rea|izar 5tudos e pesquisas s0bre questões cu|turais re|evantes;
+
+[trecho i|egível n0 OCR]
+
+Art. 4° Esta Lei entra em vigor na data de 5ua publicação.
+
+PA|ÁCIO D0 GOVERN0 - P0rto Vel|0/R0, 20 de n0vembr0 de 1985.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+    </versao>
+  </dispositivo>
+
+</lei>

--- a/tests/fixtures/leizilla_xml/with-revogacao-total.xml
+++ b/tests/fixtures/leizilla_xml/with-revogacao-total.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture: revogação TOTAL da lei.
+
+  Cobre:
+  - <revogacao> elemento filho da <lei> (não de dispositivo).
+  - Posição estrutural = escopo: revogação total cascateia para
+    todos os dispositivos.
+  - Consistency checker valida: revogação total exclui qualquer
+    <revogacao> em descendentes.
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:1985-11-20;0042"
+     vigente-em="2026-05-20">
+
+  <revogacao em="2018-12-30" tipo="expressa"
+             por="urn:lex:br;estado:rondonia;lei:2018-12-30;4500">
+    <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04500"/>
+  </revogacao>
+
+  <dispositivo path="ementa">
+    <versao>
+      <texto>Cria o Conselho Estadual de Cultura de Rondônia.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-1">
+    <versao>
+      <texto>Fica criado o Conselho Estadual de Cultura, vinculado à Secretaria de Educação e Cultura, com as seguintes atribuições.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-2">
+    <versao>
+      <texto>O Conselho será composto por 9 (nove) membros nomeados pelo Governador, com mandato de 4 (quatro) anos.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
+    </versao>
+  </dispositivo>
+
+</lei>

--- a/tests/fixtures/leizilla_xml/with-revogacao-total.xml
+++ b/tests/fixtures/leizilla_xml/with-revogacao-total.xml
@@ -11,7 +11,7 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:1985-11-20;0042"
+     urn-lex="urn:lex:br;estado:rondonia;lei:1985-11-20;42"
      vigente-em="2026-05-20">
 
   <revogacao em="2018-12-30" tipo="expressa"

--- a/tests/fixtures/leizilla_xml/with-revogacoes.xml
+++ b/tests/fixtures/leizilla_xml/with-revogacoes.xml
@@ -16,7 +16,7 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:1990-03-20;0500"
+     urn-lex="urn:lex:br;estado:rondonia;lei:1990-03-20;500"
      vigente-em="2026-05-20">
 
   <dispositivo path="ementa">

--- a/tests/fixtures/leizilla_xml/with-revogacoes.xml
+++ b/tests/fixtures/leizilla_xml/with-revogacoes.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture: revogações em todas as suas formas estruturadas.
+
+  Cobre:
+  - <revogacao> parcial (expressa) num dispositivo após a última versão.
+  - <revogacao> parcial por inconstitucionalidade (URN de ADI).
+  - <revogacao> parcial por caducidade (sem `por`, lei temporária).
+  - <revogacao> parcial tácita (URN da lei posterior incompatível).
+  - <fonte> filha em cada <revogacao> apontando para o IA item que
+    documenta o ato revocatório.
+
+  Não cobre revogação TOTAL da lei — está em with-revogacao-total.xml
+  (não criado aqui para manter a matriz em 5 fixtures; cenário coberto
+  estruturalmente no XSD via posicionamento de <revogacao> no root).
+-->
+<lei xmlns="https://leizilla.org/lei/0.1"
+     schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:1990-03-20;0500"
+     vigente-em="2026-05-20">
+
+  <dispositivo path="ementa">
+    <versao>
+      <texto>Dispõe sobre o regime jurídico dos servidores públicos do Estado de Rondônia.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-1">
+    <versao>
+      <texto>Esta Lei estabelece o regime jurídico dos servidores públicos do Estado de Rondônia.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </versao>
+  </dispositivo>
+
+  <dispositivo path="art-3">
+    <versao>
+      <texto>São direitos do servidor público: estabilidade após três anos de efetivo exercício, férias anuais remuneradas, e gratificação natalina.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </versao>
+    <revogacao em="2020-06-15" tipo="expressa"
+               por="urn:lex:br;estado:rondonia;lei:2020-06-15;9999">
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
+    </revogacao>
+  </dispositivo>
+
+  <dispositivo path="art-5">
+    <versao>
+      <texto>Os candidatos a cargo público deverão comprovar filiação a partido político, mediante atestado da respectiva agremiação.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </versao>
+    <revogacao em="2015-08-12" tipo="inconstitucionalidade"
+               por="urn:lex:br;federal;adi:2015-08-12;5234">
+      <fonte ia-id="leizilla-raw-federal-stf-adi-5234-2015"/>
+    </revogacao>
+  </dispositivo>
+
+  <dispositivo path="art-7">
+    <versao em="1990-03-20">
+      <texto>As disposições deste artigo vigorarão por 5 (cinco) anos a contar da publicação desta Lei, podendo ser prorrogadas por lei específica.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </versao>
+    <revogacao em="1995-03-20" tipo="caducidade">
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </revogacao>
+  </dispositivo>
+
+  <dispositivo path="art-9">
+    <versao>
+      <texto>Aplicam-se subsidiariamente as normas estaduais sobre licitação para contratação de serviços técnicos especializados.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </versao>
+    <revogacao em="2021-04-01" tipo="tacita"
+               por="urn:lex:br;federal;lei:2021-04-01;14133">
+      <fonte ia-id="leizilla-raw-federal-planalto-lei-14133-2021"/>
+    </revogacao>
+  </dispositivo>
+
+</lei>


### PR DESCRIPTION
## Summary

Redesign do Leizilla XML a partir do princípio **"dispositivo é a unidade básica"**. Substitui o design do PR #7 após auditoria first-principles revelar ~10 conceitos derivados ou redundantes no XSD anterior. PR #7 fica como referência histórica.

Conversa de design completa em #7 (a partir do comentário "tem várias coisas mal pensadas — talvez o correto seria repensar a partir de first principles").

## Modelagem final

```
<lei> [xmlns, schema-version, urn-lex, vigente-em]
  <revogacao>?              [em, por?, tipo]              ← total da lei
    <fonte/>+               [ia-id]
  <dispositivo>+ [path, quality?]
    <versao>+               [em?, alterado-por?]
      <inicio>?             [tipo]                         ← proveniência da vigência
        <fonte/>+           [ia-id]
      <texto/>
      <fonte/>+             [ia-id, diverge?]
        <texto/>?           (só quando diverge=true)
    <dispositivo>*          (recursivo)
    <revogacao>?            [em, por?, tipo]              ← parcial deste dispositivo
      <fonte/>+
```

6 elementos · ~10 atributos · 235 linhas de XSD.

## O que mudou vs #7

**Cai do XML** (derivado ou redundante):
- `<header>` (URN cobre ente/tipo/numero/ano/data)
- `<rotulo>`/`<rotulo_versao>` (derivados de `(tipo, path)` via token map)
- atributo `tipo` no dispositivo (deriva do `path`)
- atributo `parent` (nesting XML é o parent)
- atributo `urn` no dispositivo (deriva de `lei.urn + "!" + path`)
- `<versoes>` wrapper (`<versao>` filha direta)
- `<versao numero="N">` (data `em` é chave natural)
- `<fonte-canonica>` separado — "fonte canônica" não existe; existe texto canônico no `<texto>` da versão + fontes que corroboram ou divergem
- `<anotacoes>` no XML (processo de parse vai para `parsed_meta.json` sidecar)
- `<bloco-livre>` separado (OCR ruim vira `<dispositivo path="ocr-ruim" quality="raw">`)

**Entra no XML**:
- **Herança de vigência** implícita: `vigente-ate` é inferido; `em` herda do ancestral ou da `data-publicacao` da URN. Caso comum (lei pequena sem alterações) declara **zero** datas.
- **`<inicio tipo>`** documenta proveniência quando não-óbvia: `vacatio-legis`, `consolidacao`, `inferencia-llm`, `decisao-judicial`.
- **`<revogacao>`** como evento estruturado com 5 tipos jurídicos (`expressa`, `tacita`, `caducidade`, `inconstitucionalidade`, `nao-recepcao`). Posição estrutural = escopo (raiz = total; em dispositivo = parcial).
- **`<fonte>`** unificada em 4 contextos (versão, início, revogação na lei, revogação em dispositivo).

**Não há flag manual de "revisão pendente"** — auditoria por embeddings (plano paralelo M3+) compara `embedding(raw_djvu)` × `embedding(texto parseado)` por dispositivo para detectar drift automaticamente. LLM não sabe quando errou.

Tabela de migração completa em `docs/SCHEMA.md` §9.

## Fixtures (6 cenários, todos validam contra o XSD)

| Arquivo | Cobre |
|---|---|
| `simple.xml` | Caminho feliz: herança de vigência pura (zero `em`, zero `vigente-ate`). |
| `with-alteracoes.xml` | Timeline com 3 versões + `<fonte diverge="true">` + dispositivo inserido por lei posterior + `<inicio tipo="vacatio-legis">`. |
| `with-blocos-organizacionais.xml` | CF/88 — path organizacional namespaceado (`tit-2-cap-1`) vs path normativo global (`art-5` aninhado dentro de bloco). URN de constituição sem `;numero`. |
| `with-revogacoes.xml` | 4 revogações parciais: expressa, inconstitucionalidade (URN de ADI), caducidade (sem `por`), tácita. |
| `with-revogacao-total.xml` | `<revogacao>` na raiz da lei. |
| `with-ocr-ruim.xml` | `<dispositivo path="ocr-ruim" quality="raw">`. Lei sem `urn-lex` (data não-extraível). |

```bash
for f in tests/fixtures/leizilla_xml/*.xml; do
  xmllint --noout --schema docs/schemas/leizilla-v0.1.xsd "$f"
done
# 6 validates
```

## Test plan

- [ ] Reviewer confirma que os 6 fixtures cobrem todos os cenários previstos no SCHEMA.md §4.
- [ ] Reviewer aplica `xmllint --schema docs/schemas/leizilla-v0.1.xsd tests/fixtures/leizilla_xml/*.xml` e confirma que todos validam.
- [ ] Reviewer flagga atributos/elementos que o XSD permite mas deveriam ser proibidos (idealmente movidos para o consistency checker — ver §7).
- [ ] Reviewer confirma que a tabela de migração (§9) reflete fielmente o que sai e o que entra.

## O que falta para fechar M0.2

- [ ] `scripts/check_schema_consistency.py` validando as 12 invariantes de §7 (incluindo `<fonte diverge>` requer `<texto>`, revogação total exclui parciais, herança de vigência consistente, ordenação de versões, token map cobre todos os paths).
- [ ] `scripts/leizilla-to-lexml.xsl` + `tests/test_lexml_export.py` validando contra LexML XSD.
- [ ] Negative test cases (XML inválido proposital).
- [ ] Resolver §8.2: URN dialect contra CGPID, ZSTD vs SNAPPY, política re-scrape, robots.txt, custo LLM real.

Depois disso, M1 abre (package restructure + ADRs + `origem→ente` migration).

---

_Generated by [Claude Code](https://claude.ai/code/session_0142QrK5n2k4bAzS7F5Vb8RR)_