### PR TITLE
ci(M0.2): wire consistency checker + XSD validation

### DIFF
--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -1,0 +1,50 @@
+name: Schema Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/schemas/**"
+      - "tests/fixtures/leizilla_xml/**"
+      - "scripts/check_schema_consistency.py"
+      - "tests/test_schema_consistency.py"
+      - ".github/workflows/schema-validate.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install xmllint
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
+      - name: XSD bem-formado
+        run: xmllint --noout docs/schemas/leizilla-v0.1.xsd
+
+      - name: Fixtures validam contra XSD
+        run: |
+          set -e
+          for f in tests/fixtures/leizilla_xml/*.xml; do
+            xmllint --noout --schema docs/schemas/leizilla-v0.1.xsd "$f"
+          done
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Consistency checker (testes)
+        run: uv run pytest tests/test_schema_consistency.py -v
+
+      - name: Consistency checker contra fixtures
+        run: python3 scripts/check_schema_consistency.py tests/fixtures/leizilla_xml/*.xml

--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           set -e
           for f in tests/fixtures/leizilla_xml/*.xml; do
+            echo "Validando: $f"
             xmllint --noout --schema docs/schemas/leizilla-v0.1.xsd "$f"
           done
 
@@ -37,14 +38,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v1
-
-      - name: Install dependencies
-        run: uv sync --dev
-
-      - name: Consistency checker (testes)
-        run: uv run pytest tests/test_schema_consistency.py -v
-
       - name: Consistency checker contra fixtures
         run: python3 scripts/check_schema_consistency.py tests/fixtures/leizilla_xml/*.xml
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Consistency checker (testes)
+        run: pytest tests/test_schema_consistency.py -v

--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install xmllint
+        timeout-minutes: 3
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
       - name: XSD bem-formado

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -10,7 +10,7 @@
 |---|---|---|---|
 | **M0.1** — Documento vivo + SCHEMA.md design | 🟢 done | #6 | Aprovado em re-review; merged em main. |
 | **M0.2a** — Schema v1 (tentativa) | 🔴 superseded | #7 | XSD `header` + `rotulo` + `<bloco-livre>` + etc. Substituído pelo redesign first-principles. Fica como referência histórica. |
-| **M0.2b** — Redesign first-principles | 🟡 in-progress | TBD | Pivô: dispositivo é unidade, vigência herda, fonte é única tag, `<revogacao>` evento estruturado. SCHEMA.md reescrito + XSD enxuto (~235 linhas) + 6 fixtures cobrindo todos os cenários. Pendente: consistency checker, leizilla-to-lexml.xsl, test_lexml_export.py, resolver 6 pendentes §10. |
+| **M0.2b** — Redesign first-principles | 🟡 in-progress | #8 #9 | SCHEMA.md reescrito + XSD enxuto (~235 linhas) + 6 fixtures + consistency checker (PR #9 merged). Pendente: `leizilla-to-lexml.xsl`, wire CI, resolver pendentes §8.2. |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
@@ -298,7 +298,7 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 - [x] `tests/fixtures/leizilla_xml/README.md` com matriz de cobertura.
 - [x] **`scripts/check_schema_consistency.py`** validando 13 das 14 invariantes do SCHEMA.md §7 + a §7.15 (root é `<lei>`). Invariantes 11 (markdown self-check) e 12 (Parquet schema_version cross-artifact) ficam deferidas para quando o Parquet writer existir (M4+). + `tests/test_schema_consistency.py` com 79 testes (1 skipped quando rodando como root), cobrindo positives (6 fixtures), negativos (1+ por invariante), exit codes (0/1/2), token map edge cases, e xs:boolean variants.
 - [ ] `scripts/leizilla-to-lexml.xsl` + teste CI `tests/test_lexml_export.py` validando contra `tests/fixtures/lexml.xsd` (bundle no repo).
-- [ ] Wire `check_schema_consistency.py` no CI (rodar contra `tests/fixtures/leizilla_xml/*.xml` a cada PR).
+- [x] Wire `check_schema_consistency.py` no CI: `.github/workflows/schema-validate.yml` roda xmllint (XSD + fixtures) + pytest + checker contra fixtures a cada PR que toca `docs/schemas/`, `tests/fixtures/leizilla_xml/`, `scripts/check_schema_consistency.py`, ou `tests/test_schema_consistency.py`.
 - [ ] Resolver pendentes §8.2: URN dialect contra CGPID spec, compressão Parquet (SNAPPY vs ZSTD em DuckDB-WASM), granularidade bundle ZIP, política de re-scrape, robots.txt rate-limit, custo LLM real.
 
 **M0.3 — Inspirações concretas** (paralelo a M0.2):

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -10,7 +10,7 @@
 |---|---|---|---|
 | **M0.1** — Documento vivo + SCHEMA.md design | 🟢 done | #6 | Aprovado em re-review; merged em main. |
 | **M0.2a** — Schema v1 (tentativa) | 🔴 superseded | #7 | XSD `header` + `rotulo` + `<bloco-livre>` + etc. Substituído pelo redesign first-principles. Fica como referência histórica. |
-| **M0.2b** — Redesign first-principles | 🟡 in-progress | #8 #9 | SCHEMA.md reescrito + XSD enxuto (~235 linhas) + 6 fixtures + consistency checker (PR #9 merged). Pendente: `leizilla-to-lexml.xsl`, wire CI, resolver pendentes §8.2. |
+| **M0.2b** — Redesign first-principles | 🟡 in-progress | #8 #9 #10 | SCHEMA.md reescrito + XSD enxuto (~235 linhas) + 6 fixtures + consistency checker (PR #9 merged) + CI wire (PR #10). Pendente: `leizilla-to-lexml.xsl`, resolver pendentes §8.2. |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |


### PR DESCRIPTION
## Summary

Wire `check_schema_consistency.py` + XSD validation no CI — penúltimo bullet de M0.2.

Novo workflow `.github/workflows/schema-validate.yml` roda em push/PR no `main` quando alguém toca:
- `docs/schemas/**`
- `tests/fixtures/leizilla_xml/**`
- `scripts/check_schema_consistency.py`
- `tests/test_schema_consistency.py`
- o próprio workflow

Steps:
1. `xmllint --noout` no XSD (bem-formedness).
2. `xmllint --schema` contra cada fixture (XSD validation).
3. `uv run pytest tests/test_schema_consistency.py -v`.
4. `python3 scripts/check_schema_consistency.py` contra fixtures.

`paths:` filter mantém o workflow rápido — PR que mexe só em `src/` ou docs não-schema não dispara.

## Por que workflow separado (vs. estender `lint.yml`)

`lint.yml` cuida de código Python (ruff/mypy). Schema validation tem outro escopo (XSD, fixtures, invariantes) e dependência diferente (xmllint via apt). Separar mantém cada workflow focado, com triggers e paths próprios.

## Test plan

- [ ] Reviewer confirma que YAML é válido (já testei localmente com `python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Reviewer confirma que ao mergear, o workflow vai rodar e ficar verde — todos os steps já são exercitados localmente:

```bash
$ xmllint --noout docs/schemas/leizilla-v0.1.xsd            # ok
$ for f in tests/fixtures/leizilla_xml/*.xml; do
    xmllint --noout --schema docs/schemas/leizilla-v0.1.xsd "$f"
  done                                                        # 6 validates
$ uv run pytest tests/test_schema_consistency.py             # 82 passed, 1 skipped
$ python3 scripts/check_schema_consistency.py tests/fixtures/leizilla_xml/*.xml
OK — 6 arquivo(s) sem violações.
```

## O que falta pra fechar M0.2 (após este merge)

- [ ] `scripts/leizilla-to-lexml.xsl` + `tests/test_lexml_export.py` validando contra `tests/fixtures/lexml.xsd` — último bullet, próximo PR.
- [ ] Resolver pendentes §8.2 (URN dialect CGPID, ZSTD vs SNAPPY, política re-scrape, robots.txt, custo LLM).

Refs: M0.2b checklist em `IMPLEMENTATION.md`.

---

_Generated by [Claude Code](https://claude.ai/code/session_0142QrK5n2k4bAzS7F5Vb8RR)_