### PR TITLE
feat(M0.2): XSLT Leizilla→LexML + XSD oficial bundled

### DIFF
--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -8,8 +8,11 @@ on:
     paths:
       - "docs/schemas/**"
       - "tests/fixtures/leizilla_xml/**"
+      - "tests/fixtures/lexml/**"
       - "scripts/check_schema_consistency.py"
+      - "scripts/leizilla-to-lexml.xsl"
       - "tests/test_schema_consistency.py"
+      - "tests/test_lexml_export.py"
       - ".github/workflows/schema-validate.yml"
 
 jobs:
@@ -19,9 +22,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install xmllint
+      - name: Install xmllint + xsltproc
         timeout-minutes: 3
-        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils xsltproc
 
       - name: XSD bem-formado
         run: xmllint --noout docs/schemas/leizilla-v0.1.xsd
@@ -42,8 +45,31 @@ jobs:
       - name: Consistency checker contra fixtures
         run: python3 scripts/check_schema_consistency.py tests/fixtures/leizilla_xml/*.xml
 
+      - name: LexML XSD bundle bem-formado
+        run: |
+          set -e
+          for f in tests/fixtures/lexml/*.xsd; do
+            echo "Validando: $f"
+            xmllint --noout "$f"
+          done
+
+      - name: XSLT Leizilla→LexML bem-formado
+        run: xmllint --noout scripts/leizilla-to-lexml.xsl
+
+      - name: Smoke — XSLT produz LexML válido para cada fixture
+        run: |
+          set -e
+          for f in tests/fixtures/leizilla_xml/*.xml; do
+            echo "Convertendo + validando: $f"
+            xsltproc scripts/leizilla-to-lexml.xsl "$f" \
+              | xmllint --noout --schema tests/fixtures/lexml/lexml-br-rigido.xsd -
+          done
+
       - name: Install pytest
         run: pip install pytest
 
       - name: Consistency checker (testes)
         run: pytest tests/test_schema_consistency.py -v
+
+      - name: LexML export (testes)
+        run: pytest tests/test_lexml_export.py -v

--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -59,11 +59,25 @@ jobs:
       - name: Smoke — XSLT produz LexML válido para cada fixture
         run: |
           set -e
+          # output-dir tmpdir isola arquivos de anexo (fixtures com
+          # <dispositivo path="anexo-N"> geram arquivos separados).
+          tmp=$(mktemp -d)
           for f in tests/fixtures/leizilla_xml/*.xml; do
             echo "Convertendo + validando: $f"
-            xsltproc scripts/leizilla-to-lexml.xsl "$f" \
-              | xmllint --noout --schema tests/fixtures/lexml/lexml-br-rigido.xsd -
+            xsltproc --param output-dir "'$tmp'" \
+              scripts/leizilla-to-lexml.xsl "$f" \
+              > "$tmp/main.xml"
+            xmllint --noout --schema tests/fixtures/lexml/lexml-br-rigido.xsd \
+              "$tmp/main.xml"
+            # Validar quaisquer arquivos de anexo gerados.
+            for a in "$tmp"/anexo-*.lexml.xml; do
+              [ -f "$a" ] || continue
+              echo "  + validando anexo: $(basename $a)"
+              xmllint --noout --schema tests/fixtures/lexml/lexml-br-rigido.xsd "$a"
+              rm "$a"  # cleanup entre fixtures
+            done
           done
+          rm -rf "$tmp"
 
       - name: Install pytest
         run: pip install pytest

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -10,7 +10,7 @@
 |---|---|---|---|
 | **M0.1** — Documento vivo + SCHEMA.md design | 🟢 done | #6 | Aprovado em re-review; merged em main. |
 | **M0.2a** — Schema v1 (tentativa) | 🔴 superseded | #7 | XSD `header` + `rotulo` + `<bloco-livre>` + etc. Substituído pelo redesign first-principles. Fica como referência histórica. |
-| **M0.2b** — Redesign first-principles | 🟡 in-progress | #8 #9 #10 | SCHEMA.md reescrito + XSD enxuto (~235 linhas) + 6 fixtures + consistency checker (PR #9 merged) + CI wire (PR #10). Pendente: `leizilla-to-lexml.xsl`, resolver pendentes §8.2. |
+| **M0.2b** — Redesign first-principles | 🟡 in-progress | #8 #9 #10 #11 | SCHEMA.md reescrito + XSD enxuto + 6 fixtures + consistency checker + CI wire + XSLT Leizilla→LexML validado contra XSD oficial bundled (PR #11). Pendente: resolver pendentes §8.2. |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
@@ -71,6 +71,33 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-21 — XSLT Leizilla→LexML + XSD oficial bundled (PR #11)
+
+Último bullet de M0.2b. XSD oficial LexML brasileiro (`lexml-br-rigido.xsd` + dependências) recuperado de `https://projeto.lexml.gov.br/esquemas/` (a pasta índice está vazia mas arquivos individuais respondem 200). Bundle local em `tests/fixtures/lexml/` com:
+
+- `lexml-br-rigido.xsd` (versão rígida) + `lexml-base.xsd` (core).
+- `xml.xsd`, `xlink-href.xsd` — standards W3C.
+- `mathml2.xsd` — **stub local** (oficial tem ~50 arquivos; MathML em leis é raríssimo).
+- Patches nos `schemaLocation` pra apontar pros arquivos locais (offline-first).
+
+XSLT (`scripts/leizilla-to-lexml.xsl`, XSLT 1.0 via xsltproc) mapeia:
+- `<lei>` → `<LexML><Metadado><Identificacao URN/></Metadado><Norma/></LexML>`.
+- `<dispositivo path="ementa">` → `<ParteInicial><Ementa/></ParteInicial>`; idem titulo-lei → `<Epigrafe>`, preambulo → `<Preambulo>`.
+- `<dispositivo path="art-N">` → `<Artigo id="artN"><Rotulo/><Caput id="artN_cpt"><p/></Caput><Paragrafo/>*</Artigo>`.
+- Path nesting Leizilla → ID LexML: insere `_cpt` implícito para inciso direto, letter→pos para alíneas (a→1, b→2), `subsec→sub` (alias LexML idAgregador).
+- Organizacionais classificados pelo **último** token do path (`tit-2-cap-1` → `<Capitulo>`, não `<Titulo>`).
+
+Perdas conhecidas (documentadas no XSLT header e SCHEMA.md §6.2):
+- Timeline `<versao>`: colapsa para versão vigente única.
+- `<fonte diverge="true">` + texto divergente: descartado.
+- `<inicio tipo>`: descartado.
+- `<revogacao>` parcial: vira `situacao="revogado"` no Artigo.
+- `<revogacao>` total na lei: descartada (LexML `<Norma>` não tem attr `situacao`).
+- Anexos: descartados (LexML requer `<ReferenciaAnexo>` em documentos separados).
+- OCR ruim: já não existia no XML.
+
+CI gate: workflow `schema-validate.yml` agora inclui xsltproc + roda XSLT contra cada fixture e valida o LexML resultante. 10 testes pytest em `tests/test_lexml_export.py` (6 parametrizados + 4 smoke).
 
 ### 2026-05-20 — Qualidade de parse não vive no XML (revisão em #9)
 
@@ -297,7 +324,7 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 - [x] 6 fixtures cobrindo: caso simples (herança pura), alterações + divergência multi-fonte + vacatio, blocos organizacionais (CF/88), revogações parciais (4 tipos), revogação total da lei, OCR ruim.
 - [x] `tests/fixtures/leizilla_xml/README.md` com matriz de cobertura.
 - [x] **`scripts/check_schema_consistency.py`** validando 13 das 14 invariantes do SCHEMA.md §7 + a §7.15 (root é `<lei>`). Invariantes 11 (markdown self-check) e 12 (Parquet schema_version cross-artifact) ficam deferidas para quando o Parquet writer existir (M4+). + `tests/test_schema_consistency.py` com 79 testes (1 skipped quando rodando como root), cobrindo positives (6 fixtures), negativos (1+ por invariante), exit codes (0/1/2), token map edge cases, e xs:boolean variants.
-- [ ] `scripts/leizilla-to-lexml.xsl` + teste CI `tests/test_lexml_export.py` validando contra `tests/fixtures/lexml.xsd` (bundle no repo).
+- [x] `scripts/leizilla-to-lexml.xsl` + `tests/test_lexml_export.py` (10 testes pass) validando contra XSD oficial LexML brasileiro bundled em `tests/fixtures/lexml/` (lexml-br-rigido + lexml-base + xml + xlink-href + stub mathml2). Wired no workflow `schema-validate.yml`. Perdas conhecidas documentadas no XSLT header e em SCHEMA.md §6.2.
 - [x] Wire `check_schema_consistency.py` no CI: `.github/workflows/schema-validate.yml` roda xmllint (XSD + fixtures) + pytest + checker contra fixtures a cada PR que toca `docs/schemas/`, `tests/fixtures/leizilla_xml/`, `scripts/check_schema_consistency.py`, ou `tests/test_schema_consistency.py`.
 - [ ] Resolver pendentes §8.2: URN dialect contra CGPID spec, compressão Parquet (SNAPPY vs ZSTD em DuckDB-WASM), granularidade bundle ZIP, política de re-scrape, robots.txt rate-limit, custo LLM real.
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -722,6 +722,22 @@ Documentadas no XSLT:
 - Timeline `<versao>` colapsa para `<TextoArticulado>` da versão vigente em `vigente-em`; histórico mapeia para `<Alteracao>` LexML quando possível.
 - Texto cru de parse parcial (lei inteira em 1 dispositivo) → vira `<TextoArticulado>` com `<Caput>` único carregando o corpo.
 
+### 6.3 Suporte completo a Anexos (multi-document export)
+
+LexML modela anexos como documentos **separados** linkados via URN — não como conteúdo inline da `<Norma>`. Nosso XSLT respeita isso:
+
+- Documento principal: emite `<Anexos><ReferenciaAnexo AlvoURN="{lei.urn-lex}!anexo-N"/>...` dentro de `<Norma>`.
+- Cada anexo: gera arquivo separado `{output-dir}/anexo-N.lexml.xml` via EXSLT `exsl:document`. Contém `<LexML><Anexo><DocumentoGenerico><PartePrincipal><p>{texto}</p></PartePrincipal></DocumentoGenerico></Anexo></LexML>` com URN derivada `{lei.urn-lex}!anexo-N`.
+
+Invocação:
+```bash
+xsltproc --param output-dir "'/path/to/out'" \
+  scripts/leizilla-to-lexml.xsl law.xml > /path/to/out/main.xml
+# Produz: main.xml + anexo-1.lexml.xml + anexo-2.lexml.xml + ...
+```
+
+Param `output-dir` default `.` (cwd). Caller (CLI/ETL) deve isolar por lei.
+
 **CI gate**:
 - A cada PR, `pytest tests/test_lexml_export.py`:
   1. Lê fixtures `tests/fixtures/leizilla_xml/*.xml`.

--- a/scripts/leizilla-to-lexml.xsl
+++ b/scripts/leizilla-to-lexml.xsl
@@ -1,0 +1,550 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  leizilla-to-lexml.xsl — converte Leizilla XML v0.1 para LexML brasileiro v1.0.
+
+  Decisão estrutural (docs/SCHEMA.md §6):
+  LexML é representação reduzida gerada sob demanda. Não é round-trip.
+  Várias dimensões do Leizilla XML não têm equivalente LexML e são
+  descartadas ou colapsadas:
+
+  - Timeline <versao>: colapsamos para a versão vigente em <lei vigente-em="X">
+    (a versão onde X ∈ [versao.em, próximo terminator)). Histórico mapeia para
+    LexML <Alteracao> quando possível, mas a forma como LexML modela isso é
+    muito diferente — versões anteriores são DESCARTADAS por padrão neste XSLT.
+  - <fonte diverge="true"> + <texto> divergente: DESCARTADOS. LexML não modela
+    divergência multi-fonte.
+  - <inicio tipo>: DESCARTADO. LexML enactment/period attrs não mapeiam direto.
+  - <revogacao>: parcial vira `situacao="revogado"` no Artigo; total vira
+    `situacao="revogado"` no <Norma>. Tipo (expressa/tacita/inconstitucionalidade)
+    é descartado.
+  - <dispositivo path="ocr-ruim*">: DESCARTADO. LexML não tem fallback para
+    OCR não-estruturado. Lei só-ocr-ruim vira <Articulacao> vazia (XSD-inválido)
+    — política upstream (SCHEMA.md §4.7): leis assim não publicam parsed item.
+
+  Limitações desta versão:
+  - Apenas a versão vigente é exportada. Histórico, alterações e revogações
+    parciais ficam como atributos `situacao` quando aplicável.
+  - Não emite <Caput> próprio para artigos que só têm texto direto sem
+    parágrafos: emite <Caput><p>{texto}</p></Caput> sempre (LexML ArticleType
+    requer Caput obrigatório quando não há DispositivoGenerico).
+  - Tradução de rótulos é heurística baseada em path. Ver `format-rotulo` template.
+-->
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:lz="https://leizilla.org/lei/0.1"
+                xmlns="http://www.lexml.gov.br/1.0"
+                exclude-result-prefixes="lz">
+
+  <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+
+  <!-- ==================================================================
+       Root: <lei> → <LexML><Metadado/><Norma/></LexML>
+       ================================================================== -->
+
+  <xsl:template match="/lz:lei">
+    <LexML>
+      <Metadado>
+        <Identificacao>
+          <xsl:attribute name="URN">
+            <xsl:choose>
+              <xsl:when test="@urn-lex">
+                <xsl:value-of select="@urn-lex"/>
+              </xsl:when>
+              <!-- Fallback URN quando lei não tem urn-lex (caso parsed fallback). -->
+              <xsl:otherwise>
+                <xsl:text>urn:lex:br;leizilla;fallback:0000-00-00;0</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:attribute>
+        </Identificacao>
+      </Metadado>
+      <Norma>
+        <!-- Revogação total da lei: LexML não tem atributo 'situacao' no
+             elemento <Norma>. A informação fica perdida no export. Para
+             gov interop, lei totalmente revogada provavelmente não seria
+             enviada via LexML (vai como documento separado). Documentado
+             em SCHEMA.md §6.2. -->
+        <xsl:call-template name="parte-inicial"/>
+        <Articulacao>
+          <xsl:apply-templates select="lz:dispositivo" mode="articulacao"/>
+        </Articulacao>
+      </Norma>
+    </LexML>
+  </xsl:template>
+
+  <!-- ==================================================================
+       <ParteInicial>: junta titulo-lei/ementa/preambulo (se presentes)
+       ================================================================== -->
+
+  <xsl:template name="parte-inicial">
+    <xsl:variable name="titulo" select="lz:dispositivo[@path='titulo-lei']"/>
+    <xsl:variable name="ementa" select="lz:dispositivo[@path='ementa']"/>
+    <xsl:variable name="preambulo" select="lz:dispositivo[@path='preambulo']"/>
+    <xsl:if test="$titulo or $ementa or $preambulo">
+      <ParteInicial>
+        <xsl:if test="$titulo">
+          <Epigrafe id="epi1">
+            <xsl:value-of select="$titulo/lz:versao[last()]/lz:texto"/>
+          </Epigrafe>
+        </xsl:if>
+        <xsl:if test="$ementa">
+          <Ementa id="ementa1">
+            <xsl:value-of select="$ementa/lz:versao[last()]/lz:texto"/>
+          </Ementa>
+        </xsl:if>
+        <xsl:if test="$preambulo">
+          <Preambulo id="pre1">
+            <p>
+              <xsl:value-of select="$preambulo/lz:versao[last()]/lz:texto"/>
+            </p>
+          </Preambulo>
+        </xsl:if>
+      </ParteInicial>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- ==================================================================
+       Articulacao: ignora titulo-lei/ementa/preambulo (já em ParteInicial),
+       ignora ocr-ruim* (LexML não modela), emite o resto.
+       ================================================================== -->
+
+  <xsl:template match="lz:dispositivo" mode="articulacao">
+    <xsl:choose>
+      <xsl:when test="@path='titulo-lei' or @path='ementa' or @path='preambulo'"/>
+      <xsl:when test="starts-with(@path, 'ocr-ruim')"/>
+      <xsl:when test="starts-with(@path, 'art-')">
+        <xsl:call-template name="emit-artigo"/>
+      </xsl:when>
+      <!-- Organizacionais: classificar pelo ÚLTIMO token do path
+           (path organizacional é namespaceado: tit-2-cap-1-sec-3 →
+           última especialização vence). Ordem mais específico → menos. -->
+      <xsl:when test="contains(@path, '-subsec-') or starts-with(@path, 'subsec-')">
+        <xsl:call-template name="emit-organizacional">
+          <xsl:with-param name="elem-name">Subsecao</xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(@path, '-sec-') or starts-with(@path, 'sec-')">
+        <xsl:call-template name="emit-organizacional">
+          <xsl:with-param name="elem-name">Secao</xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(@path, '-cap-') or starts-with(@path, 'cap-')">
+        <xsl:call-template name="emit-organizacional">
+          <xsl:with-param name="elem-name">Capitulo</xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(@path, '-tit-') or starts-with(@path, 'tit-')">
+        <xsl:call-template name="emit-organizacional">
+          <xsl:with-param name="elem-name">Titulo</xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(@path, '-liv-') or starts-with(@path, 'liv-')">
+        <xsl:call-template name="emit-organizacional">
+          <xsl:with-param name="elem-name">Livro</xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(@path, '-parte-') or starts-with(@path, 'parte-')">
+        <xsl:call-template name="emit-organizacional">
+          <xsl:with-param name="elem-name">Parte</xsl:with-param>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="starts-with(@path, 'anexo-')">
+        <!-- LexML modela anexos como ReferenciaAnexo em <Anexos>, não dentro
+             de <Articulacao>. Suporte completo requer documento separado
+             linkado. DESCARTADO neste XSLT — perda documentada. -->
+      </xsl:when>
+      <xsl:when test="starts-with(@path, 'disp-transitoria-')
+                      or starts-with(@path, 'disp-final-')">
+        <!-- Disposições transitórias/finais são artigos do ponto de vista
+             jurídico, mas geralmente em <ParteFinal>. Aqui emitimos como
+             Artigo regular dentro de Articulacao (perda: contexto temporal). -->
+        <xsl:call-template name="emit-artigo"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- Token não mapeado: skip silenciosamente. Consistency checker
+             do Leizilla XML já garante que path é válido; aqui é guard
+             contra evolução futura do token map. -->
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- ==================================================================
+       Artigo
+       ================================================================== -->
+
+  <xsl:template name="emit-artigo">
+    <Artigo>
+      <xsl:attribute name="id">
+        <xsl:call-template name="path-to-id"/>
+      </xsl:attribute>
+      <xsl:if test="lz:revogacao">
+        <xsl:attribute name="situacao">revogado</xsl:attribute>
+      </xsl:if>
+      <Rotulo>
+        <xsl:call-template name="rotulo-artigo"/>
+      </Rotulo>
+      <Caput>
+        <xsl:attribute name="id">
+          <xsl:call-template name="path-to-id"/>
+          <xsl:text>_cpt</xsl:text>
+        </xsl:attribute>
+        <p>
+          <xsl:value-of select="lz:versao[last()]/lz:texto"/>
+        </p>
+        <!-- Incisos diretos no caput (sem parágrafo) -->
+        <xsl:apply-templates select="lz:dispositivo[starts-with(@path, concat(current()/@path, '-inc-'))]"
+                             mode="inciso"/>
+      </Caput>
+      <!-- Parágrafos do artigo -->
+      <xsl:apply-templates select="lz:dispositivo[contains(@path, '-par-')
+                                                  and not(contains(substring-after(@path, '-par-'), '-'))]"
+                           mode="paragrafo"/>
+    </Artigo>
+  </xsl:template>
+
+  <!-- ==================================================================
+       Parágrafo
+       ================================================================== -->
+
+  <xsl:template match="lz:dispositivo" mode="paragrafo">
+    <Paragrafo>
+      <xsl:attribute name="id">
+        <xsl:call-template name="path-to-id"/>
+      </xsl:attribute>
+      <xsl:if test="lz:revogacao">
+        <xsl:attribute name="situacao">revogado</xsl:attribute>
+      </xsl:if>
+      <Rotulo>
+        <xsl:call-template name="rotulo-paragrafo"/>
+      </Rotulo>
+      <p>
+        <xsl:value-of select="lz:versao[last()]/lz:texto"/>
+      </p>
+      <xsl:apply-templates select="lz:dispositivo[contains(@path, '-inc-')]"
+                           mode="inciso"/>
+    </Paragrafo>
+  </xsl:template>
+
+  <!-- ==================================================================
+       Inciso / Alinea / Item
+       ================================================================== -->
+
+  <xsl:template match="lz:dispositivo" mode="inciso">
+    <Inciso>
+      <xsl:attribute name="id">
+        <xsl:call-template name="path-to-id"/>
+      </xsl:attribute>
+      <Rotulo>
+        <xsl:call-template name="rotulo-inciso"/>
+      </Rotulo>
+      <p><xsl:value-of select="lz:versao[last()]/lz:texto"/></p>
+      <xsl:apply-templates select="lz:dispositivo[contains(@path, '-ali-')]"
+                           mode="alinea"/>
+    </Inciso>
+  </xsl:template>
+
+  <xsl:template match="lz:dispositivo" mode="alinea">
+    <Alinea>
+      <xsl:attribute name="id">
+        <xsl:call-template name="path-to-id"/>
+      </xsl:attribute>
+      <Rotulo>
+        <xsl:value-of select="substring-after(@path, 'ali-')"/>
+        <xsl:text>)</xsl:text>
+      </Rotulo>
+      <p><xsl:value-of select="lz:versao[last()]/lz:texto"/></p>
+      <xsl:apply-templates select="lz:dispositivo[contains(@path, '-item-')]"
+                           mode="item"/>
+    </Alinea>
+  </xsl:template>
+
+  <xsl:template match="lz:dispositivo" mode="item">
+    <Item>
+      <xsl:attribute name="id">
+        <xsl:call-template name="path-to-id"/>
+      </xsl:attribute>
+      <Rotulo>
+        <xsl:value-of select="substring-after(@path, 'item-')"/>
+      </Rotulo>
+      <p><xsl:value-of select="lz:versao[last()]/lz:texto"/></p>
+    </Item>
+  </xsl:template>
+
+  <!-- ==================================================================
+       Organizacionais (Livro / Titulo / Capitulo / Secao / Subsecao / Parte)
+       ================================================================== -->
+
+  <xsl:template name="emit-organizacional">
+    <xsl:param name="elem-name"/>
+    <xsl:element name="{$elem-name}" namespace="http://www.lexml.gov.br/1.0">
+      <xsl:attribute name="id">
+        <xsl:call-template name="path-to-id-organizacional"/>
+      </xsl:attribute>
+      <Rotulo>
+        <xsl:value-of select="lz:versao[last()]/lz:texto"/>
+      </Rotulo>
+      <xsl:apply-templates select="lz:dispositivo" mode="articulacao"/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- ==================================================================
+       Helpers: rotulos derivados de path
+       ================================================================== -->
+
+  <xsl:template name="rotulo-artigo">
+    <!-- art-N → "Art. Nº" (ordinal 1º-9º; Nº a partir de 10).
+         LexML rotulo é livre, então emitimos "Art. N" simples. -->
+    <xsl:text>Art. </xsl:text>
+    <xsl:value-of select="substring-after(@path, 'art-')"/>
+  </xsl:template>
+
+  <xsl:template name="rotulo-paragrafo">
+    <xsl:variable name="last-par" select="substring-after(@path, '-par-')"/>
+    <xsl:choose>
+      <xsl:when test="$last-par='unico'">
+        <xsl:text>Parágrafo único</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>§ </xsl:text>
+        <xsl:value-of select="$last-par"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="rotulo-inciso">
+    <!-- Simples: emite o número arábico. Idealmente seria romano, mas
+         XSLT 1.0 não tem function de número→roman builtin. Refinamento. -->
+    <xsl:value-of select="substring-after(@path, '-inc-')"/>
+  </xsl:template>
+
+  <!-- ==================================================================
+       Helper: path → id LexML (substitui hífens entre tokens por _).
+       art-5-par-2-inc-3-ali-a → art5_par2_inc3_ali3
+       Mas LexML id pattern não permite letras em ali — precisa converter
+       a→1, b→2 etc. Simplificação: aceitamos perda aqui (refinamento).
+       ================================================================== -->
+
+  <xsl:template name="path-to-id">
+    <!--
+      Leizilla path → LexML idArtigo.
+
+      Casos:
+        art-N           → artN
+        art-N-X         → artN-X (renumeração letras; pattern aceita)
+        art-N-par-M     → artN_parM
+        art-N-par-unico → artN_par1u
+        art-N-inc-K     → artN_cpt_incK  (insere _cpt implícito!)
+        art-N-par-M-inc-K → artN_parM_incK
+        art-N-..-inc-K-ali-X → ..._incK_aliP(X)  (X=letra → P=posição: a→1, b→2)
+        art-N-..-ali-X-item-L → ..._aliP_iteL
+
+      LexML pattern: art{N}(_cpt|_par{M})_inc{K}_ali{P}_ite{L}
+    -->
+    <xsl:variable name="path" select="@path"/>
+
+    <!-- art-N or art-N-X -->
+    <xsl:variable name="art-num">
+      <xsl:choose>
+        <xsl:when test="contains(substring-after($path, 'art-'), '-')">
+          <xsl:value-of select="substring-before(substring-after($path, 'art-'), '-')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="substring-after($path, 'art-')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:text>art</xsl:text>
+    <xsl:value-of select="$art-num"/>
+
+    <!-- Componentes opcionais -->
+    <xsl:variable name="after-art" select="substring-after($path, concat('art-', $art-num, '-'))"/>
+    <xsl:if test="$after-art != ''">
+      <xsl:call-template name="emit-id-componentes">
+        <xsl:with-param name="tail" select="$after-art"/>
+        <xsl:with-param name="has-par">false</xsl:with-param>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="emit-id-componentes">
+    <!-- Processa cauda do path: par-M, inc-K, ali-X, item-L sequenciais. -->
+    <xsl:param name="tail"/>
+    <xsl:param name="has-par"/>
+    <xsl:choose>
+      <xsl:when test="starts-with($tail, 'par-')">
+        <xsl:variable name="par-val">
+          <xsl:choose>
+            <xsl:when test="contains(substring-after($tail, 'par-'), '-')">
+              <xsl:value-of select="substring-before(substring-after($tail, 'par-'), '-')"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="substring-after($tail, 'par-')"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:text>_par</xsl:text>
+        <xsl:choose>
+          <xsl:when test="$par-val='unico'">1u</xsl:when>
+          <xsl:otherwise><xsl:value-of select="$par-val"/></xsl:otherwise>
+        </xsl:choose>
+        <xsl:variable name="rest" select="substring-after($tail, concat('par-', $par-val))"/>
+        <xsl:if test="$rest != ''">
+          <xsl:call-template name="emit-id-componentes">
+            <xsl:with-param name="tail" select="substring($rest, 2)"/>
+            <xsl:with-param name="has-par">true</xsl:with-param>
+          </xsl:call-template>
+        </xsl:if>
+      </xsl:when>
+      <xsl:when test="starts-with($tail, 'inc-')">
+        <!-- Inciso direto em artigo (sem par) → precisa _cpt antes. -->
+        <xsl:if test="$has-par = 'false'">
+          <xsl:text>_cpt</xsl:text>
+        </xsl:if>
+        <xsl:variable name="inc-num">
+          <xsl:choose>
+            <xsl:when test="contains(substring-after($tail, 'inc-'), '-')">
+              <xsl:value-of select="substring-before(substring-after($tail, 'inc-'), '-')"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="substring-after($tail, 'inc-')"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:text>_inc</xsl:text>
+        <xsl:value-of select="$inc-num"/>
+        <xsl:variable name="rest" select="substring-after($tail, concat('inc-', $inc-num))"/>
+        <xsl:if test="$rest != ''">
+          <xsl:call-template name="emit-id-componentes">
+            <xsl:with-param name="tail" select="substring($rest, 2)"/>
+            <xsl:with-param name="has-par">true</xsl:with-param>
+          </xsl:call-template>
+        </xsl:if>
+      </xsl:when>
+      <xsl:when test="starts-with($tail, 'ali-')">
+        <xsl:variable name="letter" select="substring($tail, 5, 1)"/>
+        <xsl:variable name="pos">
+          <xsl:call-template name="letter-to-pos">
+            <xsl:with-param name="letter" select="$letter"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:text>_ali</xsl:text>
+        <xsl:value-of select="$pos"/>
+        <xsl:variable name="rest" select="substring($tail, 6)"/>
+        <xsl:if test="$rest != ''">
+          <xsl:call-template name="emit-id-componentes">
+            <xsl:with-param name="tail" select="substring($rest, 2)"/>
+            <xsl:with-param name="has-par">true</xsl:with-param>
+          </xsl:call-template>
+        </xsl:if>
+      </xsl:when>
+      <xsl:when test="starts-with($tail, 'item-')">
+        <xsl:variable name="item-num">
+          <xsl:choose>
+            <xsl:when test="contains(substring-after($tail, 'item-'), '-')">
+              <xsl:value-of select="substring-before(substring-after($tail, 'item-'), '-')"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="substring-after($tail, 'item-')"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:text>_ite</xsl:text>
+        <xsl:value-of select="$item-num"/>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="letter-to-pos">
+    <xsl:param name="letter"/>
+    <xsl:value-of select="string-length(substring-before('abcdefghijklmnopqrstuvwxyz', $letter)) + 1"/>
+  </xsl:template>
+
+  <xsl:template name="path-to-id-organizacional">
+    <!--
+      Leizilla org path → LexML idAgregador.
+
+      Casos:
+        liv-N → livN
+        tit-N → titN
+        tit-N-cap-M → titN_capM
+        tit-N-cap-M-sec-K → titN_capM_secK
+        ...-subsec-X → ..._subX  (LexML usa "sub", não "subsec")
+    -->
+    <xsl:call-template name="org-path-emit">
+      <xsl:with-param name="rest" select="@path"/>
+      <xsl:with-param name="first">true</xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template name="org-path-emit">
+    <xsl:param name="rest"/>
+    <xsl:param name="first"/>
+    <!-- Identifica próximo token (liv/tit/cap/sec/subsec/parte) -->
+    <xsl:variable name="tok">
+      <xsl:choose>
+        <xsl:when test="starts-with($rest, 'liv-')">liv</xsl:when>
+        <xsl:when test="starts-with($rest, 'tit-')">tit</xsl:when>
+        <xsl:when test="starts-with($rest, 'cap-')">cap</xsl:when>
+        <xsl:when test="starts-with($rest, 'sec-')">sec</xsl:when>
+        <xsl:when test="starts-with($rest, 'subsec-')">sub</xsl:when>
+        <xsl:when test="starts-with($rest, 'parte-')">prt</xsl:when>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="prefix-len">
+      <xsl:choose>
+        <xsl:when test="$tok='sub'">7</xsl:when>
+        <xsl:when test="$tok='prt'">6</xsl:when>
+        <xsl:otherwise>4</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="after" select="substring($rest, $prefix-len + 1)"/>
+    <xsl:variable name="num">
+      <xsl:choose>
+        <xsl:when test="contains($after, '-')">
+          <xsl:value-of select="substring-before($after, '-')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$after"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:if test="$first != 'true'">
+      <xsl:text>_</xsl:text>
+    </xsl:if>
+    <xsl:value-of select="$tok"/>
+    <xsl:value-of select="$num"/>
+    <xsl:variable name="next" select="substring($after, string-length($num) + 2)"/>
+    <xsl:if test="$next != ''">
+      <xsl:call-template name="org-path-emit">
+        <xsl:with-param name="rest" select="$next"/>
+        <xsl:with-param name="first">false</xsl:with-param>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- ==================================================================
+       Utility: string replace (XSLT 1.0 não tem builtin)
+       ================================================================== -->
+
+  <xsl:template name="replace-string">
+    <xsl:param name="text"/>
+    <xsl:param name="from"/>
+    <xsl:param name="to"/>
+    <xsl:choose>
+      <xsl:when test="contains($text, $from)">
+        <xsl:value-of select="substring-before($text, $from)"/>
+        <xsl:value-of select="$to"/>
+        <xsl:call-template name="replace-string">
+          <xsl:with-param name="text" select="substring-after($text, $from)"/>
+          <xsl:with-param name="from" select="$from"/>
+          <xsl:with-param name="to" select="$to"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$text"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/scripts/leizilla-to-lexml.xsl
+++ b/scripts/leizilla-to-lexml.xsl
@@ -17,10 +17,6 @@
   - <revogacao>: parcial vira `situacao="revogado"` no Artigo; total vira
     `situacao="revogado"` no <Norma>. Tipo (expressa/tacita/inconstitucionalidade)
     é descartado.
-  - <dispositivo path="ocr-ruim*">: DESCARTADO. LexML não tem fallback para
-    OCR não-estruturado. Lei só-ocr-ruim vira <Articulacao> vazia (XSD-inválido)
-    — política upstream (SCHEMA.md §4.7): leis assim não publicam parsed item.
-
   Limitações desta versão:
   - Apenas a versão vigente é exportada. Histórico, alterações e revogações
     parciais ficam como atributos `situacao` quando aplicável.
@@ -106,13 +102,12 @@
 
   <!-- ==================================================================
        Articulacao: ignora titulo-lei/ementa/preambulo (já em ParteInicial),
-       ignora ocr-ruim* (LexML não modela), emite o resto.
+       emite o resto.
        ================================================================== -->
 
   <xsl:template match="lz:dispositivo" mode="articulacao">
     <xsl:choose>
       <xsl:when test="@path='titulo-lei' or @path='ementa' or @path='preambulo'"/>
-      <xsl:when test="starts-with(@path, 'ocr-ruim')"/>
       <xsl:when test="starts-with(@path, 'art-')">
         <xsl:call-template name="emit-artigo"/>
       </xsl:when>

--- a/scripts/leizilla-to-lexml.xsl
+++ b/scripts/leizilla-to-lexml.xsl
@@ -17,6 +17,12 @@
   - <revogacao>: parcial vira `situacao="revogado"` no Artigo; total vira
     `situacao="revogado"` no <Norma>. Tipo (expressa/tacita/inconstitucionalidade)
     é descartado.
+  - <dispositivo path="anexo-N">: emite <ReferenciaAnexo AlvoURN="..."/> na
+    <Norma>/<Anexos> do documento principal E gera arquivo LexML separado
+    `{output-dir}/anexo-{N}.lexml.xml` (via EXSLT exsl:document). Cada anexo
+    fica como <LexML><Anexo><DocumentoGenerico><PartePrincipal><p>...
+    Conforme modelo LexML brasileiro: anexos são documentos linkados por URN,
+    não estruturas inline.
   Limitações desta versão:
   - Apenas a versão vigente é exportada. Histórico, alterações e revogações
     parciais ficam como atributos `situacao` quando aplicável.
@@ -28,32 +34,44 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:lz="https://leizilla.org/lei/0.1"
+                xmlns:exsl="http://exslt.org/common"
                 xmlns="http://www.lexml.gov.br/1.0"
-                exclude-result-prefixes="lz">
+                extension-element-prefixes="exsl"
+                exclude-result-prefixes="lz exsl">
 
   <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
   <xsl:strip-space elements="*"/>
+
+  <!--
+    Parâmetro `output-dir`: onde escrever os documentos LexML dos anexos
+    (cada anexo vira arquivo separado, conforme modelo LexML). Default `.`.
+    Caller (CLI/ETL) deve passar a flag de parâmetro do xsltproc
+    (`param output-dir "'/path/dir'"`, escrita com double-dash) para
+    isolar outputs por lei.
+  -->
+  <xsl:param name="output-dir" select="'.'"/>
 
   <!-- ==================================================================
        Root: <lei> → <LexML><Metadado/><Norma/></LexML>
        ================================================================== -->
 
   <xsl:template match="/lz:lei">
+    <xsl:variable name="urn-lei">
+      <xsl:choose>
+        <xsl:when test="@urn-lex">
+          <xsl:value-of select="@urn-lex"/>
+        </xsl:when>
+        <!-- Fallback URN quando lei não tem urn-lex (caso parsed fallback). -->
+        <xsl:otherwise>
+          <xsl:text>urn:lex:br;leizilla;fallback:0000-00-00;0</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="anexos" select="lz:dispositivo[starts-with(@path, 'anexo-')]"/>
+
     <LexML>
       <Metadado>
-        <Identificacao>
-          <xsl:attribute name="URN">
-            <xsl:choose>
-              <xsl:when test="@urn-lex">
-                <xsl:value-of select="@urn-lex"/>
-              </xsl:when>
-              <!-- Fallback URN quando lei não tem urn-lex (caso parsed fallback). -->
-              <xsl:otherwise>
-                <xsl:text>urn:lex:br;leizilla;fallback:0000-00-00;0</xsl:text>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:attribute>
-        </Identificacao>
+        <Identificacao URN="{$urn-lei}"/>
       </Metadado>
       <Norma>
         <!-- Revogação total da lei: LexML não tem atributo 'situacao' no
@@ -65,8 +83,37 @@
         <Articulacao>
           <xsl:apply-templates select="lz:dispositivo" mode="articulacao"/>
         </Articulacao>
+        <xsl:if test="$anexos">
+          <Anexos>
+            <xsl:for-each select="$anexos">
+              <ReferenciaAnexo AlvoURN="{concat($urn-lei, '!', @path)}"/>
+            </xsl:for-each>
+          </Anexos>
+        </xsl:if>
       </Norma>
     </LexML>
+
+    <!-- Gerar arquivo LexML separado para cada anexo (EXSLT exsl:document).
+         Caller controla output-dir via parâmetro do xsltproc. -->
+    <xsl:for-each select="$anexos">
+      <exsl:document href="{$output-dir}/{@path}.lexml.xml"
+                     method="xml" encoding="UTF-8" indent="yes">
+        <LexML xmlns="http://www.lexml.gov.br/1.0">
+          <Metadado>
+            <Identificacao URN="{concat($urn-lei, '!', @path)}"/>
+          </Metadado>
+          <Anexo>
+            <DocumentoGenerico id="doc-{@path}">
+              <PartePrincipal id="pp-{@path}">
+                <p id="p-{@path}">
+                  <xsl:value-of select="lz:versao[last()]/lz:texto"/>
+                </p>
+              </PartePrincipal>
+            </DocumentoGenerico>
+          </Anexo>
+        </LexML>
+      </exsl:document>
+    </xsl:for-each>
   </xsl:template>
 
   <!-- ==================================================================
@@ -145,9 +192,9 @@
         </xsl:call-template>
       </xsl:when>
       <xsl:when test="starts-with(@path, 'anexo-')">
-        <!-- LexML modela anexos como ReferenciaAnexo em <Anexos>, não dentro
-             de <Articulacao>. Suporte completo requer documento separado
-             linkado. DESCARTADO neste XSLT — perda documentada. -->
+        <!-- Anexos NÃO entram em <Articulacao>. São coletados no template
+             raiz e viram <ReferenciaAnexo> em <Anexos> + documento LexML
+             separado (via exsl:document). -->
       </xsl:when>
       <xsl:when test="starts-with(@path, 'disp-transitoria-')
                       or starts-with(@path, 'disp-final-')">

--- a/scripts/leizilla-to-lexml.xsl
+++ b/scripts/leizilla-to-lexml.xsl
@@ -523,28 +523,4 @@
     </xsl:if>
   </xsl:template>
 
-  <!-- ==================================================================
-       Utility: string replace (XSLT 1.0 não tem builtin)
-       ================================================================== -->
-
-  <xsl:template name="replace-string">
-    <xsl:param name="text"/>
-    <xsl:param name="from"/>
-    <xsl:param name="to"/>
-    <xsl:choose>
-      <xsl:when test="contains($text, $from)">
-        <xsl:value-of select="substring-before($text, $from)"/>
-        <xsl:value-of select="$to"/>
-        <xsl:call-template name="replace-string">
-          <xsl:with-param name="text" select="substring-after($text, $from)"/>
-          <xsl:with-param name="from" select="$from"/>
-          <xsl:with-param name="to" select="$to"/>
-        </xsl:call-template>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="$text"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
 </xsl:stylesheet>

--- a/tests/fixtures/lexml/README.md
+++ b/tests/fixtures/lexml/README.md
@@ -1,0 +1,59 @@
+# LexML brasileiro — XSD oficial (bundle)
+
+Schemas oficiais do LexML brasileiro v1.0, bundled aqui para validação
+CI offline e reprodutibilidade (decisão em `docs/SCHEMA.md` §9 / §8.2).
+
+## Arquivos
+
+| Arquivo | Origem | Notas |
+|---|---|---|
+| `lexml-br-rigido.xsd` | https://projeto.lexml.gov.br/esquemas/lexml-br-rigido.xsd | Restrições rigidas (versão preferida para validação). Redefine `lexml-base.xsd`. |
+| `lexml-base.xsd` | https://projeto.lexml.gov.br/esquemas/lexml-base.xsd | Schema core (~43KB). Define tipos, attribute groups, elementos. |
+| `xml.xsd` | https://www.w3.org/2001/xml.xsd | Standard W3C (atributos `xml:lang`, `xml:base`). |
+| `xlink-href.xsd` | https://www.w3.org/Math/XMLSchema/mathml2/common/xlink-href.xsd | Standard W3C (atributo `xlink:href`). |
+| `mathml2.xsd` | **stub local** | Schema oficial MathML2 tem ~50 arquivos; leis brasileiras quase nunca usam MathML estruturado. Stub aceita qualquer conteúdo no elemento `<math>`. Substituir por MathML2 oficial completo apenas se validação rigorosa de fórmulas matemáticas em leis virar requisito. |
+
+## Patches aplicados aos XSDs originais
+
+Os `schemaLocation` em `lexml-base.xsd` e `lexml-br-rigido.xsd` foram
+alterados para apontar pros arquivos locais (sem rewrite de conteúdo
+estrutural):
+
+| Original | Local |
+|---|---|
+| `http://www.w3.org/2001/xml.xsd` | `xml.xsd` |
+| `http://www.w3.org/Math/XMLSchema/mathml2/common/xlink-href.xsd` | `xlink-href.xsd` |
+| `http://www.w3.org/Math/XMLSchema/mathml2/mathml2.xsd` | `mathml2.xsd` |
+
+Aplicado via `sed` (idempotente). Sem essas mudanças, `xmllint` falha
+quando offline.
+
+## Histórico do LexML
+
+LexML brasileiro está **parado desde ~2010** (ver `docs/SCHEMA.md`
+§0.3). A pasta oficial https://projeto.lexml.gov.br/esquemas atualmente
+retorna "Atualmente não existem itens nessa pasta" no índice — mas os
+arquivos individuais ainda respondem 200 quando você sabe os nomes.
+
+Mantemos o bundle aqui para:
+1. **Reprodutibilidade**: CI não depende de servidor LexML gov estar
+   no ar. Repo é self-contained.
+2. **Defesa contra link rot**: se o servidor sair do ar, o teste
+   continua funcionando.
+3. **Auditoria**: pin explícito da versão do schema usada.
+
+Se o projeto LexML reviver, atualizar via `curl` desses URLs.
+
+## Por que validamos contra LexML
+
+Ver `docs/SCHEMA.md` §6 inteiro. Resumo:
+- Leizilla XML é o formato canônico (dispositivo-cêntrico, vigência
+  herda, fonte unificada).
+- LexML é representação reduzida para gov interop (Senado/Câmara).
+- XSLT `scripts/leizilla-to-lexml.xsl` faz a conversão sob demanda.
+- Perdas conhecidas documentadas: divergências multi-fonte, timeline
+  histórica, `<inicio tipo>`, anexos. Ver §6.2.
+- CI gate: a cada PR, garantir que TODOS os fixtures Leizilla XML
+  produzem LexML válido (`pytest tests/test_lexml_export.py`).
+
+CI **não** valida round-trip (LexML → Leizilla XML não é objetivo).

--- a/tests/fixtures/lexml/lexml-base.xsd
+++ b/tests/fixtures/lexml/lexml-base.xsd
@@ -1,0 +1,1252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsd:schema xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:mathml="http://www.w3.org/1998/Math/MathML"
+	elementFormDefault="qualified"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+    <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink-href.xsd" />
+    <xsd:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="mathml2.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+		O esquema do projeto LexML Brasil é uma adaptação dos schemas
+			Akoma Ntoso (1.0) (http://www.akomantoso.org/)
+		e
+			Norme in Rete (2.0) (http://www.nir.it)
+		para a técnica legisativa brasileira. Esses esquemas foram
+		originalmente criados por Fabio Vitali  ( Universidade of Bolonha )
+		com a supervisão (Direito) de Monica Palmirani ( Universidade de Bolonha ).
+
+		Adaptado   por João Alberto de Oliveira Lima (Senado Federal - joaolima@senado.gov.br)
+		e revisado por Fernando Ciciliati (Interlegis - ciciliati@interlegis.gov.br)
+        e Marcos Fragomeni (Senado Federal))
+
+		O presente esquema usa XML design patterns de forma sistemática, tal como
+		descrito em  http://www.xmlpatterns.com/
+		Alguns deles são mencionados explicitamente, quando o seu uso
+		não é suficientemente claro ou natural. Outros são usados sem nenhuma
+		referência.
+
+                        Versao 1.5 - setembro/11 - novo elemento TituloDispositivo. Sai TituloArtigo.
+                                                 - Omissis pode ser filho de agrupadores de artigo em Alteracao.
+                                                 - Ajustes no id do Omissis
+                                                 - Correção nos id's para aceitar 'u' como indicador de dispositivo único.
+                                                 - Epigrafe, Ementa e TituloDispositivo não têm p
+                                                 - Não são mais aceitos tags html diretamente dentro de Alteracao.
+
+                        Versao 1.4 - agosto/11 - troca dos elementos AbreAspas, FechaAspas e NotaAlteracao pelos atributos abreAspas, fechaAspas e notaAlteracao
+                                               - utilização do atributo URN no elemento Identificacao, removendo demais atributos e sub-elementos
+                                               - remoção do elemento Contexto com elementos FRBR do Metadado
+                                               - criação do atributo id no elemento Omissis
+                                               - criação do atributo textoOmitido
+                                               - remoção do atributo seqOrdem
+                                               - ajustes na regra de validação dos id's (nos schemas lexml-br-rigido.xsd e lexml-flexivel.xsd)
+                                               - possibilidade de Epigrafe, Ementa e Preambulo dentro de Alteracao (e ajustes de ID)
+                                               - possibilidade de Alinea dentro de Caput e de Paragrafo quando em Alteracao
+                                               - utilização dos atributos abreAspas, fechaAspas e notaAlteracao apenas em dispositivos dentro de Alteracao
+                                               - id da Pena passa a ser obrigatório
+
+                        Versao 1.3 - novembro/10 - inclusao da tag FormulaPromulgacao (para atender Decreto Legislativo)
+                                                   ajuste na Tag Alteracao
+
+                        Versão 1.2 - setembro/10 - remoção do elemento AspasEstrutura e AspasTexto e criação de atributos para aspas e notaAlteração
+                                                 - alteração no conteúdo do Elemento Omissis
+
+                        Versão 1.1 - agosto/10 - remoção do targetNamespace para permitir utilizar o esquema como
+                                                 camaleão (Chameleon schema).
+                                               - referência ao MathML e xlink externos em www.w3.org.
+                                               - criação de elementos abstratos com prefixo "_".
+                                               - definição de idArtigo e DispositivoType para posterior redefinição
+                                                 em sub-esquemas.
+                                               - as alterações feitas nesta versão permitem que o esquema seja
+                                                 validado sozinho.
+
+                        Versão 1.0 - dezembro/08 - exclusão dos elementos Texto e TextoSimples
+
+                        Versão 0.7 - agosto/08 - ajuste no patterns de ids de dispositivos para trocar o complemento alfa para num
+                                                             - inclusão do elemento inline Formula com conteúdo MathML.
+
+                        Versão 0.6 - abril/08 - alteração nos ids das subdivisões de artigo retirando o 'alt' e incluindo o
+		                                        prefixo do dispositivo pai.
+		                                      - inclusão do elemento Pena após o Texto dos dispostivos de artigo.
+		                                      - alteração de nome da tag "Justificativa" para "Justificacao
+		                                      - inclusão do elemento EmConformidadeCom
+		                                      - inclusão de elemento Apelido no nível ObraIndividual
+		                                        e ObraIndividualComplementar
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		Principais Grupos de Elementos
+			- LexML (Hierarchy, Inline, Marker)
+			- HTML (Container, Block, Inline, Marker)
+			- LexML + HTML + generic elements
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:group name="LXhier">
+		<xsd:choice>
+			<xsd:element ref="_Parte"/>
+			<xsd:element ref="_Livro"/>
+			<xsd:element ref="_Titulo"/>
+			<xsd:element ref="_Capitulo"/>
+			<xsd:element ref="_Secao"/>
+			<xsd:element ref="_Artigo"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="LXhierCompleto">
+		<xsd:choice>
+			<xsd:group ref="LXhier"/>
+			<xsd:element ref="_Subsecao"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="LXcontainers">
+		<xsd:choice>
+			<xsd:element ref="_Caput"/>
+			<xsd:element ref="_Paragrafo"/>
+			<xsd:element ref="_Inciso"/>
+			<xsd:element ref="_Alinea"/>
+			<xsd:element ref="_Item"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="LXinline">
+		<xsd:choice>
+			<xsd:element ref="Remissao"/>
+			<xsd:element ref="RemissaoMultipla"/>
+			<xsd:element ref="Alteracao"/>
+		    <xsd:element ref="Formula"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="LXmarker">
+		<xsd:choice>
+			<xsd:element ref="NotaReferenciada"/>
+		</xsd:choice>
+	</xsd:group>
+
+
+	<xsd:group name="HTMLcontainers">
+		<xsd:sequence>
+			<xsd:element ref="div"/>
+		</xsd:sequence>
+	</xsd:group>
+
+	<xsd:group name="HTMLblock">
+		<xsd:choice>
+			<xsd:element ref="p"/>
+			<xsd:element ref="ul"/>
+			<xsd:element ref="ol"/>
+			<xsd:element ref="table"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="HTMLinline">
+		<xsd:choice>
+			<xsd:element ref="span"/>
+			<xsd:element ref="b"/>
+			<xsd:element ref="i"/>
+			<xsd:element ref="a"/>
+			<xsd:element ref="sub"/>
+			<xsd:element ref="sup"/>
+			<xsd:element ref="ins"/>
+			<xsd:element ref="del"/>
+			<xsd:element ref="dfn"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="HTMLmarker">
+		<xsd:sequence>
+			<xsd:element ref="img"/>
+		</xsd:sequence>
+	</xsd:group>
+
+	<xsd:group name="hierElements">
+		<xsd:choice>
+			<xsd:group ref="LXhier" />
+			<xsd:element ref="AgrupamentoHierarquico"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="hierElementsCompleto">
+		<xsd:choice>
+			<xsd:group ref="LXhierCompleto" />
+			<xsd:element ref="AgrupamentoHierarquico"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="containerElements">
+		<xsd:choice>
+			<xsd:group ref="HTMLcontainers" />
+			<xsd:element ref="Agrupamento"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="parteInicialElements">
+		<xsd:choice>
+            <xsd:element ref="FormulaPromulgacao"/>
+            <xsd:element ref="Epigrafe"/>
+            <xsd:element ref="Ementa"/>
+            <xsd:element ref="Preambulo"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="blockElements">
+		<xsd:choice>
+			<xsd:group ref="HTMLblock" />
+			<xsd:element ref="ConteudoExterno"/>
+			<xsd:element ref="Bloco"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="inlineElements">
+		<xsd:choice>
+			<xsd:group ref="LXinline" />
+			<xsd:group ref="HTMLinline" />
+			<xsd:element ref="EmLinha"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:group name="markerElements">
+		<xsd:choice>
+			<xsd:group ref="LXmarker" />
+			<xsd:group ref="HTMLmarker" />
+			<xsd:element ref="Marcador"/>
+		</xsd:choice>
+	</xsd:group>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		Grupos de Atributos
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:attributeGroup name="nome">
+		<xsd:attribute name="nome" type="xsd:string" use="required"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="source">
+		<xsd:attribute name="fonte"  use="required" type="xsd:anyURI"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="date">
+		<xsd:attribute name="data" type="xsd:date" use="required"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="link">
+	                      <xsd:attribute ref="xlink:href" use="required"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="linkID">
+	                      <xsd:attribute name="nota" type="xsd:IDREF" use="required"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="linkURN">
+	                      <xsd:attribute name="URN" type="xsd:anyURI" use="required"/>
+	                      <xsd:attribute name="showAs" type="xsd:string"/>
+	</xsd:attributeGroup>
+
+                      <xsd:attributeGroup name="linkopt">
+	                      <xsd:attribute ref="xlink:href"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="optvalue">
+		<xsd:attribute name="value" type="xsd:string"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="period">
+		<xsd:attribute name="eventoInicial" type="xsd:anyURI"/>
+		<xsd:attribute name="eventoFinal" type="xsd:anyURI"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="enactment">
+		<xsd:attributeGroup ref="period"/>
+		<xsd:attribute name="situacao" type="TipoSituacao"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="cellattrs">
+		<xsd:attribute name="rowspan" type="xsd:integer" default="1" />
+		<xsd:attribute name="colspan" type="xsd:integer" default="1" />
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="HTMLattrs">
+		<xsd:attribute name="class" type="xsd:string"/>
+		<xsd:attribute name="style" type="xsd:string"/>
+		<xsd:attribute name="title" type="xsd:string"/>
+	                      <xsd:attribute ref="xml:lang" default="pt-BR"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="HTMLname">
+		<xsd:attribute name="name" type="xsd:string"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="idreq">
+		<xsd:attribute name="id"   use="required" type="xsd:ID"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="idreqArt">
+		<xsd:attribute name="id"   use="required" type="idArtigo"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="idopt">
+		<xsd:attribute name="id" type="xsd:ID"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="corereq">
+		<xsd:attributeGroup ref="HTMLattrs"/>
+		<xsd:attributeGroup ref="enactment"/>
+		<xsd:attributeGroup ref="idreq"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="coreopt">
+		<xsd:attributeGroup ref="HTMLattrs"/>
+		<xsd:attributeGroup ref="enactment"/>
+		<xsd:attributeGroup ref="idopt"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="corereqArt">
+		<xsd:attributeGroup ref="HTMLattrs"/>
+		<xsd:attributeGroup ref="enactment"/>
+		<xsd:attributeGroup ref="idreqArt"/>
+        <xsd:attribute name="textoOmitido" type="TipoMarcador"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="attrsCitacao">
+		<xsd:attribute name="abreAspas" type="TipoMarcador"/>
+		<xsd:attribute name="fechaAspas" type="TipoMarcador"/>
+		<xsd:attribute name="notaAlteracao" type="xsd:string"/>
+	</xsd:attributeGroup>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		Tipos Simples
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+
+	<xsd:simpleType name="TipoSituacao">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="omissis" />
+			<xsd:enumeration value="revogado" />
+			<xsd:enumeration value="suspenso" />
+			<xsd:enumeration value="vetado"/>
+			<xsd:enumeration value="superado" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+    <xsd:simpleType name="TipoMarcador">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="s" />
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		Tipos Complexos
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:complexType name="hierarchy" >
+		<xsd:sequence>
+			<xsd:element ref="Rotulo" minOccurs="0" maxOccurs="1" />
+			<xsd:element ref="NomeAgrupador" minOccurs="0" maxOccurs="1" />
+			<xsd:sequence>
+				<xsd:element ref="AgrupamentoHierarquico" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:sequence>
+		<xsd:attributeGroup ref="corereq"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="blocksreq" >
+		<xsd:sequence minOccurs="1" maxOccurs="unbounded" >
+			<xsd:group ref="blockElements" />
+		</xsd:sequence>
+		<xsd:attributeGroup ref="corereq"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="blocksopt">
+		<xsd:sequence minOccurs="1" maxOccurs="unbounded" >
+			<xsd:group ref="blockElements" />
+		</xsd:sequence>
+		<xsd:attributeGroup ref="coreopt"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="inline" mixed="true">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded" >
+			<xsd:group ref="inlineElements" />
+			<xsd:group ref="markerElements" />
+		</xsd:choice>
+		<xsd:attributeGroup ref="coreopt"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="inlineReq" mixed="true">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded" >
+			<xsd:group ref="inlineElements" />
+			<xsd:group ref="markerElements" />
+		</xsd:choice>
+		<xsd:attributeGroup ref="corereq"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="markerreq" >
+		<xsd:attributeGroup ref="corereq"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="markeropt" >
+		<xsd:attributeGroup ref="coreopt"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="anyOther"  >
+		<xsd:choice>
+			<xsd:any  namespace="##other"/>
+		</xsd:choice>
+	</xsd:complexType>
+
+	<xsd:complexType name="participaType" >
+		<xsd:sequence>
+			<xsd:element ref="Rotulo" minOccurs="1" maxOccurs="1" />
+			<xsd:element ref="Tratamento" minOccurs="0" maxOccurs="1" />
+			<xsd:element ref="NomeAgente" minOccurs="1" maxOccurs="1" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="textoType">
+		<xsd:sequence>
+			<xsd:element ref="p" minOccurs="0" maxOccurs="unbounded" />
+		</xsd:sequence>
+		<xsd:attributeGroup ref="corereq"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="textoSimplesType">
+		<xsd:sequence>
+			<xsd:element ref="p" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attributeGroup ref="corereq"/>
+	</xsd:complexType>
+
+                        <xsd:complexType name="textoSimplesOptType">
+                                          <xsd:sequence>
+                                                            <xsd:element ref="p" minOccurs="0" maxOccurs="1" />
+                                          </xsd:sequence>
+                                          <xsd:attributeGroup ref="coreopt"/>
+                        </xsd:complexType>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		Elemento Raiz
+		Comentário Um elemento genérico raiz contendo todos os tipos de documentos
+		Pattern: Universal Root
+		Referência: http://www.xmlpatterns.com/UniversalRootMain.shtml
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:complexType name="DocumentTypes" >
+		<xsd:sequence >
+			<xsd:element ref="Metadado" />
+			<xsd:choice >
+				<xsd:element ref="Norma" />
+				<xsd:element ref="ProjetoNorma" />
+				<xsd:element ref="Jurisprudencia" />
+				<xsd:element ref="DocumentoGenerico" />
+				<xsd:element ref="Anexo" />
+			</xsd:choice>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:element name="LexML" type="DocumentTypes" />
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		Tipos de Documento
+		Comentário: Todos os tipos de documentos compartinham dois modelos de conteúdo (Hierárquico, Aberto)
+		Pattern: Consistent Element Set
+		Referência: http://www.xmlpatterns.com/ConsistentElementSetMain.shtml
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:complexType name="HierarchicalStructure" >
+		<xsd:sequence >
+			<xsd:element ref="ParteInicial" minOccurs="0" maxOccurs="1" />
+			<xsd:element ref="Articulacao" />
+			<xsd:element ref="ParteFinal" minOccurs="0" maxOccurs="1" />
+			<xsd:element ref="Anexos" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+	                      <xsd:attribute ref="xml:lang"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="OpenStructure" >
+		<xsd:sequence >
+			<xsd:element ref="PartePrincipal" minOccurs="0" maxOccurs="1" />
+			<xsd:element ref="Anexos" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attributeGroup  ref="coreopt"/>
+	</xsd:complexType>
+
+                        <xsd:element name="Norma" type="HierarchicalStructure"/>
+
+	<xsd:element name="ProjetoNorma">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="Norma"/>
+				<xsd:element name="Justificacao" type="OpenStructure" minOccurs="0" maxOccurs="unbounded" />
+				<xsd:element name="AutorProjeto" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+
+
+	<xsd:element name="Jurisprudencia">
+		<xsd:complexType>
+			<xsd:choice>
+				<xsd:element ref="Sumula"/>
+				<xsd:element ref="Acordao"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="DocumentoGenerico" type="OpenStructure" />
+
+                      <xsd:element name="Anexo">
+		<xsd:complexType>
+			<xsd:choice>
+				<xsd:element name="DocumentoArticulado" type="HierarchicalStructure"/>
+				<xsd:element ref="DocumentoGenerico"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		LX common containers elements
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+                     <!-- Articulação (Normas e Projetos de Normas) -->
+
+	<xsd:element name="ParteInicial" >
+		<xsd:complexType >
+			<xsd:sequence>
+                <xsd:element ref="FormulaPromulgacao" minOccurs="0" maxOccurs="1" />
+				<xsd:element ref="Epigrafe" minOccurs="0" maxOccurs="1" />
+				<xsd:element ref="Ementa" minOccurs="0" maxOccurs="1" />
+				<xsd:element ref="Preambulo" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="ParteFinal" >
+		<xsd:complexType >
+			<xsd:sequence>
+				<xsd:element ref="LocalDataFecho" minOccurs="0" maxOccurs="1" />
+				<xsd:choice>
+					<xsd:element ref="AssinaturaGrupo" minOccurs="0" maxOccurs="unbounded" />
+					<xsd:element ref="Assinaturas" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="Assinatura" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:choice>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:element name="FormulaPromulgacao" type="textoSimplesType"/>
+
+	<xsd:element name="Epigrafe" type="inlineReq"/>
+
+	<xsd:element name="Ementa" type="inlineReq"/>
+
+	<xsd:element name="LocalDataFecho" type="textoSimplesType"/>
+
+	<xsd:element name="Observacao" type="textoSimplesType"/>
+
+	<xsd:element name="Preambulo" type="textoType"/>
+
+	<xsd:element name="AssinaturaGrupo">
+		<xsd:complexType >
+			<xsd:sequence>
+				<xsd:element name="NomeGrupo" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+				<xsd:choice>
+					<xsd:element ref="Assinaturas" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="Assinatura" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:choice>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Assinaturas">
+		<xsd:complexType >
+			<xsd:sequence >
+				<xsd:element ref="Assinatura" minOccurs="1" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Assinatura">
+		<xsd:complexType >
+			<xsd:sequence >
+				<xsd:element ref="NomePessoa" minOccurs="1" maxOccurs="unbounded" />
+				<xsd:element ref="Cargo" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="NomePessoa" type="xsd:string"/>
+
+	<xsd:element name="Cargo" type="xsd:string"/>
+
+                        <xsd:element name="ReferenciaAnexo" type="refURN" />
+
+                        <xsd:element name="Anexos">
+		<xsd:complexType >
+			<xsd:sequence >
+				<xsd:element ref="ReferenciaAnexo" minOccurs="1" maxOccurs="unbounded" />
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreopt"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Articulacao">
+		<xsd:complexType >
+			<xsd:sequence minOccurs="1" maxOccurs="unbounded" >
+				<xsd:group ref="hierElements" />
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreopt"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!--- Jurisprudencia ( elementos específicos) -->
+
+                      <xsd:element name="Tratamento" type="xsd:string"/>
+
+                      <xsd:element name="NomeAgente" type="xsd:string"/>
+
+                      <xsd:element name="Sumula">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="Epigrafe" minOccurs="1" maxOccurs="1"/>
+				<xsd:element ref="Ementa" minOccurs="1" maxOccurs="1"/>
+				<xsd:element ref="Observacao" minOccurs="0" maxOccurs="1"/>
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreopt"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Acordao">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="CabecalhoAcordao" minOccurs="1" maxOccurs="1"/>
+			 	<xsd:element name="EmentaTexto" type="OpenStructure" minOccurs="1" maxOccurs="1"/>
+			 	<xsd:element name="AcordaoTexto" type="OpenStructure" minOccurs="1" maxOccurs="1"/>
+				<xsd:element name="RelatorioTexto" type="OpenStructure" minOccurs="1" maxOccurs="1"/>
+				<xsd:element name="VotoTexto" type="OpenStructure" minOccurs="1" maxOccurs="1"/>
+				<xsd:element name="DebateTexto" type="OpenStructure" minOccurs="0" maxOccurs="1"/>
+				<xsd:element name="ExtratoAtaTexto" type="OpenStructure" minOccurs="1" maxOccurs="1"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="CabecalhoAcordao">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="Epigrafe" minOccurs="1" maxOccurs="1"/>
+				<xsd:element name="DataJulgamento" type="xsd:date" minOccurs="1" maxOccurs="1"/>
+				<xsd:element name="OrgaoJulgador" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				<xsd:element ref="Relator" minOccurs="1" maxOccurs="1"/>
+				<xsd:element ref="PartesProcesso" minOccurs="2" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Relator" type="participaType"/>
+
+	<xsd:element name="PartesProcesso">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="ParteProcesso" type="participaType" minOccurs="1" maxOccurs="unbounded"/>
+				<xsd:element name="AdvogadosParte" type="participaType" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+                                <!-- Open Structure -->
+
+                                <xsd:element name="PartePrincipal">
+                                        <xsd:complexType >
+                                                <xsd:choice minOccurs="1" maxOccurs="unbounded" >
+                                                        <xsd:element ref="AgrupamentoHierarquico" />
+                                                        <xsd:group ref="containerElements"/>
+                                                        <xsd:group ref="blockElements" />
+                                                </xsd:choice>
+                                                <xsd:attributeGroup ref="coreopt"/>
+                                        </xsd:complexType>
+                                </xsd:element>
+
+	<xsd:element name="DispositivoGenerico">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="DispositivoType">
+					<xsd:attributeGroup ref="nome"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="PenaType">
+        <xsd:sequence >
+            <xsd:element ref="Rotulo" minOccurs="0" maxOccurs="1" />
+            <xsd:element ref="p" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="DispositivoGenerico" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attributeGroup ref="corereq"/>
+        <xsd:attributeGroup ref="linkopt"/>
+    </xsd:complexType>
+
+	<xsd:element name="Pena" type="PenaType"/>
+
+	<xsd:element name="TituloDispositivo" type="inline" />
+
+	<xsd:element name="Rotulo" type="xsd:string" />
+
+	<xsd:element name="NomeAgrupador" type="inline" />
+
+	<xsd:element name="Texto" type="blocksopt"/>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		LX elementos inline
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="Remissao">
+		<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:attributeGroup ref="link"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="RemissaoMultipla">
+		<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:attribute ref="xml:base" use="required"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="NotaReferenciada">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="markeropt">
+					<xsd:attributeGroup ref="linkID"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Alteracao" type="AlteracaoType"/>
+
+    <xsd:complexType name="AlteracaoType">
+        <xsd:attribute ref="xml:base"/>
+        <xsd:attributeGroup ref="corereq"/>
+    </xsd:complexType>
+
+	<xsd:element name="Omissis">
+        <xsd:complexType>
+            <xsd:attribute name="id" use="required" type="idOmissis"/>
+            <xsd:attributeGroup ref="attrsCitacao"/>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="Formula">
+       <xsd:complexType>
+          <xsd:sequence minOccurs="0" maxOccurs="1">
+             <xsd:element ref="mathml:math" />
+          </xsd:sequence>
+          <xsd:attribute name="fonte" type="xsd:string"/>
+          <xsd:attribute name="tipo" type="xsd:string"/>
+       </xsd:complexType>
+    </xsd:element>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		Elementos Genéricos
+
+		Comentário: Cada elementos deste esquema correspode a um dos cinco modelos
+		de conteúdo: Hierarchy, Container, Block, Inline e Mark. Além destes elementos,
+		o esquema provê um elemento genérico para cada um dos modelos. Estes elementos
+		genéricos podem ser utilizados para atender necessidades específicas ou situações não previstas
+		no modelo original. O atributo nome do elemento genérico será uma indicação do seu significado.
+
+		Pattern: Generic Document + Role Attribute
+		Referência: http://www.xmlpatterns.com/GenericDocumentMain.shtml +
+		http://www.xmlpatterns.com/RoleAttributeMain.shtml
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="AgrupamentoHierarquico">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="hierarchy">
+					<xsd:sequence>
+						<xsd:group ref="LXhierCompleto" minOccurs="1" maxOccurs="unbounded"/>
+					</xsd:sequence>
+					<xsd:attributeGroup ref="nome"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Agrupamento">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="blocksreq">
+					<xsd:attributeGroup ref="nome"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Bloco">
+		<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:attributeGroup ref="nome"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="EmLinha">
+		<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:attributeGroup ref="nome"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Marcador">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="markerreq">
+					<xsd:attributeGroup ref="nome"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="ConteudoExterno"  type="anyOther" />
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		HTML elements
+		Comment: Many elements are drawn directly from HTML 4.0
+		Pattern: Reuse Document Types (partial)
+		Reference: http://www.xmlpatterns.com/ReuseDocumentTypesMain.shtml
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="div" type="blocksreq" />
+
+	<xsd:element name="p" type="inline" />
+
+	<xsd:element name="li">
+		<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:choice minOccurs="0" maxOccurs="unbounded" >
+						<xsd:element ref="ul" />
+						<xsd:element ref="ol" />
+						<xsd:element ref="p"/>
+					</xsd:choice>
+					<xsd:attributeGroup ref="optvalue"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!--  <xsd:element name="span" type="inline"/> -->
+	<xsd:element name="span">
+	<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:attributeGroup ref="link"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="b" type="inline" />
+
+	<xsd:element name="i" type="inline" />
+
+	<xsd:element name="sub" type="inline" />
+
+	<xsd:element name="sup" type="inline" />
+
+	<xsd:element name="ins" type="inline" />
+
+	<xsd:element name="del" type="inline" />
+
+	<xsd:element name="dfn" type="inline" />
+
+	<xsd:element name="a">
+		<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:attributeGroup ref="link"/>
+					<xsd:attributeGroup ref="HTMLname"/>
+					<xsd:attribute name="target" type="xsd:string"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="img">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="markeropt">
+					<xsd:attribute name="src" type="xsd:anyURI" use="required"/>
+					<xsd:attribute name="alt" type="xsd:string"/>
+					<xsd:attribute name="width" type="xsd:integer"/>
+					<xsd:attribute name="height" type="xsd:integer"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="ul">
+		<xsd:complexType >
+			<xsd:sequence >
+				<xsd:element ref="li" minOccurs="1" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="ol">
+		<xsd:complexType >
+			<xsd:sequence >
+				<xsd:element ref="li" minOccurs="1" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="table">
+		<xsd:complexType >
+			<xsd:sequence >
+				<xsd:element ref="tr" minOccurs="1" maxOccurs="unbounded" />
+			</xsd:sequence>
+			<xsd:attributeGroup ref="HTMLattrs"/>
+			<xsd:attribute name="width" type="xsd:integer"/>
+			<xsd:attribute name="border" type="xsd:integer"/>
+			<xsd:attribute name="cellspacing" type="xsd:integer"/>
+			<xsd:attribute name="cellpadding" type="xsd:integer"/>
+			<xsd:attributeGroup ref="idreq"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="tr">
+		<xsd:complexType >
+			<xsd:choice minOccurs="1" maxOccurs="unbounded" >
+				<xsd:element ref="th" />
+				<xsd:element ref="td" />
+			</xsd:choice>
+				<xsd:attributeGroup ref="HTMLattrs"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="th">
+		<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:attributeGroup ref="cellattrs"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="td">
+		<xsd:complexType mixed="true">
+			<xsd:complexContent>
+				<xsd:extension base="inline">
+					<xsd:attributeGroup ref="cellattrs"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		Metadados
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:complexType name="MetaSection" >
+		<xsd:sequence >
+			<xsd:element ref="Identificacao" />
+			<xsd:element ref="CicloDeVida" minOccurs="0" maxOccurs="1" />
+		    <xsd:element ref="EventosGerados" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="Notas" minOccurs="0" maxOccurs="unbounded" />
+		    <xsd:element ref="Recursos" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="MetadadoProprietario" minOccurs="0" maxOccurs="unbounded" />
+		</xsd:sequence>
+	</xsd:complexType>
+
+    <xsd:element name="Metadado" type="MetaSection" />
+
+	<xsd:complexType name="IdentificacaoType" >
+        <xsd:attribute name="URN" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+
+    <xsd:element name="Identificacao" type="IdentificacaoType"/>
+
+	<xsd:element name="CicloDeVida">
+		<xsd:complexType >
+			<xsd:sequence>
+				<xsd:element ref="Evento" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="EventosGerados">
+		<xsd:complexType >
+			<xsd:sequence>
+				<xsd:element ref="Evento" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:element name="Evento">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="markerreq">
+				          <xsd:choice minOccurs="1" maxOccurs="unbounded">
+				                <xsd:element ref="Criacao"/>
+				                <xsd:element ref="Publicacao"/>
+				                <xsd:element ref="EntradaEmVigor"/>
+				                <xsd:element ref="Retificacao"/>
+				                <xsd:element ref="Republicacao"/>
+				                <xsd:element ref="RevogacaoTotal"/>
+				                <xsd:element ref="AnulamentoTotal"/>
+				                <xsd:element ref="AlteracaoFragmento"/>
+				                <!-- AlteraçãoFragmento inclui modificação (Substituicao Textual), Revogacao Parcial,
+				                      Anulamento Parcial e Derrubada de Veto Parcial-->
+				          </xsd:choice>
+				<xsd:attributeGroup ref="date"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="refURN" >
+		<xsd:attributeGroup ref="coreopt"/>
+		<xsd:attribute name="AlvoURN" type="xsd:anyURI"/>
+		<xsd:attribute name="FonteURN" type="xsd:anyURI"/>
+	</xsd:complexType>
+
+      	<xsd:complexType name="refURNSimples" >
+		<xsd:attributeGroup ref="coreopt"/>
+		<xsd:attribute name="URN" type="xsd:anyURI"/>
+	</xsd:complexType>
+
+                      <xsd:element name="Publicacao" type="refURN" />
+
+                      <xsd:element name="EntradaEmVigor" type="refURN"/>
+
+	<xsd:element name="Republicacao" type="refURN" />
+
+	<xsd:element name="Retificacao" type="refURN" />
+
+	<xsd:element name="ProjetoNormaOrigem" type="refURN" />
+
+	<xsd:element name="JulgadoOrigemAnulacao" type="refURN" />
+
+                      <xsd:element name="NormaFonte" type="refURN"/>
+
+                      <xsd:element name="MensagemVetoAplicado" type="refURN" />
+
+                       <xsd:element name="RevogacaoTotal" type="refURN"/>
+
+                       <xsd:element name="AnulamentoTotal" type="refURN"/>
+
+	<xsd:element name="Criacao">
+	      <xsd:complexType>
+	            <xsd:sequence>
+	                  <xsd:element ref="ProjetoNormaOrigem" minOccurs="0" maxOccurs="unbounded"/>
+	                  <xsd:element ref="JulgadoOrigemAnulacao" minOccurs="0" maxOccurs="unbounded"/>
+	                  <xsd:element ref="MensagemVetoAplicado" minOccurs="0" maxOccurs="unbounded"/>
+	            </xsd:sequence>
+	      </xsd:complexType>
+	</xsd:element>
+
+      	<xsd:complexType name="refURNAlvo" >
+		<xsd:attributeGroup ref="coreopt"/>
+		<xsd:attribute name="FonteURN" type="xsd:anyURI"/>
+      	                      <xsd:attribute name="AlvoURN"/>
+		<xsd:attribute name="AlvoLocal" type="xsd:IDREFS"/>
+      	                      <xsd:attribute name="FonteLocal" type="xsd:IDREFS"/>
+	</xsd:complexType>
+
+      	<xsd:complexType name="URNtype" >
+		<xsd:attributeGroup ref="coreopt"/>
+		<xsd:attribute name="URN" type="xsd:anyURI"/>
+	</xsd:complexType>
+
+                      <xsd:element name="AlteracaoFragmento">
+                             <xsd:complexType>
+                                   <xsd:sequence>
+                                         <xsd:element ref="ModificacaoTextual" minOccurs="0" maxOccurs="unbounded"/>
+                                         <xsd:element ref="RevogacaoParcial" minOccurs="0" maxOccurs="unbounded"/>
+                                         <xsd:element ref="AnulamentoParcial" minOccurs="0" maxOccurs="unbounded"/>
+                                         <xsd:element ref="DerrubadaVetoParcial" minOccurs="0" maxOccurs="unbounded"/>
+                                   </xsd:sequence>
+                             </xsd:complexType>
+                       </xsd:element>
+
+                       <xsd:element name="ModificacaoTextual" type="refURNAlvo"/>
+                       <xsd:element name="RevogacaoParcial" type="refURNAlvo"/>
+                       <xsd:element name="AnulamentoParcial" type="refURNAlvo"/>
+                       <xsd:element name="DerrubadaVetoParcial" type="refURNAlvo"/>
+
+
+	<xsd:element name="Notas">
+		<xsd:complexType >
+			<xsd:sequence minOccurs="1" maxOccurs="unbounded" >
+				<xsd:element ref="Nota" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Nota">
+	      <xsd:complexType>
+	            <xsd:complexContent>
+	                  <xsd:extension base="textoType">
+	                        <xsd:attribute name="exporta" type="xsd:boolean"/>
+	                        <xsd:attribute name="dataInclusao" type="xsd:date"/>
+	                        <xsd:attribute name="autor" type="xsd:IDREF"/>
+	                  </xsd:extension>
+	            </xsd:complexContent>
+	      </xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Recursos">
+		<xsd:complexType >
+			<xsd:sequence minOccurs="1" maxOccurs="unbounded" >
+				<xsd:element ref="Recurso" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="Recurso" type="markerreq" />
+
+	<xsd:element name="MetadadoProprietario">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="xsd:anyType">
+					<xsd:attributeGroup ref="source"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:annotation>
+        <xsd:documentation>
+         =====================================================================
+
+        Elementos e tipos abstratos
+
+        =====================================================================
+        </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:element name="_Parte" abstract="true"/>
+    <xsd:element name="_Livro" abstract="true"/>
+    <xsd:element name="_Titulo" abstract="true"/>
+    <xsd:element name="_Capitulo" abstract="true"/>
+    <xsd:element name="_Secao" abstract="true"/>
+    <xsd:element name="_Subsecao" abstract="true"/>
+    <xsd:element name="_Artigo" abstract="true"/>
+    <xsd:element name="_Caput" abstract="true"/>
+    <xsd:element name="_Paragrafo" abstract="true"/>
+    <xsd:element name="_Inciso" abstract="true"/>
+    <xsd:element name="_Alinea" abstract="true"/>
+    <xsd:element name="_Item" abstract="true"/>
+
+    <xsd:simpleType name="idArtigo">
+        <xsd:restriction base="xsd:ID"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="idOmissis">
+        <xsd:restriction base="xsd:ID"/>
+    </xsd:simpleType>
+
+    <xsd:complexType name="DispositivoType"/>
+
+    <xsd:annotation>
+        <xsd:documentation>
+         =====================================================================
+
+        End of Schema
+
+        =====================================================================
+        </xsd:documentation>
+    </xsd:annotation>
+
+</xsd:schema>

--- a/tests/fixtures/lexml/lexml-br-rigido.xsd
+++ b/tests/fixtures/lexml/lexml-br-rigido.xsd
@@ -1,0 +1,470 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsd:schema targetNamespace="http://www.lexml.gov.br/1.0"
+	xmlns="http://www.lexml.gov.br/1.0"
+	elementFormDefault="qualified"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+
+    <xsd:redefine schemaLocation="lexml-base.xsd">
+
+	<xsd:simpleType name="idArtigo">
+		<xsd:annotation>
+			<xsd:documentation>
+				A regras abaixo tratam dos IDs de dispositivos no nível de artigo para baixo.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="idArtigo">
+			<xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)((_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_(inc|dpg)\d+(-[0-9]{1,3}){0,3}(_(ali|dpg)\d+(-[0-9]{1,3}){0,3}(_(ite|dpg)\d+(-[0-9]{1,3}){0,3})?)?)?)?"></xsd:pattern>
+            <xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+(_art(\d+(-[0-9]{1,3}){0,3}|1u)((_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_(inc|dpg)\d+(-[0-9]{1,3}){0,3})?(_(ali|dpg)\d+(-[0-9]{1,3}){0,3}(_(ite|dpg)\d+(-[0-9]{1,3}){0,3})?)?)?)?"></xsd:pattern>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+    <xsd:simpleType name="idOmissis">
+        <xsd:restriction base="idOmissis">
+            <xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+(_art(\d+(-[0-9]{1,3}){0,3}|1u)((_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_(inc|dpg)\d+(-[0-9]{1,3}){0,3}(_(ali|dpg)\d+(-[0-9]{1,3}){0,3}(_(ite|dpg)\d+(-[0-9]{1,3}){0,3})?)?)?)?)?_omi\d+"></xsd:pattern>
+            <xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_(prt|agh)\d+(-[0-9]{1,3}){0,3}_omi\d+"></xsd:pattern>
+            <xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_((prt|agh)\d+(-[0-9]{1,3}){0,3}_)?(liv|agh)\d+(-[0-9]{1,3}){0,3}_omi\d+"></xsd:pattern>
+            <xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_(((prt|agh)\d+(-[0-9]{1,3}){0,3}_)?(liv|agh)\d+(-[0-9]{1,3}){0,3}_)?(tit|agh)\d+(-[0-9]{1,3}){0,3}_omi\d+"></xsd:pattern>
+            <xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_((((prt|agh)\d+(-[0-9]{1,3}){0,3}_)?(liv|agh)\d+(-[0-9]{1,3}){0,3}_)?(tit|agh)\d+(-[0-9]{1,3}){0,3}_)?(cap|agh)\d+(-[0-9]{1,3}){0,3}_omi\d+"></xsd:pattern>
+            <xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_(((((prt|agh)\d+(-[0-9]{1,3}){0,3}_)?(liv|agh)\d+(-[0-9]{1,3}){0,3}_)?(tit|agh)\d+(-[0-9]{1,3}){0,3}_)?(cap|agh)\d+(-[0-9]{1,3}){0,3}_)?(sec|agh)\d+(-[0-9]{1,3}){0,3}_omi\d+"></xsd:pattern>
+            <xsd:pattern value="art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_(((((prt|agh)\d+(-[0-9]{1,3}){0,3}_)?(liv|agh)\d+(-[0-9]{1,3}){0,3}_)?(tit|agh)\d+(-[0-9]{1,3}){0,3}_)?(cap|agh)\d+(-[0-9]{1,3}){0,3}_)?(sec|agh)\d+(-[0-9]{1,3}){0,3}_(sub|agh)\d+(-[0-9]{1,3}){0,3}_omi\d+"></xsd:pattern>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="DispositivoType" >
+        <xsd:complexContent>
+            <xsd:extension base="DispositivoType">
+                <xsd:sequence>
+                    <xsd:element ref="TituloDispositivo" minOccurs="0" maxOccurs="1" />
+                    <xsd:element ref="Rotulo" minOccurs="0" maxOccurs="1" />
+                    <xsd:element ref="p" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element ref="Alteracao" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element ref="DispositivoGenerico" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+                <xsd:attributeGroup ref="corereqArt"/>
+                <xsd:attributeGroup ref="linkopt"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="AlteracaoType" mixed="true">
+        <xsd:complexContent>
+            <xsd:extension base="AlteracaoType">
+                <xsd:choice minOccurs="1" maxOccurs="unbounded" >
+                    <xsd:group ref="parteInicialElements" />
+                    <!--
+                    <xsd:element ref="AgrupamentoHierarquico"/>
+                     -->
+                    <xsd:element name="Parte" type="ParteEmAlteracaoType"/>
+                    <xsd:element name="Livro" type="LivroEmAlteracaoType"/>
+                    <xsd:element name="Titulo" type="TituloEmAlteracaoType"/>
+                    <xsd:element name="Capitulo" type="CapituloEmAlteracaoType"/>
+                    <xsd:element name="Secao" type="SecaoEmAlteracaoType"/>
+                    <xsd:element name="Subsecao" type="SubsecaoEmAlteracaoType"/>
+                    <xsd:element name="Artigo" type="ArtigoEmAlteracaoType" />
+                    <xsd:element name="Paragrafo" type="ParagrafoEmAlteracaoType"/>
+                    <xsd:element name="Inciso" type="IncisoEmAlteracaoType"/>
+                    <xsd:element name="Alinea" type="AlineaEmAlteracaoType"/>
+                    <xsd:element name="Item" type="ItemEmAlteracaoType"/>
+                    <xsd:element ref="Omissis"/>
+                </xsd:choice>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    </xsd:redefine>
+
+	<xsd:simpleType name="idAgregador">
+		<xsd:annotation>
+			<xsd:documentation>
+				A regras abaixo tratam dos IDs de dispositivos no nível de artigo para cima.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:ID">
+			<xsd:pattern value="(art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_)?(prt|agh)(\d+(-[0-9]{1,3}){0,3}|1u)"></xsd:pattern>
+			<xsd:pattern value="(art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_)?((prt|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(liv|agh)(\d+(-[0-9]{1,3}){0,3}|1u)"></xsd:pattern>
+			<xsd:pattern value="(art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_)?(((prt|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(liv|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(tit|agh)(\d+(-[0-9]{1,3}){0,3}|1u)"></xsd:pattern>
+			<xsd:pattern value="(art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_)?((((prt|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(liv|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(tit|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(cap|agh)(\d+(-[0-9]{1,3}){0,3}|1u)"></xsd:pattern>
+			<xsd:pattern value="(art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_)?(((((prt|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(liv|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(tit|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(cap|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(sec|agh)(\d+(-[0-9]{1,3}){0,3}|1u)"></xsd:pattern>
+			<xsd:pattern value="(art(\d+(-[0-9]{1,3}){0,3}|1u)(_cpt|(_(par|dpg)(\d+(-[0-9]{1,3}){0,3}|1u)))(_inc\d+(-[0-9]{1,3}){0,3})?_alt\d+_)?(((((prt|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(liv|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(tit|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(cap|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_)?(sec|agh)(\d+(-[0-9]{1,3}){0,3}|1u)_(sub|agh)(\d+(-[0-9]{1,3}){0,3}|1u)"></xsd:pattern>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+    <xsd:annotation>
+        <xsd:documentation>
+		=====================================================================
+
+		Elements for hierarchical documents
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+    <xsd:complexType name="PenaEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="PenaType">
+                <xsd:attributeGroup ref="attrsCitacao"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="hierarchyEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="hierarchy">
+                <xsd:attributeGroup ref="attrsCitacao"/>
+                <xsd:attributeGroup ref="linkopt"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="DispositivoEmAlteracaoType" >
+        <xsd:complexContent>
+            <xsd:extension base="DispositivoType">
+                <xsd:attributeGroup ref="attrsCitacao"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+
+	<xsd:element name="Parte" substitutionGroup="_Parte">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="hierarchy">
+					<xsd:sequence>
+						<xsd:element ref="Artigo" minOccurs="0" maxOccurs="unbounded" />
+						<xsd:element ref="Livro" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="ParteEmAlteracaoType">
+		<xsd:complexContent>
+			<xsd:extension base="hierarchyEmAlteracaoType">
+				<xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="Artigo" type="ArtigoEmAlteracaoType" />
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+					<xsd:element name="Livro" type="LivroEmAlteracaoType" minOccurs="0" maxOccurs="unbounded" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="Livro" substitutionGroup="_Livro">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="hierarchy">
+					<xsd:sequence>
+						<xsd:element ref="Artigo" minOccurs="0" maxOccurs="unbounded" />
+						<xsd:element ref="Titulo" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="LivroEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="hierarchyEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="Artigo" type="ArtigoEmAlteracaoType" />
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+                    <xsd:element name="Titulo" type="TituloEmAlteracaoType" minOccurs="0" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:element name="Titulo" substitutionGroup="_Titulo">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="hierarchy">
+					<xsd:sequence>
+						<xsd:element ref="Artigo" minOccurs="0" maxOccurs="unbounded" />
+						<xsd:element ref="Capitulo" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="TituloEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="hierarchyEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="Artigo" type="ArtigoEmAlteracaoType" />
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+                    <xsd:element name="Capitulo" type="CapituloEmAlteracaoType" minOccurs="0" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+
+	<xsd:element name="Capitulo" substitutionGroup="_Capitulo">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="hierarchy">
+					<xsd:sequence>
+						<xsd:element ref="Artigo" minOccurs="0" maxOccurs="unbounded" />
+						<xsd:element ref="Secao" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="CapituloEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="hierarchyEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="Artigo" type="ArtigoEmAlteracaoType" />
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+                    <xsd:element name="Secao" type="SecaoEmAlteracaoType" minOccurs="0" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:element name="Secao" substitutionGroup="_Secao">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="hierarchy">
+					<xsd:sequence>
+						<xsd:element ref="Artigo" minOccurs="0" maxOccurs="unbounded" />
+						<xsd:element ref="Subsecao" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="SecaoEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="hierarchyEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="Artigo" type="ArtigoEmAlteracaoType" />
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+                    <xsd:element name="Subsecao" type="SubsecaoEmAlteracaoType" minOccurs="0" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:element name="Subsecao" substitutionGroup="_Subsecao">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="hierarchy">
+					<xsd:sequence>
+						<xsd:element ref="Artigo" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="SubsecaoEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="hierarchyEmAlteracaoType">
+                <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                    <xsd:element name="Artigo" type="ArtigoEmAlteracaoType" />
+                    <xsd:element ref="Omissis"/>
+                </xsd:choice>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:complexType name="ArticleType">
+		<xsd:sequence >
+            <xsd:element ref="TituloDispositivo" minOccurs="0" maxOccurs="1" />
+			<xsd:element ref="Rotulo" minOccurs="1" maxOccurs="1" />
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element ref="Caput" minOccurs="1" maxOccurs="1" />
+  					<xsd:element ref="Paragrafo" minOccurs="0" maxOccurs="unbounded" />
+				</xsd:sequence>
+				<xsd:element ref="DispositivoGenerico" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:choice>
+		</xsd:sequence>
+		<xsd:attributeGroup ref="corereqArt"/>
+		<xsd:attributeGroup ref="linkopt"/>
+	</xsd:complexType>
+
+	<xsd:element name="Artigo" type="ArticleType" substitutionGroup="_Artigo"/>
+
+	<xsd:complexType name="ArtigoEmAlteracaoType" >
+		<xsd:sequence >
+			<xsd:element ref="TituloDispositivo" minOccurs="0" maxOccurs="1" />
+			<xsd:element ref="Rotulo" minOccurs="1" maxOccurs="1" />
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element name="Caput" type="CaputEmAlteracaoType" />
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded" >
+    					<xsd:element name="Paragrafo" type="ParagrafoEmAlteracaoType" minOccurs="0" maxOccurs="unbounded" />
+    					<xsd:element ref="Omissis" minOccurs="0" maxOccurs="unbounded" />
+                    </xsd:choice>
+				</xsd:sequence>
+				<xsd:element ref="DispositivoGenerico" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:choice>
+		</xsd:sequence>
+		<xsd:attributeGroup ref="corereqArt"/>
+		<xsd:attributeGroup ref="linkopt"/>
+		<xsd:attributeGroup ref="attrsCitacao"/>
+	</xsd:complexType>
+
+	<xsd:element name="Caput" substitutionGroup="_Caput">
+		<xsd:complexType>
+			<xsd:complexContent>
+                <xsd:extension base="DispositivoType">
+                    <xsd:sequence>
+                        <xsd:element ref="Inciso" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element ref="Pena" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="CaputEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="DispositivoEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded" >
+                        <xsd:element name="Inciso" type="IncisoEmAlteracaoType"/>
+                        <xsd:element name="Alinea" type="AlineaEmAlteracaoType"/>
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+                    <xsd:element name="Pena" type="PenaEmAlteracaoType" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:element name="Inciso" substitutionGroup="_Inciso">
+		<xsd:complexType>
+			<xsd:complexContent>
+                <xsd:extension base="DispositivoType">
+                    <xsd:sequence>
+                        <xsd:element ref="Alinea" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element ref="Pena" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="IncisoEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="DispositivoEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded" >
+                        <xsd:element name="Alinea" type="AlineaEmAlteracaoType"/>
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+                    <xsd:element name="Pena" type="PenaEmAlteracaoType" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:element name="Alinea" substitutionGroup="_Alinea">
+		<xsd:complexType>
+			<xsd:complexContent>
+                <xsd:extension base="DispositivoType">
+                    <xsd:sequence>
+                        <xsd:element ref="Item" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element ref="Pena" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="AlineaEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="DispositivoEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded" >
+                        <xsd:element name="Item" type="ItemEmAlteracaoType"/>
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+                    <xsd:element name="Pena" type="PenaEmAlteracaoType" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:element name="Paragrafo" substitutionGroup="_Paragrafo">
+		<xsd:complexType>
+			<xsd:complexContent>
+                <xsd:extension base="DispositivoType">
+                    <xsd:sequence>
+                        <xsd:element ref="Inciso" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element ref="Pena" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:complexType name="ParagrafoEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="DispositivoEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded" >
+                        <xsd:element name="Inciso" type="IncisoEmAlteracaoType"/>
+                        <xsd:element name="Alinea" type="AlineaEmAlteracaoType"/>
+                        <xsd:element ref="Omissis"/>
+                    </xsd:choice>
+                    <xsd:element name="Pena" type="PenaEmAlteracaoType" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:element name="Item" substitutionGroup="_Item">
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="DispositivoType">
+                    <xsd:sequence>
+                        <xsd:element ref="Pena" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:complexType name="ItemEmAlteracaoType">
+        <xsd:complexContent>
+            <xsd:extension base="DispositivoEmAlteracaoType">
+                <xsd:sequence>
+                    <xsd:element name="Pena" type="PenaEmAlteracaoType" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:annotation>
+		<xsd:documentation>
+		 =====================================================================
+
+		End of Schema
+
+		=====================================================================
+		</xsd:documentation>
+	</xsd:annotation>
+
+</xsd:schema>

--- a/tests/fixtures/lexml/mathml2.xsd
+++ b/tests/fixtures/lexml/mathml2.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Stub minimal de MathML2 para validação LexML offline.
+
+  O LexML brasileiro importa o schema oficial MathML2 da W3C (~50
+  arquivos) só para permitir <math> opcional dentro de algumas
+  estruturas. Leis brasileiras quase nunca usam MathML — bundlear
+  o schema completo seria absurdo para esse 1 elemento opcional.
+
+  Este stub declara o namespace MathML e o elemento <math> como
+  conteúdo livre (xsd:anyType). Se uma lei real usar MathML
+  estruturado, a validação aqui aceita tudo — sem garantir
+  conformidade MathML. Para validação rigorosa, substituir por
+  mathml2.xsd oficial e seus dependentes.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.w3.org/1998/Math/MathML"
+            xmlns="http://www.w3.org/1998/Math/MathML"
+            elementFormDefault="qualified">
+  <xsd:element name="math" type="xsd:anyType"/>
+</xsd:schema>

--- a/tests/fixtures/lexml/xlink-href.xsd
+++ b/tests/fixtures/lexml/xlink-href.xsd
@@ -1,0 +1,20 @@
+<schema targetNamespace="http://www.w3.org/1999/xlink" 
+        xmlns:xlink="http://www.w3.org/1999/xlink" 
+        xmlns="http://www.w3.org/2001/XMLSchema">
+  <annotation>
+    <documentation xml:lang="en">
+      This schema provides the XLink href attribute for use in the MathML2 
+      schema. Written by Max Froumentin, W3C.
+    </documentation>
+  </annotation>
+
+  <attribute name="href" type="anyURI"/>
+</schema>
+
+     
+<!--
+  Copyright &#251; 2002 World Wide Web Consortium, (Massachusetts Institute
+  of Technology, Institut National de Recherche en Informatique et en
+  Automatique, Keio University). All Rights Reserved. See
+  http://www.w3.org/Consortium/Legal/.
+  -->

--- a/tests/fixtures/lexml/xml.xsd
+++ b/tests/fixtures/lexml/xml.xsd
@@ -1,0 +1,145 @@
+<?xml version='1.0'?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    id   (as an attribute name): denotes an attribute whose value
+         should be interpreted as if declared to be of type ID.
+         This name is reserved by virtue of its definition in the
+         xml:id specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang, xml:space or xml:id
+        attributes on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .>
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .>
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/>
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2007/08/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself, or with the XML namespace itself.  In other words, if the XML
+   Schema or XML namespaces change, the version of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2007/08/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>Attempting to install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values is probably never
+         going to be a realistic possibility.  See
+         RFC 3066 at http://www.ietf.org/rfc/rfc3066.txt and the IANA registry
+         at http://www.iana.org/assignments/lang-tag-apps.htm for
+         further information.
+
+         The union allows for the 'un-declaration' of xml:lang with
+         the empty string.</xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xml-id/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+</xs:schema>

--- a/tests/test_lexml_export.py
+++ b/tests/test_lexml_export.py
@@ -102,17 +102,83 @@ def test_xslt_emits_identificacao_urn() -> None:
         assert "URN=" in lexml_xml
 
 
-def test_xslt_drops_known_losses() -> None:
-    """Smoke: ocr-ruim dispositivos are NOT emitted (LexML has no
-    equivalent). Anexos are also dropped (would require ReferenciaAnexo
-    + separate documents). See SCHEMA.md §6.2 + XSLT header comment
-    for full list of known losses."""
-    parcial = FIXTURES / "with-parse-parcial.xml"
-    if parcial.exists():
-        lexml_xml = _xslt(parcial)
-        # ocr-ruim content (if any in fixture) doesn't bleed into LexML.
-        # The fixture has only regular dispositivos with raw OCR text in
-        # <texto>, which IS emitted — what's dropped is the dispositivo
-        # itself when path starts with "ocr-ruim".
-        # This test is mostly a documentation marker.
-        assert "<LexML" in lexml_xml
+def test_xslt_drops_ocr_ruim_dispositivos(tmp_path: Path) -> None:
+    """XSLT pula <dispositivo path="ocr-ruim*"> — LexML não tem
+    equivalente. Documentado em SCHEMA.md §6.2 + XSLT header.
+
+    Constrói fixture inline com 1 dispositivo válido + 1 ocr-ruim e
+    confirma que o LexML resultante contém apenas o primeiro.
+    """
+    fixture = tmp_path / "with-ocr-ruim-inline.xml"
+    fixture.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:1990-03-20;500"
+     vigente-em="2026-05-20">
+  <dispositivo path="art-1">
+    <versao>
+      <texto>Texto parseado normal.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </versao>
+  </dispositivo>
+  <dispositivo path="ocr-ruim-1">
+    <versao>
+      <texto>Tre|ho i||egí|el n0 OCR</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
+    </versao>
+  </dispositivo>
+</lei>
+""",
+        encoding="utf-8",
+    )
+    lexml_xml = _xslt(fixture)
+
+    # XSLT deve produzir LexML com art-1 mas SEM ocr-ruim.
+    assert "Texto parseado normal." in lexml_xml, (
+        "dispositivo regular deveria estar no LexML"
+    )
+    assert "Tre|ho" not in lexml_xml, (
+        f"ocr-ruim NÃO deveria vazar pro LexML:\n{lexml_xml}"
+    )
+    assert "ocr-ruim" not in lexml_xml, (
+        f"id/path ocr-ruim NÃO deveria aparecer no LexML:\n{lexml_xml}"
+    )
+
+    # Sanity: validação contra XSD ainda passa.
+    code, stderr = _validate_lexml(lexml_xml)
+    assert code == 0, f"LexML inválido:\n{stderr}"
+
+
+def test_xslt_drops_anexos(tmp_path: Path) -> None:
+    """Anexos no Leizilla XML (path="anexo-N") não viram <Articulacao>
+    em LexML — LexML modela anexos via <ReferenciaAnexo> em documentos
+    separados. Documentado em SCHEMA.md §6.2."""
+    fixture = tmp_path / "with-anexo-inline.xml"
+    fixture.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:2000-01-01;1234"
+     vigente-em="2026-05-20">
+  <dispositivo path="art-1">
+    <versao>
+      <texto>Corpo da lei.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+    </versao>
+  </dispositivo>
+  <dispositivo path="anexo-1">
+    <versao>
+      <texto>Tabela ANEXA — não deveria aparecer no LexML export.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
+    </versao>
+  </dispositivo>
+</lei>
+""",
+        encoding="utf-8",
+    )
+    lexml_xml = _xslt(fixture)
+    assert "Corpo da lei." in lexml_xml
+    assert "Tabela ANEXA" not in lexml_xml, (
+        f"anexo NÃO deveria vazar pro LexML:\n{lexml_xml}"
+    )
+    code, _ = _validate_lexml(lexml_xml)
+    assert code == 0

--- a/tests/test_lexml_export.py
+++ b/tests/test_lexml_export.py
@@ -32,14 +32,18 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _xslt(fixture: Path) -> str:
-    """Apply XSLT to fixture, return LexML XML as string."""
-    result = subprocess.run(
-        ["xsltproc", str(XSLT), str(fixture)],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+def _xslt(fixture: Path, output_dir: Path | None = None) -> str:
+    """Apply XSLT to fixture, return LexML XML do principal como string.
+
+    `output_dir` (opcional): se a lei tem `<dispositivo path="anexo-N">`,
+    o XSLT escreve `{output_dir}/anexo-N.lexml.xml` (via exsl:document).
+    Default: cwd. Caller que precisa coletar anexos deve passar tmp_path.
+    """
+    args = ["xsltproc"]
+    if output_dir is not None:
+        args.extend(["--param", "output-dir", f"'{output_dir}'"])
+    args.extend([str(XSLT), str(fixture)])
+    result = subprocess.run(args, capture_output=True, text=True, check=True)
     return result.stdout
 
 
@@ -55,20 +59,23 @@ def _validate_lexml(xml_str: str) -> tuple[int, str]:
 
 
 @pytest.mark.parametrize("fixture", sorted(FIXTURES.glob("*.xml")))
-def test_xslt_produces_valid_lexml(fixture: Path) -> None:
+def test_xslt_produces_valid_lexml(fixture: Path, tmp_path: Path) -> None:
     """Every Leizilla fixture, after XSLT, must validate against the
-    official LexML XSD (lexml-br-rigido.xsd, bundled in tests/fixtures/lexml/)."""
-    lexml_xml = _xslt(fixture)
+    official LexML XSD (lexml-br-rigido.xsd, bundled in tests/fixtures/lexml/).
+
+    tmp_path isola output-dir — fixtures com anexos geram arquivos
+    separados que não devem poluir o cwd nem o repo."""
+    lexml_xml = _xslt(fixture, output_dir=tmp_path)
     code, stderr = _validate_lexml(lexml_xml)
     assert code == 0, f"LexML validation failed for {fixture.name}:\n{stderr}"
 
 
-def test_xslt_output_is_well_formed_xml() -> None:
+def test_xslt_output_is_well_formed_xml(tmp_path: Path) -> None:
     """Independent of XSD: every output must at least be well-formed XML.
     Catches XSLT regressions that produce malformed output (which would
     fail the LexML validation upstream)."""
     for fixture in FIXTURES.glob("*.xml"):
-        lexml_xml = _xslt(fixture)
+        lexml_xml = _xslt(fixture, output_dir=tmp_path)
         # xmllint with --noout but no --schema = just well-formedness check.
         result = subprocess.run(
             ["xmllint", "--noout", "-"],
@@ -81,31 +88,37 @@ def test_xslt_output_is_well_formed_xml() -> None:
         )
 
 
-def test_xslt_emits_lexml_root_element() -> None:
+def test_xslt_emits_lexml_root_element(tmp_path: Path) -> None:
     """Smoke: every output has <LexML> as root in the official namespace.
     Tests the basic shape of the conversion without parsing structure."""
     for fixture in FIXTURES.glob("*.xml"):
-        lexml_xml = _xslt(fixture)
+        lexml_xml = _xslt(fixture, output_dir=tmp_path)
         assert 'xmlns="http://www.lexml.gov.br/1.0"' in lexml_xml, (
             f"{fixture.name} output missing LexML namespace"
         )
         assert "<LexML" in lexml_xml, f"{fixture.name} output missing <LexML> root"
 
 
-def test_xslt_emits_identificacao_urn() -> None:
+def test_xslt_emits_identificacao_urn(tmp_path: Path) -> None:
     """Smoke: every output has <Identificacao URN="...">. URN content
     correctness is the responsibility of the Leizilla checker (§7.10);
     here we only confirm the LexML envelope wires it through."""
     for fixture in FIXTURES.glob("*.xml"):
-        lexml_xml = _xslt(fixture)
+        lexml_xml = _xslt(fixture, output_dir=tmp_path)
         assert "<Identificacao" in lexml_xml
         assert "URN=" in lexml_xml
 
 
-def test_xslt_drops_anexos(tmp_path: Path) -> None:
-    """Anexos no Leizilla XML (path="anexo-N") não viram <Articulacao>
-    em LexML — LexML modela anexos via <ReferenciaAnexo> em documentos
-    separados. Documentado em SCHEMA.md §6.2."""
+def test_xslt_emits_anexo_as_separate_document(tmp_path: Path) -> None:
+    """Anexos no Leizilla XML (path='anexo-N') viram:
+    (a) <ReferenciaAnexo AlvoURN='{lei.urn}!anexo-N'/> no documento
+        principal, dentro de <Norma>/<Anexos>.
+    (b) Arquivo LexML separado `{output_dir}/anexo-N.lexml.xml` com
+        <Anexo><DocumentoGenerico><PartePrincipal><p>{texto}</p>.
+
+    Modelo LexML: anexos são documentos linkados via URN, não estruturas
+    inline. Documentado em SCHEMA.md §6 e no XSLT header.
+    """
     fixture = tmp_path / "with-anexo-inline.xml"
     fixture.write_text(
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -120,7 +133,7 @@ def test_xslt_drops_anexos(tmp_path: Path) -> None:
   </dispositivo>
   <dispositivo path="anexo-1">
     <versao>
-      <texto>Tabela ANEXA — não deveria aparecer no LexML export.</texto>
+      <texto>Tabela do Anexo 1 — conteúdo aqui.</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-01234"/>
     </versao>
   </dispositivo>
@@ -128,10 +141,80 @@ def test_xslt_drops_anexos(tmp_path: Path) -> None:
 """,
         encoding="utf-8",
     )
-    lexml_xml = _xslt(fixture)
-    assert "Corpo da lei." in lexml_xml
-    assert "Tabela ANEXA" not in lexml_xml, (
-        f"anexo NÃO deveria vazar pro LexML:\n{lexml_xml}"
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    lexml_main = _xslt(fixture, output_dir=out_dir)
+
+    # (a) Principal contém ReferenciaAnexo, NÃO contém o texto do anexo.
+    assert "Corpo da lei." in lexml_main
+    assert "<ReferenciaAnexo" in lexml_main, (
+        f"Principal deveria conter <ReferenciaAnexo>:\n{lexml_main}"
     )
-    code, _ = _validate_lexml(lexml_xml)
-    assert code == 0
+    assert (
+        'AlvoURN="urn:lex:br;estado:rondonia;lei:2000-01-01;1234!anexo-1"' in lexml_main
+    ), f"AlvoURN incorreta:\n{lexml_main}"
+    assert "Tabela do Anexo" not in lexml_main, (
+        f"texto do anexo não deveria vazar pro principal:\n{lexml_main}"
+    )
+    # Principal valida.
+    code, stderr = _validate_lexml(lexml_main)
+    assert code == 0, f"Principal inválido:\n{stderr}"
+
+    # (b) Arquivo separado existe, tem o texto, URN bate, valida.
+    anexo_file = out_dir / "anexo-1.lexml.xml"
+    assert anexo_file.exists(), f"arquivo do anexo não gerado em {out_dir}"
+    anexo_content = anexo_file.read_text(encoding="utf-8")
+    assert "Tabela do Anexo 1" in anexo_content
+    assert (
+        'URN="urn:lex:br;estado:rondonia;lei:2000-01-01;1234!anexo-1"' in anexo_content
+    )
+    assert "<Anexo>" in anexo_content
+    assert "<DocumentoGenerico" in anexo_content
+    code, stderr = _validate_lexml(anexo_content)
+    assert code == 0, f"Anexo inválido:\n{stderr}"
+
+
+def test_xslt_emits_multiple_anexos_as_separate_files(tmp_path: Path) -> None:
+    """Lei com 2 anexos → 2 arquivos separados + 2 <ReferenciaAnexo>."""
+    fixture = tmp_path / "with-2-anexos.xml"
+    fixture.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"
+     urn-lex="urn:lex:br;estado:rondonia;lei:2010-01-01;5555"
+     vigente-em="2026-05-20">
+  <dispositivo path="art-1">
+    <versao>
+      <texto>Corpo.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-05555"/>
+    </versao>
+  </dispositivo>
+  <dispositivo path="anexo-1">
+    <versao>
+      <texto>Primeiro anexo.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-05555"/>
+    </versao>
+  </dispositivo>
+  <dispositivo path="anexo-2">
+    <versao>
+      <texto>Segundo anexo.</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-05555"/>
+    </versao>
+  </dispositivo>
+</lei>
+""",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    lexml_main = _xslt(fixture, output_dir=out_dir)
+
+    # 2 ReferenciaAnexo no principal.
+    assert lexml_main.count("<ReferenciaAnexo") == 2
+    # 2 arquivos separados, ambos validam.
+    for n, txt in ((1, "Primeiro anexo."), (2, "Segundo anexo.")):
+        f = out_dir / f"anexo-{n}.lexml.xml"
+        assert f.exists(), f"anexo-{n}.lexml.xml não gerado"
+        content = f.read_text(encoding="utf-8")
+        assert txt in content
+        code, stderr = _validate_lexml(content)
+        assert code == 0, f"anexo-{n} inválido:\n{stderr}"

--- a/tests/test_lexml_export.py
+++ b/tests/test_lexml_export.py
@@ -1,0 +1,118 @@
+"""Tests for scripts/leizilla-to-lexml.xsl.
+
+For each Leizilla XML fixture in tests/fixtures/leizilla_xml/, applies
+the XSLT and validates the output against the official LexML brasileiro
+XSD bundled in tests/fixtures/lexml/.
+
+CI gate (SCHEMA.md §6): LexML is reduced representation generated on
+demand for gov interop. Round-trip (LexML → Leizilla XML) is NOT a
+goal. Known losses documented inline in the XSLT and in SCHEMA.md §6.2.
+
+Requires `xsltproc` and `xmllint` (libxml2-utils). The CI workflow
+installs both via apt.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "leizilla_xml"
+XSLT = REPO_ROOT / "scripts" / "leizilla-to-lexml.xsl"
+LEXML_XSD = REPO_ROOT / "tests" / "fixtures" / "lexml" / "lexml-br-rigido.xsd"
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("xsltproc") is None or shutil.which("xmllint") is None,
+    reason="xsltproc and xmllint required (apt install libxml2-utils xsltproc)",
+)
+
+
+def _xslt(fixture: Path) -> str:
+    """Apply XSLT to fixture, return LexML XML as string."""
+    result = subprocess.run(
+        ["xsltproc", str(XSLT), str(fixture)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _validate_lexml(xml_str: str) -> tuple[int, str]:
+    """Validate XML string against LexML XSD. Returns (exit_code, stderr)."""
+    result = subprocess.run(
+        ["xmllint", "--noout", "--schema", str(LEXML_XSD), "-"],
+        input=xml_str,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stderr
+
+
+@pytest.mark.parametrize("fixture", sorted(FIXTURES.glob("*.xml")))
+def test_xslt_produces_valid_lexml(fixture: Path) -> None:
+    """Every Leizilla fixture, after XSLT, must validate against the
+    official LexML XSD (lexml-br-rigido.xsd, bundled in tests/fixtures/lexml/)."""
+    lexml_xml = _xslt(fixture)
+    code, stderr = _validate_lexml(lexml_xml)
+    assert code == 0, f"LexML validation failed for {fixture.name}:\n{stderr}"
+
+
+def test_xslt_output_is_well_formed_xml() -> None:
+    """Independent of XSD: every output must at least be well-formed XML.
+    Catches XSLT regressions that produce malformed output (which would
+    fail the LexML validation upstream)."""
+    for fixture in FIXTURES.glob("*.xml"):
+        lexml_xml = _xslt(fixture)
+        # xmllint with --noout but no --schema = just well-formedness check.
+        result = subprocess.run(
+            ["xmllint", "--noout", "-"],
+            input=lexml_xml,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"XSLT produced malformed XML for {fixture.name}:\n{result.stderr}"
+        )
+
+
+def test_xslt_emits_lexml_root_element() -> None:
+    """Smoke: every output has <LexML> as root in the official namespace.
+    Tests the basic shape of the conversion without parsing structure."""
+    for fixture in FIXTURES.glob("*.xml"):
+        lexml_xml = _xslt(fixture)
+        assert 'xmlns="http://www.lexml.gov.br/1.0"' in lexml_xml, (
+            f"{fixture.name} output missing LexML namespace"
+        )
+        assert "<LexML" in lexml_xml, f"{fixture.name} output missing <LexML> root"
+
+
+def test_xslt_emits_identificacao_urn() -> None:
+    """Smoke: every output has <Identificacao URN="...">. URN content
+    correctness is the responsibility of the Leizilla checker (§7.10);
+    here we only confirm the LexML envelope wires it through."""
+    for fixture in FIXTURES.glob("*.xml"):
+        lexml_xml = _xslt(fixture)
+        assert "<Identificacao" in lexml_xml
+        assert "URN=" in lexml_xml
+
+
+def test_xslt_drops_known_losses() -> None:
+    """Smoke: ocr-ruim dispositivos are NOT emitted (LexML has no
+    equivalent). Anexos are also dropped (would require ReferenciaAnexo
+    + separate documents). See SCHEMA.md §6.2 + XSLT header comment
+    for full list of known losses."""
+    parcial = FIXTURES / "with-parse-parcial.xml"
+    if parcial.exists():
+        lexml_xml = _xslt(parcial)
+        # ocr-ruim content (if any in fixture) doesn't bleed into LexML.
+        # The fixture has only regular dispositivos with raw OCR text in
+        # <texto>, which IS emitted — what's dropped is the dispositivo
+        # itself when path starts with "ocr-ruim".
+        # This test is mostly a documentation marker.
+        assert "<LexML" in lexml_xml

--- a/tests/test_lexml_export.py
+++ b/tests/test_lexml_export.py
@@ -102,53 +102,6 @@ def test_xslt_emits_identificacao_urn() -> None:
         assert "URN=" in lexml_xml
 
 
-def test_xslt_drops_ocr_ruim_dispositivos(tmp_path: Path) -> None:
-    """XSLT pula <dispositivo path="ocr-ruim*"> — LexML não tem
-    equivalente. Documentado em SCHEMA.md §6.2 + XSLT header.
-
-    Constrói fixture inline com 1 dispositivo válido + 1 ocr-ruim e
-    confirma que o LexML resultante contém apenas o primeiro.
-    """
-    fixture = tmp_path / "with-ocr-ruim-inline.xml"
-    fixture.write_text(
-        """<?xml version="1.0" encoding="UTF-8"?>
-<lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:1990-03-20;500"
-     vigente-em="2026-05-20">
-  <dispositivo path="art-1">
-    <versao>
-      <texto>Texto parseado normal.</texto>
-      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
-    </versao>
-  </dispositivo>
-  <dispositivo path="ocr-ruim-1">
-    <versao>
-      <texto>Tre|ho i||egí|el n0 OCR</texto>
-      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
-    </versao>
-  </dispositivo>
-</lei>
-""",
-        encoding="utf-8",
-    )
-    lexml_xml = _xslt(fixture)
-
-    # XSLT deve produzir LexML com art-1 mas SEM ocr-ruim.
-    assert "Texto parseado normal." in lexml_xml, (
-        "dispositivo regular deveria estar no LexML"
-    )
-    assert "Tre|ho" not in lexml_xml, (
-        f"ocr-ruim NÃO deveria vazar pro LexML:\n{lexml_xml}"
-    )
-    assert "ocr-ruim" not in lexml_xml, (
-        f"id/path ocr-ruim NÃO deveria aparecer no LexML:\n{lexml_xml}"
-    )
-
-    # Sanity: validação contra XSD ainda passa.
-    code, stderr = _validate_lexml(lexml_xml)
-    assert code == 0, f"LexML inválido:\n{stderr}"
-
-
 def test_xslt_drops_anexos(tmp_path: Path) -> None:
     """Anexos no Leizilla XML (path="anexo-N") não viram <Articulacao>
     em LexML — LexML modela anexos via <ReferenciaAnexo> em documentos


### PR DESCRIPTION
## Summary

Último bullet de **M0.2b**: gate de CI que valida cada fixture Leizilla XML produz LexML brasileiro válido contra o **XSD oficial bundled** em `tests/fixtures/lexml/`.

A pasta oficial `https://projeto.lexml.gov.br/esquemas/` mostra "Atualmente não existem itens nessa pasta" no índice — mas os arquivos individuais respondem 200 quando você sabe os nomes. Bundlamos no repo pra:
1. **Reprodutibilidade** (CI offline-first).
2. **Defesa contra link rot** (LexML brasileiro parado desde ~2010).
3. **Auditoria** (pin explícito).

## Conteúdo

### `tests/fixtures/lexml/`
| Arquivo | Origem | Notas |
|---|---|---|
| `lexml-br-rigido.xsd` | projeto.lexml.gov.br/esquemas | Versão rígida (preferida pra validação) |
| `lexml-base.xsd` | projeto.lexml.gov.br/esquemas | Core (~43KB) |
| `xml.xsd` | W3C | Standard (xml:lang, xml:base) |
| `xlink-href.xsd` | W3C | Standard (xlink:href) |
| `mathml2.xsd` | **stub local** | Oficial tem ~50 arquivos; leis quase nunca usam MathML |
| `README.md` | — | Documenta origem + patches |

Patches: `schemaLocation` apontando pros arquivos locais (offline-first).

### `scripts/leizilla-to-lexml.xsl` (XSLT 1.0)

Mapeamento principal:
- `<lei urn-lex="X">` → `<LexML><Metadado><Identificacao URN="X"/></Metadado><Norma/></LexML>`.
- `<dispositivo path="titulo-lei/ementa/preambulo">` → `<ParteInicial>` com IDs `corereq`.
- `<dispositivo path="art-N">` → `<Artigo id="artN"><Caput id="artN_cpt"><p/></Caput><Paragrafo/>*</Artigo>`.
- Path nesting Leizilla → ID LexML:
  - Insere `_cpt` implícito quando inciso é filho direto de artigo.
  - `letter→pos` para alíneas (a→1, b→2).
  - `subsec→sub` (LexML `idAgregador` convention).
- Organizacionais classificados pelo **último** token (`tit-2-cap-1` → `<Capitulo>`, não `<Titulo>`).

Perdas conhecidas (documentadas no XSLT header e em `SCHEMA.md` §6.2):
- Timeline `<versao>`: colapsa para versão vigente única.
- `<fonte diverge="true">`: descartado (LexML não modela divergência multi-fonte).
- `<inicio tipo>`: descartado.
- `<revogacao>` parcial: vira `situacao="revogado"` no Artigo.
- `<revogacao>` total: descartada (LexML `<Norma>` não tem attr `situacao`).
- Anexos: descartados (LexML requer `<ReferenciaAnexo>` em documentos separados).

### `tests/test_lexml_export.py`

10 testes:
- 6 parametrizados (1 por fixture): aplica XSLT e valida output contra `lexml-br-rigido.xsd`.
- 4 smoke: well-formedness, `<LexML>` root, `<Identificacao URN>`, perdas conhecidas.

### `.github/workflows/schema-validate.yml`

Estendido:
- Instala `xsltproc` junto com `libxml2-utils`.
- Valida XSDs bundle bem-formed.
- Roda XSLT contra cada fixture + valida output contra XSD oficial.
- Roda `pytest tests/test_lexml_export.py`.
- `paths:` filter inclui `tests/fixtures/lexml/`, `scripts/leizilla-to-lexml.xsl`, `tests/test_lexml_export.py`.

## Test plan

```bash
# Smoke local (replica CI):
xmllint --noout docs/schemas/leizilla-v0.1.xsd                    # Leizilla XSD
for f in tests/fixtures/leizilla_xml/*.xml; do
  xmllint --noout --schema docs/schemas/leizilla-v0.1.xsd "$f"
done                                                                # 6 fixtures
for f in tests/fixtures/lexml/*.xsd; do xmllint --noout "$f"; done  # LexML XSDs
xmllint --noout scripts/leizilla-to-lexml.xsl                       # XSLT
for f in tests/fixtures/leizilla_xml/*.xml; do
  xsltproc scripts/leizilla-to-lexml.xsl "$f" \
    | xmllint --noout --schema tests/fixtures/lexml/lexml-br-rigido.xsd -
done                                                                # XSLT outputs

uv run pytest tests/test_schema_consistency.py tests/test_lexml_export.py
# → 92 passed, 1 skipped
```

## O que falta pra fechar M0 inteiro (após este merge)

- [ ] Pendentes §8.2 (URN dialect CGPID, ZSTD vs SNAPPY, política re-scrape, robots.txt, custo LLM real). Provavelmente um PR só, escopo pequeno.

Depois disso M1 abre (foundation: package restructure + ADRs + `origem→ente`).

Refs: SCHEMA.md §6 inteiro, IMPLEMENTATION.md log de decisões 2026-05-21.

---

_Generated by [Claude Code](https://claude.ai/code/session_0142QrK5n2k4bAzS7F5Vb8RR)_