### PR TITLE
docs(M0.3): URN LEX canônica + close pendentes §8 — fecha M0

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -10,7 +10,8 @@
 |---|---|---|---|
 | **M0.1** — Documento vivo + SCHEMA.md design | 🟢 done | #6 | Aprovado em re-review; merged em main. |
 | **M0.2a** — Schema v1 (tentativa) | 🔴 superseded | #7 | XSD `header` + `rotulo` + `<bloco-livre>` + etc. Substituído pelo redesign first-principles. Fica como referência histórica. |
-| **M0.2b** — Redesign first-principles | 🟡 in-progress | #8 #9 #10 #11 | SCHEMA.md reescrito + XSD enxuto + 6 fixtures + consistency checker + CI wire + XSLT Leizilla→LexML validado contra XSD oficial bundled (PR #11). Pendente: resolver pendentes §8.2. |
+| **M0.2b** — Redesign first-principles | 🟢 done | #8 #9 #10 #12 | SCHEMA.md reescrito + XSD enxuto + 6 fixtures + consistency checker + CI wire + XSLT Leizilla→LexML validado contra XSD oficial bundled (PRs #8-#12 merged). |
+| **M0.3** — URN canônica + close pendentes §8 | 🟡 in-progress | TBD | URN LEX contra spec CGPID 2008 oficial; política re-scrape; robots.txt princípio. 3 outros pendentes deferidos para M2/M4 (bloqueados). |
 | M1 — Foundation (package + ADRs + deps) | ⚪ todo | — | Bloqueado por M0 |
 | M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
@@ -46,6 +47,7 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 7. **ZIP raw bulk (padrão ficha) + Parquet single-table denormalizado + IA item para distribuição.** Manifest CSV no IA como source of truth (padrão baliza). Uma única tabela `versoes` (grain: lei × dispositivo × versão) cobre tudo durante M0–M4; estrutura emerge via `SELECT DISTINCT`. Pode evoluir para tabelas separadas se DuckDB-WASM ficar gargalo (decisão em M5).
 8. **Vigente compilado é canônico, histórico via timeline.** Parsed item = "como deve estar vigente hoje" (best-effort). Versões anteriores acessíveis via date picker. Fontes (DO, Casa Civil, Assembleia) cross-verificam — não competem por autoridade.
 9. **Wayback Machine é caminho primário de fetch.** Crawler não bate na fonte original — dispara Wayback save de `fonte_url` + `pdf_url`, depois fetch o PDF do snapshot Wayback para upload na nossa coleção IA. Fail-open: se Wayback falha, fallback de download direto. Polite com sites .gov.br frágeis + testemunha externa automática. Detalhes em SCHEMA.md §0.5.
+10. **Crawler respeita robots.txt e rate-limita.** Robots.txt rejeição é **permanente** para aquela URL (sem retry); rate-limit baseline de **1 request/segundo por host** em fallback direto. Wayback bot (princípio 9) atua como buffer — bates diretas só no fail-open. ADR-0008 formal em M1.
 
 ---
 
@@ -71,6 +73,36 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-21 — Fecha M0: URN LEX canônica + política re-scrape + robots.txt princípio
+
+Resolve 3 dos 6 pendentes do SCHEMA.md §8.2. Os outros 3 (compressão Parquet, granularidade ZIP, custo LLM real) são genuinamente bloqueados por milestones futuros e ficaram deferidos com target explícito (M2, M4) em SCHEMA.md §8.3.
+
+**URN LEX dialect** (§8.2.1): Baixei e li a spec oficial CGPID 2008 (`https://projeto.lexml.gov.br/documentacao/Parte-2-LexML-URN.pdf`, 73 páginas). Forma canônica é:
+
+```
+urn:lex:br(;LOCAL)*:AUTORIDADE:TIPO:DESCRITOR(!PATH)*
+```
+
+Diferenças vs. uso provisório (PRs #6-#12):
+
+| Componente | Antes (errado) | Depois (canônico) |
+|---|---|---|
+| Local estado | `;estado:rondonia;` | `;rondonia:` (sem prefixo "estado:") |
+| Local federal | `;federal;` | `:federal:` (não há local; vai direto pra autoridade) |
+| Autoridade | implícita no tipo | `federal` / `estadual` / `municipal` explícito |
+| Separadores | `;` em vários lugares | `:` entre LOCAL/AUTORIDADE/TIPO; `;` só dentro de LOCAL e DESCRITOR |
+| Path-dispositivo | `!art-N` | `!artN` (formato LexML idArtigo, `_` interno) |
+
+Atualizado: SCHEMA.md §5.6 reescrito com tabela de exemplos; XSD regex `UrnLex`; checker regex `_RE_URN_LEX`; 6 fixtures; tests de checker (4 helpers); tests de export LexML (continuam validando porque XSLT só copia URN). 93 tests pass + 1 skipped.
+
+**Política re-scrape** (§8.2.4): PDF re-publicado pela fonte (hash diferente) NÃO vira novo raw item automaticamente. Só sob auditoria explícita (humana ou embeddings drift): novo raw vira `{chave}-r{N}`, raw anterior fica imutável. Implementação em M2.
+
+**Robots.txt + rate limiting** (§8.2.5): Novo princípio load-bearing #10 em IMPLEMENTATION.md. Robots rejeição = permanente (sem retry); rate-limit baseline = 1 req/s por host. Wayback bot (princípio 9) já atua como buffer. ADR-0008 formal em M1.
+
+**Deferred** (§8.3): compressão Parquet → M4 (precisa de Parquet writer e DuckDB-WASM real); granularidade ZIP → M2 (precisa de scrape real); custo LLM → M2/M3 (precisa de parse runs reais).
+
+Com isso, **M0 fecha pragmaticamente**. M1 abre em sequência: package restructure + ADRs 0004-0010 + `origem→ente` rename em CLI/storage.
 
 ### 2026-05-21 — XSLT Leizilla→LexML + XSD oficial bundled (PR #11)
 
@@ -318,17 +350,17 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 **M0.2a — superseded** 🔴 (PR #7). Design v1 do XSD foi abandonado após auditoria first-principles. Fica como referência histórica.
 
-**M0.2b — Redesign first-principles** (PR #8 merged):
-- [x] `docs/SCHEMA.md` reescrito do zero (princípio "dispositivo é a unidade").
-- [x] `docs/schemas/leizilla-v0.1.xsd` enxuto (~235 linhas; 6 elementos).
-- [x] 6 fixtures cobrindo: caso simples (herança pura), alterações + divergência multi-fonte + vacatio, blocos organizacionais (CF/88), revogações parciais (4 tipos), revogação total da lei, OCR ruim.
-- [x] `tests/fixtures/leizilla_xml/README.md` com matriz de cobertura.
-- [x] **`scripts/check_schema_consistency.py`** validando 13 das 14 invariantes do SCHEMA.md §7 + a §7.15 (root é `<lei>`). Invariantes 11 (markdown self-check) e 12 (Parquet schema_version cross-artifact) ficam deferidas para quando o Parquet writer existir (M4+). + `tests/test_schema_consistency.py` com 79 testes (1 skipped quando rodando como root), cobrindo positives (6 fixtures), negativos (1+ por invariante), exit codes (0/1/2), token map edge cases, e xs:boolean variants.
-- [x] `scripts/leizilla-to-lexml.xsl` + `tests/test_lexml_export.py` (10 testes pass) validando contra XSD oficial LexML brasileiro bundled em `tests/fixtures/lexml/` (lexml-br-rigido + lexml-base + xml + xlink-href + stub mathml2). Wired no workflow `schema-validate.yml`. Perdas conhecidas documentadas no XSLT header e em SCHEMA.md §6.2.
-- [x] Wire `check_schema_consistency.py` no CI: `.github/workflows/schema-validate.yml` roda xmllint (XSD + fixtures) + pytest + checker contra fixtures a cada PR que toca `docs/schemas/`, `tests/fixtures/leizilla_xml/`, `scripts/check_schema_consistency.py`, ou `tests/test_schema_consistency.py`.
-- [ ] Resolver pendentes §8.2: URN dialect contra CGPID spec, compressão Parquet (SNAPPY vs ZSTD em DuckDB-WASM), granularidade bundle ZIP, política de re-scrape, robots.txt rate-limit, custo LLM real.
+**M0.2b — Redesign first-principles** ✅ (PRs #8 #9 #10 #12 merged).
 
-**M0.3 — Inspirações concretas** (paralelo a M0.2):
-- [ ] Aprofundar `docs/SCHEMA.md` §8 com paths exatos em ficha/baliza/causaganha (manifest CSV columns, naming patterns, footer KV examples).
+**M0.3 — Fecha M0** (este PR):
+- [x] **URN LEX canônica** contra spec CGPID 2008 — SCHEMA.md §5.6 + XSD regex + checker regex + 6 fixtures + tests atualizados.
+- [x] **Política re-scrape** documentada (§8.2.4 resolvida): `{chave}-r{N}` sob auditoria explícita, nunca automático.
+- [x] **Robots.txt + rate-limit** como princípio load-bearing #10 em IMPLEMENTATION.md.
+- [x] **Deferred** pendentes bloqueados por milestones futuros (§8.3): compressão Parquet → M4, granularidade ZIP → M2, custo LLM → M2/M3.
 
-**M1 — Foundation** (após M0.2 fechar): package restructure `src/` → `src/leizilla/`, ADRs 0004–0010, deps, e a migração `origem` → `ente` em CLI + schema (storage.py:44, cli.py:29,69,169,199,260).
+**M1 — Foundation** (próximo):
+- [ ] Package restructure `src/` → `src/leizilla/`.
+- [ ] ADRs 0004 (Wayback como fetch path), 0005 (IA identifiers), 0006 (XSD + checker), 0007 (LexML export), 0008 (robots.txt + rate-limit), 0009 (LGPD ética).
+- [ ] Migração `origem` → `ente` em CLI + schema (storage.py:44, cli.py:29,69,169,199,260).
+- [ ] `src/leizilla/entes.py` com catálogo (federal + 27 UFs + DF).
+- [ ] `src/leizilla/fontes/{ente}.py` stubs.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -660,22 +660,56 @@ Esse é o mesmo princípio que eliminou `revisao-pendente` no XML (§0.5): o sis
 
 `v0` (pre-M5, schema_version "0.1") é válido e citável.
 
-### 5.6 URN LEX
+### 5.6 URN LEX (spec oficial CGPID 2008)
 
-**Lei**: `urn:lex:br;{jurisdicao};{tipo}:{YYYY-MM-DD};{numero}`
-- `{jurisdicao}` para estados: `estado:rondonia` / `estado:sao-paulo`
-- `{jurisdicao}` para federal: `federal`
-- `{jurisdicao}` para municípios: `municipio:rondonia;porto-velho`
+Resolvida em M0.3 contra a spec oficial **LexML Brasil Parte 2 — LexML URN v1.0 (Dezembro/2008)** (`https://projeto.lexml.gov.br/documentacao/Parte-2-LexML-URN.pdf`). Gramática canônica:
 
-**Dispositivo**: `{urn-lei}!{path}` — exemplo: `urn:lex:br;estado:rondonia;lei:2003-06-15;1234!art-5!par-2`.
+```
+urn:lex:br(;{local})*:{autoridade}:{tipo}:{descritor}(!{path-dispositivo})*
+```
 
-**Constituição** (sem número): `urn:lex:br;federal;constituicao:1988-10-05` (sem `;numero` final).
+**`<local>`** — começa com `br`, opcionalmente seguido de `;{estado}` e `;{municipio}`:
+- Federal: `br`
+- Estado de Rondônia: `br;rondonia`
+- Município de Porto Velho-RO: `br;rondonia;porto.velho`
+- Distrito Federal: `br;distrito.federal`
 
-**Lei sem numero** (fallback): omitir o `;{numero}` final OU registrar `urn_lex` como NULL no Parquet. Identifier IA usa pattern fallback (§5.4).
+Nomes em minúsculas, por extenso, sem hífen — espaços viram `.`. **Não há prefixo `estado:` ou `municipio:`**: a posição no `<local>` define a hierarquia.
 
-> Dialect provisório — pendente verificação contra spec CGPID atual. Ver §8.
+**`<autoridade>`** — para normas comuns (leis, decretos, etc.) usa-se uma das três strings convencionadas:
+- `federal` (esfera União)
+- `estadual` (esfera estado)
+- `municipal` (esfera município)
 
-### 5.7 Slug `{ente}`
+Outras normas (resoluções, portarias, instruções normativas) especificam autoridade emitente unívoca (ex: `ministerio.fazenda;secretaria.receita.federal`).
+
+**`<tipo-documento>`** — vocabulário fixo: `lei`, `decreto`, `lei.complementar`, `medida.provisoria`, `constituicao`, `emenda.constitucional`, `resolucao`, `portaria`...
+
+**`<descritor>`** — combina data e número:
+- Canônica: `{YYYY-MM-DD};{numero}` (ex: `2003-10-01;10741`).
+- Reduzida (URN de Referência): só ano permitido (`2003;10741`).
+- Sem número (raro): usa `lex-{N}` autogerado (`1999-12-21;lex-16`) ou apelido (`2003-10-01;estatuto.idoso`).
+
+**`<path-dispositivo>`** — separado por `!`. Sintaxe interna usa `_` entre tokens (formato LexML idArtigo): `!art1`, `!art5_par2`, `!art5_par2_inc3`, `!art12-2_inc3_alt1` (renumeração com letra → `-N`, alteração com `_alt{N}`).
+
+### Exemplos
+
+| Norma | URN canônica |
+|---|---|
+| Lei federal 14.133/2021 | `urn:lex:br:federal:lei:2021-04-01;14133` |
+| Lei RO 1234/2003 | `urn:lex:br;rondonia:estadual:lei:2003-06-15;1234` |
+| Lei municipal Porto Velho 123/2010 | `urn:lex:br;rondonia;porto.velho:municipal:lei:2010-05-15;123` |
+| CF/88 | `urn:lex:br:federal:constituicao:1988-10-05` |
+| EC 45/2004 | `urn:lex:br:federal:emenda.constitucional:2004-12-30;45` |
+| Art. 5º CF | `urn:lex:br:federal:constituicao:1988-10-05!art5` |
+| Art. 5º §2º inc. III CF | `urn:lex:br:federal:constituicao:1988-10-05!art5_par2_inc3` |
+| Anexo I lei RO 9999/1999 | `urn:lex:br;rondonia:estadual:lei:1999-06-15;9999!anexo.1` |
+
+### Fallback (Leizilla)
+
+Quando data ou número não são extraíveis do PDF (caso raro em leis antigas), o `urn-lex` da `<lei>` é **omitido** no XML. Identidade é recuperada do filename canônico ou fallback (§5.3/§5.4). Consistency checker §7.10 valida cross-check.
+
+### 5.7 Slug `{ente}` (interno Leizilla)
 
 - União: `federal`
 - Estados: ISO 3166-2:BR sem `BR-`, lowercase: `ro`, `sp`, `mg`...
@@ -785,16 +819,23 @@ XSD não consegue expressar tudo. `scripts/check_schema_consistency.py` (M0.2) v
 - ✅ **Token map** é fonte única de verdade para tipo de dispositivo.
 - ✅ **Auditoria por embeddings raw vs parseado** substitui flags manuais de "revisão pendente".
 
-### 8.2 Pendentes (resolver em M0.3 antes de fechar M0)
+### 8.2 Resolvidas em M0.3 (este PR, fecha M0)
 
-- [ ] **URN LEX dialect**: verificar contra spec CGPID atual se separadores são `;`/`,`/`:` em casos como `urn:lex:br;rondonia:estadual:lei,2003-06-15;1234`.
-- [ ] **Compressão Parquet**: SNAPPY vs ZSTD. Verificar suporte em DuckDB-WASM via benchmark real.
-- [ ] **Granularidade bundle ZIP**: semanal vs mensal — revisitar se tamanho ficar trivial em M2.
-- [ ] **Política de re-scrape**: PDF re-publicado pela fonte (hash diferente) vira `{chave}-r{N}`? Só sob auditoria, nunca automático.
-- [ ] **Robots.txt + rate limiting** como princípio explícito do crawler (ADR-0008 em M1).
-- [ ] **Estimativa real de custo LLM** após M2 expor casos reais.
+- ✅ **URN LEX dialect**: spec oficial CGPID 2008 ([Parte 2 — LexML URN v1.0](https://projeto.lexml.gov.br/documentacao/Parte-2-LexML-URN.pdf)) lida e adotada. Forma canônica documentada em §5.6 com exemplos para lei federal/estadual/municipal, CF, EC, e path-dispositivo. Regex XSD + checker + 6 fixtures + 4 helpers de teste atualizados para a forma correta. Substituídas formas erradas: `br;estado:rondonia;lei:` → `br;rondonia:estadual:lei:`, `br;federal;lei:` → `br:federal:lei:`, etc.
 
-### 8.3 Open questions (v0.2+)
+- ✅ **Política de re-scrape**: PDF re-publicado pela fonte (hash diferente do anterior) **NÃO** vira novo raw item automaticamente. Só sob **auditoria explícita** (humana ou via embeddings drift) — neste caso o novo raw vira `{chave}-r{N}` (sufixo `-r1`, `-r2`, ...) e o raw anterior permanece imutável. Implementação fica em M2 (crawler).
+
+- ✅ **Robots.txt + rate limiting**: novo princípio load-bearing #10 em `IMPLEMENTATION.md`. Crawler **obedece robots.txt** (rejeição = não rascpear, não retry) e impõe **rate-limit baseline** de 1 request/segundo por host. Wayback bot (princípio 9) já atua como buffer — bates diretas só acontecem no fail-open. ADR formal (ADR-0008) fica em M1 com o package restructure.
+
+### 8.3 Deferred (dependem de milestones futuros — não bloqueiam M0)
+
+| Item | Bloqueio | Decisão deferida para |
+|---|---|---|
+| **Compressão Parquet** (SNAPPY vs ZSTD) | Precisa de Parquet writer e DuckDB-WASM real pra benchmark. | M4 (dataset items) |
+| **Granularidade bundle ZIP** (semanal vs mensal) | Precisa de scrape real pra dimensionar arquivos. | M2 (crawler) |
+| **Custo LLM realista** | Precisa de parse runs reais sobre casos diversos. | M2/M3 (após primeiras leis parseadas) |
+
+### 8.4 Open questions (v0.2+)
 
 - **Catálogo de fontes federais** (Câmara, Senado, Planalto, DOU) — modelo acomoda, vocabulário concreto quando atacarmos `ente=federal`.
 - **Catálogo de fontes municipais** — 5.570 estruturas distintas; modelo escala, curadoria é desafio próprio.

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -73,7 +73,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="urn:lex:br(;[a-z][a-z0-9.]*)*:[a-z][a-z0-9.]*:[a-z][a-z0-9.]*:\d{4}(-\d{2}-\d{2})?(;[a-z0-9.\-]+)?(![a-z0-9._\-]+)*"/>
+      <xs:pattern value="urn:lex:br(;[a-z][a-z0-9.]*)*:[a-z][a-z0-9.]*(;[a-z][a-z0-9.]*)*:[a-z][a-z0-9.]*:\d{4}(-\d{2}-\d{2})?(;[a-z0-9.\-]+)?(![a-z0-9._\-]+)*"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/docs/schemas/leizilla-v0.1.xsd
+++ b/docs/schemas/leizilla-v0.1.xsd
@@ -53,17 +53,27 @@
   <xs:simpleType name="UrnLex">
     <xs:annotation>
       <xs:documentation>
-        URN LEX (dialect provisório — ver SCHEMA.md secao 5.6 e 8).
-        Aceita lei (com numero), constituicao (sem numero), e
-        referencias a dispositivos via sufixo bang-path.
+        URN LEX brasileira (CGPID, LexML Brasil Parte 2 v1.0, Dez/2008).
+
+        Gramatica canonica:
+          urn:lex:br(;LOCAL)*:AUTORIDADE:TIPO:DESCRITOR(!PATH-DISPOSITIVO)*
+
+        - LOCAL: nomes minusculos, sem hifen, espacos viram `.` (ex:
+          `rondonia`, `sao.paulo`, `porto.velho`, `distrito.federal`).
+        - AUTORIDADE: `federal` / `estadual` / `municipal` para normas
+          comuns; ou orgao especifico para resolucoes etc.
+        - TIPO: `lei` / `decreto` / `lei.complementar` /
+          `medida.provisoria` / `constituicao` / `emenda.constitucional`...
+        - DESCRITOR: `YYYY-MM-DD;NUMERO` ou apenas `YYYY-MM-DD` (CF),
+          ou `YYYY;NUMERO` (forma reduzida).
+        - PATH-DISPOSITIVO: `art5`, `art5_par2`, `art5_par2_inc3`,
+          `anexo.1`, etc. — formato LexML idArtigo/idAgregador.
+
+        Ver SCHEMA.md secao 5.6 para exemplos.
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <!--
-        Jurisdição aceita 1 ou 2 segmentos (federal/estadual usam 1; municipal
-        usa 2: municipio:UF;slug). Bang-path opcional referencia dispositivos.
-      -->
-      <xs:pattern value="urn:lex:br;([^;]+;)?[^;]+;[^;]+:\d{4}-\d{2}-\d{2}(;[^!;]+)?(![a-z0-9-]+)*"/>
+      <xs:pattern value="urn:lex:br(;[a-z][a-z0-9.]*)*:[a-z][a-z0-9.]*:[a-z][a-z0-9.]*:\d{4}(-\d{2}-\d{2})?(;[a-z0-9.\-]+)?(![a-z0-9._\-]+)*"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/scripts/check_schema_consistency.py
+++ b/scripts/check_schema_consistency.py
@@ -145,13 +145,28 @@ _RE_IA_BUNDLE = re.compile(
     r"^leizilla-bundle-(?P<ente>[a-z][a-z0-9-]*)-(?P<fonte>[a-z]+)-"
     r"(?P<periodo>\d{4}-W\d{2})$"
 )
-# URN LEX: urn:lex:br;{jurisdicao};{tipo}:{data}[;{numero}][!{path}...]
-# Jurisdição pode ter ; interno (municipios).
+# URN LEX brasileira (CGPID, LexML Brasil Parte 2 v1.0, Dez/2008).
+#
+#   urn:lex:br(;LOCAL)*:AUTORIDADE:TIPO:DESCRITOR(!PATH)*
+#
+# LOCAL: minúsculas, sem hífen, `.` para espaços (`rondonia`,
+# `sao.paulo`, `porto.velho`). Múltiplos `;LOCAL` aceitos
+# (estado;municipio).
+# AUTORIDADE: `federal` / `estadual` / `municipal` (normas comuns)
+# ou órgão (`ministerio.fazenda`).
+# TIPO: `lei`, `decreto`, `constituicao`, `emenda.constitucional`...
+# DESCRITOR: `YYYY-MM-DD;NUMERO` ou `YYYY-MM-DD` (CF), ou
+# `YYYY;NUMERO` (forma reduzida).
+# PATH: formato LexML idArtigo/idAgregador (`art5`, `art5_par2`,
+# `anexo.1`).
 _RE_URN_LEX = re.compile(
-    r"^urn:lex:br;([^;]+;)?[^;]+;(?P<tipo>[^;]+):"
-    r"(?P<data>\d{4}-\d{2}-\d{2})"
-    r"(;(?P<numero>[^!;]+))?"
-    r"(?P<paths>(![a-z0-9-]+)*)$"
+    r"^urn:lex:br"
+    r"(?P<locais>(;[a-z][a-z0-9.]*)*)"
+    r":(?P<autoridade>[a-z][a-z0-9.]*)"
+    r":(?P<tipo>[a-z][a-z0-9.]*)"
+    r":(?P<data>\d{4}(-\d{2}-\d{2})?)"
+    r"(;(?P<numero>[a-z0-9.\-]+))?"
+    r"(?P<paths>(![a-z0-9._\-]+)*)$"
 )
 
 

--- a/scripts/check_schema_consistency.py
+++ b/scripts/check_schema_consistency.py
@@ -147,22 +147,23 @@ _RE_IA_BUNDLE = re.compile(
 )
 # URN LEX brasileira (CGPID, LexML Brasil Parte 2 v1.0, Dez/2008).
 #
-#   urn:lex:br(;LOCAL)*:AUTORIDADE:TIPO:DESCRITOR(!PATH)*
+#   urn:lex:br(;LOCAL)*:AUTORIDADE(;SUB-AUTORIDADE)*:TIPO:DESCRITOR(!PATH)*
 #
 # LOCAL: minúsculas, sem hífen, `.` para espaços (`rondonia`,
 # `sao.paulo`, `porto.velho`). Múltiplos `;LOCAL` aceitos
 # (estado;municipio).
 # AUTORIDADE: `federal` / `estadual` / `municipal` (normas comuns)
-# ou órgão (`ministerio.fazenda`).
+# ou órgão com hierarquia opcional separada por `;`
+# (`ministerio.fazenda;secretaria.receita.federal`).
 # TIPO: `lei`, `decreto`, `constituicao`, `emenda.constitucional`...
 # DESCRITOR: `YYYY-MM-DD;NUMERO` ou `YYYY-MM-DD` (CF), ou
-# `YYYY;NUMERO` (forma reduzida).
+# `YYYY;NUMERO` (forma reduzida — URN de Referência).
 # PATH: formato LexML idArtigo/idAgregador (`art5`, `art5_par2`,
 # `anexo.1`).
 _RE_URN_LEX = re.compile(
     r"^urn:lex:br"
     r"(?P<locais>(;[a-z][a-z0-9.]*)*)"
-    r":(?P<autoridade>[a-z][a-z0-9.]*)"
+    r":(?P<autoridade>[a-z][a-z0-9.]*(;[a-z][a-z0-9.]*)*)"
     r":(?P<tipo>[a-z][a-z0-9.]*)"
     r":(?P<data>\d{4}(-\d{2}-\d{2})?)"
     r"(;(?P<numero>[a-z0-9.\-]+))?"
@@ -173,21 +174,43 @@ _RE_URN_LEX = re.compile(
 def _extract_data_publicacao(urn_lex: str | None) -> datetime.date | None:
     """Decompose URN LEX → publication date.
 
-    Returns None when urn-lex is absent, fails the regex, or carries a
-    regex-valid but calendar-invalid date (e.g. `2020-13-01`). Calendar
-    validity is best-effort here; §7.10 reports the regex-level rejection
-    separately, and an invalid calendar slips through XSD too (the
-    pattern only enforces digit shape).
+    Returns None when urn-lex is absent, fails the regex, carries a
+    regex-valid but calendar-invalid date (e.g. `2020-13-01`), OR when
+    the URN uses the reduced form (year-only `YYYY`, valid per spec
+    §10.1 for URN de Referência / sistemas legados). Calendar validity
+    is best-effort here; §7.10 reports the regex-level rejection
+    separately. Year-only URNs are handled via carve-out in
+    `_check_inheritance_inicio` — sem ancoragem precisa, §7.5/§7.6
+    ficam exemptas (mesmo behavior que URN ausente).
     """
     if not urn_lex:
         return None
     m = _RE_URN_LEX.match(urn_lex)
     if not m:
         return None
+    data_str = m.group("data") or ""
+    # Reduced form `YYYY` (4 chars): no precise date anchor — return None.
+    if len(data_str) == 4:
+        return None
     try:
-        return datetime.date.fromisoformat(m.group("data"))
+        return datetime.date.fromisoformat(data_str)
     except ValueError:
         return None
+
+
+def _urn_is_reduced_year_only(urn_lex: str | None) -> bool:
+    """True when URN regex matches and `data` is year-only (`YYYY`).
+
+    Used by §7.5/§7.6 to distinguish:
+    (a) URN malformed → §7.5 reports.
+    (b) URN reduced (year-only, valid per spec) → §7.5 exempts.
+    """
+    if not urn_lex:
+        return False
+    m = _RE_URN_LEX.match(urn_lex)
+    if not m:
+        return False
+    return len(m.group("data") or "") == 4
 
 
 # ---------------------------------------------------------------------------
@@ -423,11 +446,14 @@ def _check_inheritance_inicio(ctx: _Ctx) -> None:
     """§7.5+§7.6 — Versão sem `em` herda; versão com `em ≠ data-publicacao`
     e sem `alterado-por` deve ter <inicio>.
 
-    Carve-out (§7.5): quando `urn-lex` é ausente, vigência não tem âncora
-    nenhuma (data-publicacao indisponível) — é o caso fallback OCR-ruim.
-    Verificação estrita de §7.5 fica suspensa nesse caso. Reportamos
-    §7.5 apenas quando URN é presente porém não decodificável (caso em
-    que §7.10 também reporta).
+    Carve-outs (§7.5):
+    1. `urn-lex` ausente: vigência não tem âncora nenhuma — caso
+       fallback (lei sem data extraível). §7.5 suspenso.
+    2. `urn-lex` presente mas regex falha: §7.10 reporta; §7.5
+       reporta uma vez pela lei (vigência irresolvível).
+    3. `urn-lex` em forma reduzida (year-only `YYYY`, válida pela spec
+       LexML URN §10.1 — URN de Referência): sem ancoragem precisa
+       de dia/mês, §7.5 suspenso (mesmo behavior que carve-out 1).
 
     Escopo do §7.6: a regra só dispara em versões com `em` declarado.
     Versões que herdam `em ≠ data-publicacao` do ancestral não disparam
@@ -437,13 +463,19 @@ def _check_inheritance_inicio(ctx: _Ctx) -> None:
     """
     pub = ctx.data_publicacao
     if ctx.urn_lex is not None and pub is None:
-        # urn-lex presente mas regex não casou — §7.10 já reporta;
-        # vigência fica irresolvível, registramos uma vez pela lei.
-        ctx.add(
-            5,
-            f'urn-lex="{ctx.urn_lex}" não decompõe → vigência herdada '
-            f"não consegue resolver pra nenhuma versão sem `em`",
-        )
+        # pub é None em 2 casos: regex falhou OU year-only. Distinguir:
+        if _urn_is_reduced_year_only(ctx.urn_lex):
+            # Carve-out: URN reduzida válida. Sem âncora precisa, mas
+            # também não há malformação a reportar.
+            pass
+        else:
+            # urn-lex presente mas regex não casou — §7.10 já reporta;
+            # registramos §7.5 uma vez pela lei (vigência irresolvível).
+            ctx.add(
+                5,
+                f'urn-lex="{ctx.urn_lex}" não decompõe → vigência herdada '
+                f"não consegue resolver pra nenhuma versão sem `em`",
+            )
     for d, _ in _walk_all_dispositivos(ctx.root):
         for v in d.findall(f"{{{NS}}}versao"):
             em = v.get("em")

--- a/tests/fixtures/leizilla_xml/README.md
+++ b/tests/fixtures/leizilla_xml/README.md
@@ -37,7 +37,7 @@ uv run pytest tests/test_leizilla_xml.py -v
 
 ## Convenções nas fixtures
 
-- **URN LEX em forma completa**: `urn:lex:br;{jurisdicao};{tipo}:{YYYY-MM-DD};{numero}` para leis ordinárias; sem `;numero` final para constituições. Dialect provisório — ver `docs/SCHEMA.md` §5.6 e §8.
+- **URN LEX canônica** (CGPID 2008): `urn:lex:br(;{local})*:{autoridade}:{tipo}:{descritor}`. Exemplo lei estadual: `urn:lex:br;rondonia:estadual:lei:2003-06-15;1234`. CF/88 sem número: `urn:lex:br:federal:constituicao:1988-10-05`. Detalhes em `docs/SCHEMA.md` §5.6.
 - **Datas históricas plausíveis** (Rondônia: leis pós-1981 quando o estado foi criado; CF/88 datada de 1988-10-05).
 - **`<fonte ia-id>`** segue `leizilla-raw-{ente}-{fonte}-{chave}` (SCHEMA.md §5.1). IA identifiers são exemplos sintéticos — não existem em IA real.
 - **Conteúdo textual** é fictício ou trecho público notório (CF/88 art. 1º, par. único). Leis fictícias usam numeração improvável (Lei 9.999/1999, Lei 1.234/2003, Lei 500/1990) para evitar confusão com leis reais existentes.

--- a/tests/fixtures/leizilla_xml/simple.xml
+++ b/tests/fixtures/leizilla_xml/simple.xml
@@ -13,7 +13,7 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:1999-06-15;9999"
+     urn-lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;9999"
      vigente-em="2026-05-20">
 
   <dispositivo path="ementa">

--- a/tests/fixtures/leizilla_xml/with-alteracoes.xml
+++ b/tests/fixtures/leizilla_xml/with-alteracoes.xml
@@ -16,7 +16,7 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:2003-06-15;1234"
+     urn-lex="urn:lex:br;rondonia:estadual:lei:2003-06-15;1234"
      vigente-em="2026-05-20">
 
   <dispositivo path="ementa">
@@ -35,17 +35,17 @@
         <texto>O Estado adotará política administrativa orientada pela eficiência e moralidade.</texto>
       </fonte>
     </versao>
-    <versao em="2018-04-10" alterado-por="urn:lex:br;estado:rondonia;lei:2018-04-10;4321">
+    <versao em="2018-04-10" alterado-por="urn:lex:br;rondonia:estadual:lei:2018-04-10;4321">
       <texto>O Estado adotará política administrativa orientada pela eficiência, moralidade e transparência pública.</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
     </versao>
-    <versao em="2024-07-30" alterado-por="urn:lex:br;estado:rondonia;lei:2024-07-30;5678">
+    <versao em="2024-07-30" alterado-por="urn:lex:br;rondonia:estadual:lei:2024-07-30;5678">
       <texto>O Estado adotará política administrativa orientada pela eficiência, moralidade, transparência e governança digital.</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-05678"/>
     </versao>
 
     <dispositivo path="art-3-par-1">
-      <versao em="2018-04-10" alterado-por="urn:lex:br;estado:rondonia;lei:2018-04-10;4321">
+      <versao em="2018-04-10" alterado-por="urn:lex:br;rondonia:estadual:lei:2018-04-10;4321">
         <texto>A transparência será assegurada por meio de portal eletrônico atualizado mensalmente.</texto>
         <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
       </versao>

--- a/tests/fixtures/leizilla_xml/with-blocos-organizacionais.xml
+++ b/tests/fixtures/leizilla_xml/with-blocos-organizacionais.xml
@@ -14,7 +14,7 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;federal;constituicao:1988-10-05"
+     urn-lex="urn:lex:br:federal:constituicao:1988-10-05"
      vigente-em="2026-05-20">
 
   <dispositivo path="titulo-lei">

--- a/tests/fixtures/leizilla_xml/with-parse-parcial.xml
+++ b/tests/fixtures/leizilla_xml/with-parse-parcial.xml
@@ -12,7 +12,7 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:1985-11-20;42"
+     urn-lex="urn:lex:br;rondonia:estadual:lei:1985-11-20;42"
      vigente-em="2026-05-20">
 
   <dispositivo path="ementa">

--- a/tests/fixtures/leizilla_xml/with-revogacao-total.xml
+++ b/tests/fixtures/leizilla_xml/with-revogacao-total.xml
@@ -11,11 +11,11 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:1985-11-20;42"
+     urn-lex="urn:lex:br;rondonia:estadual:lei:1985-11-20;42"
      vigente-em="2026-05-20">
 
   <revogacao em="2018-12-30" tipo="expressa"
-             por="urn:lex:br;estado:rondonia;lei:2018-12-30;4500">
+             por="urn:lex:br;rondonia:estadual:lei:2018-12-30;4500">
     <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04500"/>
   </revogacao>
 

--- a/tests/fixtures/leizilla_xml/with-revogacoes.xml
+++ b/tests/fixtures/leizilla_xml/with-revogacoes.xml
@@ -16,7 +16,7 @@
 -->
 <lei xmlns="https://leizilla.org/lei/0.1"
      schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:1990-03-20;500"
+     urn-lex="urn:lex:br;rondonia:estadual:lei:1990-03-20;500"
      vigente-em="2026-05-20">
 
   <dispositivo path="ementa">
@@ -39,7 +39,7 @@
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
     </versao>
     <revogacao em="2020-06-15" tipo="expressa"
-               por="urn:lex:br;estado:rondonia;lei:2020-06-15;9999">
+               por="urn:lex:br;rondonia:estadual:lei:2020-06-15;9999">
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
     </revogacao>
   </dispositivo>
@@ -50,7 +50,7 @@
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
     </versao>
     <revogacao em="2015-08-12" tipo="inconstitucionalidade"
-               por="urn:lex:br;federal;adi:2015-08-12;5234">
+               por="urn:lex:br:federal:adi:2015-08-12;5234">
       <fonte ia-id="leizilla-raw-federal-stf-adi-5234-2015"/>
     </revogacao>
   </dispositivo>
@@ -71,7 +71,7 @@
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00500"/>
     </versao>
     <revogacao em="2021-04-01" tipo="tacita"
-               por="urn:lex:br;federal;lei:2021-04-01;14133">
+               por="urn:lex:br:federal:lei:2021-04-01;14133">
       <fonte ia-id="leizilla-raw-federal-planalto-lei-14133-2021"/>
     </revogacao>
   </dispositivo>

--- a/tests/test_schema_consistency.py
+++ b/tests/test_schema_consistency.py
@@ -28,7 +28,7 @@ def _write(tmp_path: Path, content: str) -> Path:
 
 
 def _wrap(
-    body: str, urn_lex: str = "urn:lex:br;estado:rondonia;lei:2000-01-01;1234"
+    body: str, urn_lex: str = "urn:lex:br;rondonia:estadual:lei:2000-01-01;1234"
 ) -> str:
     """Wrap dispositivo body in a minimal <lei> envelope."""
     return f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -243,7 +243,7 @@ def test_inv01_diverge_one_without_texto_still_violation(tmp_path: Path) -> None
 
 def test_inv02_revogacao_total_excludes_partial(tmp_path: Path) -> None:
     xml = _wrap(
-        """  <revogacao em="2020-01-01" tipo="expressa" por="urn:lex:br;estado:rondonia;lei:2020-01-01;9999">
+        """  <revogacao em="2020-01-01" tipo="expressa" por="urn:lex:br;rondonia:estadual:lei:2020-01-01;9999">
     <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999"/>
   </revogacao>
   <dispositivo path="art-1">
@@ -251,7 +251,7 @@ def test_inv02_revogacao_total_excludes_partial(tmp_path: Path) -> None:
       <texto>X</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00001"/>
     </versao>
-    <revogacao em="2019-01-01" tipo="expressa" por="urn:lex:br;estado:rondonia;lei:2019-01-01;8888">
+    <revogacao em="2019-01-01" tipo="expressa" por="urn:lex:br;rondonia:estadual:lei:2019-01-01;8888">
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-08888"/>
     </revogacao>
   </dispositivo>"""
@@ -267,7 +267,7 @@ def test_inv03_caducidade_with_por(tmp_path: Path) -> None:
       <texto>X</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00001"/>
     </versao>
-    <revogacao em="2005-01-01" tipo="caducidade" por="urn:lex:br;estado:rondonia;lei:2005-01-01;5555">
+    <revogacao em="2005-01-01" tipo="caducidade" por="urn:lex:br;rondonia:estadual:lei:2005-01-01;5555">
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00001"/>
     </revogacao>
   </dispositivo>"""
@@ -395,11 +395,11 @@ def test_inv06_inicio_required(tmp_path: Path) -> None:
 def test_inv07_versions_out_of_order(tmp_path: Path) -> None:
     xml = _wrap(
         """  <dispositivo path="art-1">
-    <versao em="2010-01-01" alterado-por="urn:lex:br;estado:rondonia;lei:2010-01-01;4321">
+    <versao em="2010-01-01" alterado-por="urn:lex:br;rondonia:estadual:lei:2010-01-01;4321">
       <texto>X1</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
     </versao>
-    <versao em="2005-01-01" alterado-por="urn:lex:br;estado:rondonia;lei:2005-01-01;5555">
+    <versao em="2005-01-01" alterado-por="urn:lex:br;rondonia:estadual:lei:2005-01-01;5555">
       <texto>X2</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-05555"/>
     </versao>
@@ -495,7 +495,7 @@ def test_inv14_urn_zero_pad(tmp_path: Path) -> None:
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00042"/>
     </versao>
   </dispositivo>""",
-        urn_lex="urn:lex:br;estado:rondonia;lei:1985-11-20;0042",
+        urn_lex="urn:lex:br;rondonia:estadual:lei:1985-11-20;0042",
     )
     v = csc.check_file(_write(tmp_path, xml))
     assert any(x.invariant == 14 for x in v)
@@ -510,7 +510,7 @@ def test_inv14_no_zero_pad_for_5plus_digits(tmp_path: Path) -> None:
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-12345"/>
     </versao>
   </dispositivo>""",
-        urn_lex="urn:lex:br;estado:rondonia;lei:2020-01-01;12345",
+        urn_lex="urn:lex:br;rondonia:estadual:lei:2020-01-01;12345",
     )
     v = csc.check_file(_write(tmp_path, xml))
     assert not any(x.invariant == 14 for x in v)
@@ -575,7 +575,7 @@ def test_invalid_calendar_date_in_urn_does_not_crash(tmp_path: Path) -> None:
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00001"/>
     </versao>
   </dispositivo>""",
-        urn_lex="urn:lex:br;estado:rondonia;lei:2020-13-01;1234",
+        urn_lex="urn:lex:br;rondonia:estadual:lei:2020-13-01;1234",
     )
     # Should complete without raising.
     violations = csc.check_file(_write(tmp_path, xml))
@@ -612,14 +612,14 @@ def test_inherited_em_skips_invalid_dates(tmp_path: Path) -> None:
 
     xml = """<?xml version="1.0" encoding="UTF-8"?>
 <lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"
-     urn-lex="urn:lex:br;estado:rondonia;lei:2000-01-01;1234"
+     urn-lex="urn:lex:br;rondonia:estadual:lei:2000-01-01;1234"
      vigente-em="2026-05-20">
   <dispositivo path="art-3">
     <versao em="2020-13-01">
       <texto>data invalida</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00001"/>
     </versao>
-    <versao em="2018-04-10" alterado-por="urn:lex:br;estado:rondonia;lei:2018-04-10;4321">
+    <versao em="2018-04-10" alterado-por="urn:lex:br;rondonia:estadual:lei:2018-04-10;4321">
       <texto>data valida</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
     </versao>
@@ -640,7 +640,7 @@ def test_inv07_inherited_em_catches_out_of_order(tmp_path: Path) -> None:
     antigo perdia (comparava com pub em vez de com o em herdado)."""
     xml = _wrap(
         """  <dispositivo path="art-3">
-    <versao em="2018-04-10" alterado-por="urn:lex:br;estado:rondonia;lei:2018-04-10;4321">
+    <versao em="2018-04-10" alterado-por="urn:lex:br;rondonia:estadual:lei:2018-04-10;4321">
       <texto>v1 art-3</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
     </versao>
@@ -649,7 +649,7 @@ def test_inv07_inherited_em_catches_out_of_order(tmp_path: Path) -> None:
         <texto>v1 par-1 (herda em=2018-04-10 do parent)</texto>
         <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-04321"/>
       </versao>
-      <versao em="2010-01-01" alterado-por="urn:lex:br;estado:rondonia;lei:2010-01-01;5555">
+      <versao em="2010-01-01" alterado-por="urn:lex:br;rondonia:estadual:lei:2010-01-01;5555">
         <texto>v2 par-1 — out of order! 2010 antes de 2018</texto>
         <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-05555"/>
       </versao>
@@ -750,7 +750,7 @@ def test_inv01_diverge_in_revogacao_rejected(tmp_path: Path) -> None:
       <texto>X</texto>
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00001"/>
     </versao>
-    <revogacao em="2020-01-01" tipo="expressa" por="urn:lex:br;estado:rondonia;lei:2020-01-01;9999">
+    <revogacao em="2020-01-01" tipo="expressa" por="urn:lex:br;rondonia:estadual:lei:2020-01-01;9999">
       <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-09999" diverge="true">
         <texto>diverge numa revogacao</texto>
       </fonte>
@@ -780,7 +780,7 @@ def test_inv10_filename_matches_urn_canonical(tmp_path: Path) -> None:
     f = _write_named(
         tmp_path,
         "leizilla-ro-lei-09999-1999",
-        _wrap(body, urn_lex="urn:lex:br;estado:rondonia;lei:1999-06-15;9999"),
+        _wrap(body, urn_lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;9999"),
     )
     assert csc.check_file(f) == []
 
@@ -796,7 +796,7 @@ def test_inv10_filename_numero_mismatch(tmp_path: Path) -> None:
     f = _write_named(
         tmp_path,
         "leizilla-ro-lei-09999-1999",
-        _wrap(body, urn_lex="urn:lex:br;estado:rondonia;lei:1999-06-15;7777"),
+        _wrap(body, urn_lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;7777"),
     )
     v = csc.check_file(f)
     assert any(x.invariant == 10 and "numero" in x.message for x in v)
@@ -812,7 +812,7 @@ def test_inv10_filename_ano_mismatch(tmp_path: Path) -> None:
     f = _write_named(
         tmp_path,
         "leizilla-ro-lei-09999-1999",
-        _wrap(body, urn_lex="urn:lex:br;estado:rondonia;lei:2020-06-15;9999"),
+        _wrap(body, urn_lex="urn:lex:br;rondonia:estadual:lei:2020-06-15;9999"),
     )
     v = csc.check_file(f)
     assert any(x.invariant == 10 and "ano" in x.message for x in v)
@@ -828,7 +828,7 @@ def test_inv10_filename_tipo_mismatch(tmp_path: Path) -> None:
     f = _write_named(
         tmp_path,
         "leizilla-ro-decreto-09999-1999",
-        _wrap(body, urn_lex="urn:lex:br;estado:rondonia;lei:1999-06-15;9999"),
+        _wrap(body, urn_lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;9999"),
     )
     v = csc.check_file(f)
     assert any(x.invariant == 10 and "tipo" in x.message for x in v)
@@ -845,7 +845,7 @@ def test_inv10_filename_canonical_but_urn_lacks_numero(tmp_path: Path) -> None:
     f = _write_named(
         tmp_path,
         "leizilla-federal-constituicao-00000-1988",
-        _wrap(body, urn_lex="urn:lex:br;federal;constituicao:1988-10-05"),
+        _wrap(body, urn_lex="urn:lex:br:federal:constituicao:1988-10-05"),
     )
     v = csc.check_file(f)
     assert any(x.invariant == 10 and "sem ;numero" in x.message for x in v)
@@ -864,7 +864,7 @@ def test_inv10_arbitrary_filename_skips_crosscheck(tmp_path: Path) -> None:
     f = _write_named(
         tmp_path,
         "simple",
-        _wrap(body, urn_lex="urn:lex:br;estado:rondonia;lei:1999-06-15;7777"),
+        _wrap(body, urn_lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;7777"),
     )
     # urn-lex válido, filename não casa pattern → §7.10 silent.
     assert csc.check_file(f) == []

--- a/tests/test_schema_consistency.py
+++ b/tests/test_schema_consistency.py
@@ -904,3 +904,51 @@ def test_inv05_no_urn_is_exempt(tmp_path: Path) -> None:
 </lei>"""
     v = csc.check_file(_write(tmp_path, xml))
     assert not any(x.invariant == 5 for x in v)
+
+
+def test_inv05_urn_year_only_is_exempt(tmp_path: Path) -> None:
+    """Codex P2: URN reduzida com `YYYY;NUMERO` (URN de Referência,
+    válida pela spec LexML §10.1) não tem ancoragem precisa de
+    dia/mês. §7.5 exempt — não há malformação a reportar."""
+    xml = _wrap(
+        """  <dispositivo path="art-1">
+    <versao>
+      <texto>X</texto>
+      <fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00001"/>
+    </versao>
+  </dispositivo>""",
+        urn_lex="urn:lex:br;rondonia:estadual:lei:2003;1234",
+    )
+    v = csc.check_file(_write(tmp_path, xml))
+    assert not any(x.invariant == 5 for x in v), (
+        f"URN reduzida (year-only) NÃO deveria disparar §7.5; got: {[str(x) for x in v]}"
+    )
+
+
+def test_urn_regex_accepts_hierarchical_authority() -> None:
+    """Codex P1: URN com autoridade hierárquica via `;` interno
+    (`ministerio.fazenda;secretaria.receita.federal`) é forma canônica
+    válida da spec — comum em portarias federais."""
+    valid_urns = [
+        "urn:lex:br:ministerio.fazenda;secretaria.receita.federal:portaria:1997-06-20;782",
+        "urn:lex:br:ministerio.justica;departamento.policia.federal;diretor.geral:portaria:2020-01-15;42",
+        "urn:lex:br:universidade.brasilia;reitor:oficio:2019-03-01;100",
+    ]
+    for urn in valid_urns:
+        m = csc._RE_URN_LEX.match(urn)
+        assert m is not None, f"URN canônica com autoridade hierárquica rejeitada: {urn}"
+        assert ";" in m.group("autoridade"), (
+            f"autoridade não capturou o `;` interno: {m.group('autoridade')}"
+        )
+
+
+def test_urn_extract_data_publicacao_year_only_returns_none() -> None:
+    """`_extract_data_publicacao` retorna None para URN year-only
+    (sem ancoragem de dia/mês) — §7.5/§7.6 usam carve-out."""
+    urn = "urn:lex:br;rondonia:estadual:lei:2003;1234"
+    assert csc._extract_data_publicacao(urn) is None
+    assert csc._urn_is_reduced_year_only(urn) is True
+    # Forma canônica completa não dispara o carve-out.
+    urn_full = "urn:lex:br;rondonia:estadual:lei:2003-06-15;1234"
+    assert csc._extract_data_publicacao(urn_full) is not None
+    assert csc._urn_is_reduced_year_only(urn_full) is False


### PR DESCRIPTION
## Summary

**Fecha M0 pragmaticamente.** Resolve 3 dos 6 pendentes §8.2 do SCHEMA.md; defere outros 3 com target explícito (M2/M4).

### Resolvido (§8.2)

**1. URN LEX dialect (§8.2.1)** — baixei spec oficial CGPID 2008 ([LexML Brasil Parte 2 v1.0, 73 pgs](https://projeto.lexml.gov.br/documentacao/Parte-2-LexML-URN.pdf)). Forma canônica:

```
urn:lex:br(;LOCAL)*:AUTORIDADE:TIPO:DESCRITOR(!PATH)*
```

Diferenças vs. uso provisório nos PRs #6-#12:

| Antes (errado) | Depois (canônico) |
|---|---|
| `br;estado:rondonia;lei:DATA;N` | `br;rondonia:estadual:lei:DATA;N` |
| `br;federal;lei:DATA;N` | `br:federal:lei:DATA;N` |
| `br;federal;constituicao:DATA` | `br:federal:constituicao:DATA` |
| `!art-N` (hyphen) | `!artN` (LexML idArtigo `_` interno) |

Atualizado: SCHEMA.md §5.6 (gramática + tabela de exemplos), XSD regex `UrnLex`, checker regex `_RE_URN_LEX` (com grupos nomeados), 6 fixtures, 17 ocorrências em testes.

**2. Política re-scrape (§8.2.4)** — PDF re-publicado pela fonte (hash diferente) **não** vira novo raw automaticamente. Só sob auditoria (humana ou embeddings drift): novo raw vira `{chave}-r{N}`, raw anterior fica imutável. Implementação em M2.

**3. Robots.txt + rate-limit (§8.2.5)** — novo princípio load-bearing #10 em IMPLEMENTATION.md. Rejeição robots = permanente (sem retry); rate-limit baseline 1 req/s por host em fail-open. Wayback bot (princípio 9) atua como buffer. ADR-0008 formal em M1.

### Deferred (§8.3 nova seção)

| Item | Bloqueio | Target |
|---|---|---|
| Compressão Parquet (SNAPPY vs ZSTD) | Precisa de writer + DuckDB-WASM real | M4 |
| Granularidade bundle ZIP (semanal vs mensal) | Precisa de scrape real | M2 |
| Custo LLM realista | Precisa de parse runs reais | M2/M3 |

### Status M0

| Milestone | Status |
|---|---|
| M0.1 (docs vivos + SCHEMA v1) | 🟢 done (#6) |
| M0.2a (XSD v1 tentativa) | 🔴 superseded (#7) |
| M0.2b (redesign first-principles) | 🟢 done (#8-#12) |
| **M0.3 (este PR — fecha M0)** | 🟡 in-progress |

**Próximo: M1 (foundation)** — package restructure `src/` → `src/leizilla/`, ADRs 0004-0009, migração `origem→ente` em CLI/storage.

## Test plan

```bash
$ uv run pytest tests/test_schema_consistency.py tests/test_lexml_export.py
93 passed, 1 skipped

$ python3 scripts/check_schema_consistency.py tests/fixtures/leizilla_xml/*.xml
OK — 6 arquivo(s) sem violações.

$ xmllint --noout docs/schemas/leizilla-v0.1.xsd                            # ok
$ for f in tests/fixtures/leizilla_xml/*.xml; do
    xmllint --noout --schema docs/schemas/leizilla-v0.1.xsd "$f"
  done                                                                       # 6 validates

$ tmp=$(mktemp -d)
$ for f in tests/fixtures/leizilla_xml/*.xml; do
    xsltproc --param output-dir "'$tmp'" scripts/leizilla-to-lexml.xsl "$f" > "$tmp/main.xml"
    xmllint --noout --schema tests/fixtures/lexml/lexml-br-rigido.xsd "$tmp/main.xml"
  done                                                                       # all validate
```

---

_Generated by [Claude Code](https://claude.ai/code/session_0142QrK5n2k4bAzS7F5Vb8RR)_