### PR TITLE
feat(M2.1): Wayback client + robots.txt + publisher sidecar

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -12,8 +12,9 @@
 | **M0.2a** — Schema v1 (tentativa) | 🔴 superseded | #7 | XSD `header` + `rotulo` + `<bloco-livre>` + etc. Substituído pelo redesign first-principles. Fica como referência histórica. |
 | **M0.2b** — Redesign first-principles | 🟢 done | #8 #9 #10 #12 | SCHEMA.md reescrito + XSD enxuto + 6 fixtures + consistency checker + CI wire + XSLT Leizilla→LexML validado contra XSD oficial bundled (PRs #8-#12 merged). |
 | **M0.3** — URN canônica + close pendentes §8 | 🟢 done | #13 | URN LEX contra spec CGPID 2008 oficial; política re-scrape; robots.txt princípio. 3 pendentes deferidos para M2/M4. |
-| **M1** — Foundation (package + ADRs + entes + fontes) | 🟡 in-progress | TBD | Package `src/leizilla/`; ADRs 0004–0009; rename `origem→ente`; `entes.py`; `fontes/ro.py`. |
-| M2 — Crawler real + Raw upload | ⚪ todo | — | Bloqueado por M1 |
+| **M1** — Foundation (package + ADRs + entes + fontes) | 🟡 in-progress | #14 | Package `src/leizilla/`; ADRs 0004–0009; rename `origem→ente`; `entes.py`; `fontes/ro.py`. |
+| **M2.1** — Wayback client + robots.txt + publisher sidecar | 🟡 in-progress | TBD | `wayback.py` (check_available/save_page/fetch_bytes) + `robots.py` (is_allowed, lru_cache) + `publisher.build_raw_meta` + `raw_meta.json` sidecar. Stacked em cima de M1. |
+| M2 — Crawler real + Raw upload (restante) | ⚪ todo | — | Bloqueado por M1+M2.1. Próximo: `scrape` CLI, integração wayback→upload no pipeline. |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
 | M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |
@@ -97,6 +98,31 @@ dados de teste atualizados para usar `ente` em vez de `origem`.
 
 PR #3 fechada com explicação: abordagem connector-based de 2025-07-01 superseded
 pelos pivôs arquiteturais de 2026-05 (PRs #6–#13).
+
+### 2026-05-22 — M2.1: Wayback client + robots.txt + publisher sidecar
+
+Primeira sub-tarefa de M2. Stacked em cima de M1 (PR #14, ainda não merged).
+
+**wayback.py**: três funções puras com stdlib só (sem deps novas):
+- `check_available(url)` → snapshot Wayback fresco (< 24h) ou None. Fail-open.
+- `save_page(url)` → dispara POST/GET para `web.archive.org/save/`. Fail-open.
+- `fetch_bytes(url)` → baixa bytes de qualquer URL (Wayback ou direto). Fail-open.
+
+**robots.py**: `is_allowed(url)` com `lru_cache` por `robots.txt` URL. Rejeição
+permanente conforme princípio #10 (callers NÃO devem retry URL bloqueada).
+Fail-open: sem robots.txt = acesso permitido.
+
+**publisher.py** atualizado: funções de construção de identifiers extraídas como
+`_raw_identifier(ente, fonte, chave)` e `_bundle_identifier(ente, fonte, dt)`.
+`build_raw_meta()` constrói `raw_meta.json` conforme SCHEMA.md §2.1 (hash_pdf,
+provenance_wayback, fetched_from, ia_id_bundle). `upload_raw()` substitui
+`upload_pdf()` — envia PDF + sidecar no mesmo IA item.
+
+**Decisão sobre deps**: stdlib apenas (urllib.request + urllib.robotparser).
+Evita depender de `httpx` ou `requests` enquanto M2 não define se o crawler
+é sync ou async (Playwright vs. simples). Revisitar em M2 restante.
+
+**Testes**: 34 novos (mock HTTP puro, sem rede). 132 total passam.
 
 ### 2026-05-21 — Fecha M0: URN LEX canônica + política re-scrape + robots.txt princípio
 

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -130,9 +130,10 @@ def cmd_upload(
                 pdf_path = Path(law["local_pdf_path"])
                 if not pdf_path.exists():
                     continue
-                result = publisher.upload_pdf(pdf_path, law)
+                pdf_bytes = pdf_path.read_bytes()
+                result = publisher.upload_raw(pdf_path, law, pdf_bytes, fetched_from="source-fallback")
                 if result.get("success"):
-                    db.update_lei(law["id"], {"url_pdf_ia": result["url"]})
+                    db.update_lei(law["id"], {"url_pdf_ia": result["ia_url"]})
                     uploaded += 1
                     echo(f"  Upload: {law.get('titulo', 'N/A')}")
                 else:

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -1,13 +1,58 @@
 """Publicação no Internet Archive e exportação de datasets."""
 
 import hashlib
+import json
 import subprocess
-from datetime import datetime
+import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from leizilla import config
 from leizilla import storage as storage_module
+
+_USER_AGENT = "leizilla-crawler/0.1"
+
+
+def _raw_identifier(ente: str, fonte: str, chave: str) -> str:
+    """Constrói IA identifier para raw item conforme SCHEMA.md §1.2."""
+    return f"leizilla-raw-{ente}-{fonte}-{chave}"
+
+
+def _bundle_identifier(ente: str, fonte: str, dt: Optional[datetime] = None) -> str:
+    """Constrói IA identifier para bundle semanal conforme SCHEMA.md §1.2."""
+    d = dt or datetime.now(tz=timezone.utc)
+    iso = d.isocalendar()
+    return f"leizilla-bundle-{ente}-{fonte}-{iso[0]}-W{iso[1]:02d}"
+
+
+def build_raw_meta(
+    lei_data: Dict[str, Any],
+    pdf_bytes: bytes,
+    fetched_from: str,
+    wayback_url: Optional[str] = None,
+    wayback_blocked_robots: bool = False,
+) -> Dict[str, Any]:
+    """Constrói raw_meta.json conforme SCHEMA.md §2.1."""
+    ente = str(lei_data.get("ente", "unknown"))
+    fonte = str(lei_data.get("fonte", "casacivil"))
+    chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
+    return {
+        "leizilla_meta_version": "0.1",
+        "ente": ente,
+        "fonte": fonte,
+        "chave": chave,
+        "fonte_url": lei_data.get("url_original"),
+        "data_captura": datetime.now(tz=timezone.utc).isoformat(),
+        "hash_pdf": f"sha256:{hashlib.sha256(pdf_bytes).hexdigest()}",
+        "user_agent": _USER_AGENT,
+        "ia_id_bundle": _bundle_identifier(ente, fonte),
+        "provenance_wayback": {
+            "fetched_from": fetched_from,
+            "wayback_url": wayback_url,
+            "wayback_blocked_robots": wayback_blocked_robots,
+        },
+    }
 
 
 class InternetArchivePublisher:
@@ -17,40 +62,54 @@ class InternetArchivePublisher:
         self.access_key = config.IA_ACCESS_KEY
         self.secret_key = config.IA_SECRET_KEY
 
-    def upload_pdf(self, pdf_path: Path, lei_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Faz upload de PDF para Internet Archive.
+    def upload_raw(
+        self,
+        pdf_path: Path,
+        lei_data: Dict[str, Any],
+        pdf_bytes: bytes,
+        fetched_from: str = "source-fallback",
+        wayback_url: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Upload raw PDF + raw_meta.json sidecar para IA.
 
-        Retorna dict com 'success', 'url', 'ia_id'.
+        Identifier: leizilla-raw-{ente}-{fonte}-{chave} (SCHEMA.md §1.2).
+        Retorna dict com 'success', 'ia_id', 'ia_url'.
         """
         if not self.access_key or not self.secret_key:
             return {"success": False, "error": "IA credentials not configured"}
 
-        ente = lei_data.get("ente", "unknown")
-        lei_id = lei_data.get("id", "unknown")
-        ia_id = f"leizilla-raw-{ente}-casacivil-{lei_id}"
+        ente = str(lei_data.get("ente", "unknown"))
+        fonte = str(lei_data.get("fonte", "casacivil"))
+        chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
+        ia_id = _raw_identifier(ente, fonte, chave)
 
-        try:
-            result = subprocess.run(
-                [
-                    "ia",
-                    "upload",
-                    ia_id,
-                    str(pdf_path),
-                    "--metadata",
-                    f"title:{lei_data.get('titulo', 'Lei')}",
-                    "--metadata",
-                    "mediatype:texts",
-                    "--metadata",
-                    f"subject:leis;{ente}",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            ia_url = f"https://archive.org/details/{ia_id}"
-            return {"success": True, "url": ia_url, "ia_id": ia_id}
-        except subprocess.CalledProcessError as e:
-            return {"success": False, "error": e.stderr}
+        raw_meta = build_raw_meta(lei_data, pdf_bytes, fetched_from, wayback_url)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            meta_path = Path(tmp) / "raw_meta.json"
+            meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
+
+            try:
+                subprocess.run(
+                    [
+                        "ia", "upload", ia_id,
+                        str(pdf_path), str(meta_path),
+                        "--metadata", f"title:{lei_data.get('titulo', 'Lei')}",
+                        "--metadata", "mediatype:texts",
+                        "--metadata", f"subject:leis;leizilla;{ente}",
+                        "--metadata", f"creator:leizilla-crawler",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                return {
+                    "success": True,
+                    "ia_id": ia_id,
+                    "ia_url": f"https://archive.org/details/{ia_id}",
+                }
+            except subprocess.CalledProcessError as e:
+                return {"success": False, "error": e.stderr, "ia_id": ia_id}
 
     def export_dataset_parquet(
         self,

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import shutil
 import subprocess
 import tempfile
 from datetime import datetime, timezone
@@ -86,6 +87,10 @@ class InternetArchivePublisher:
         raw_meta = build_raw_meta(lei_data, pdf_bytes, fetched_from, wayback_url)
 
         with tempfile.TemporaryDirectory() as tmp:
+            # Rename PDF to {ia_id}.pdf so IA OCR output is {ia_id}_djvu.txt,
+            # matching the URL template used by parser.fetch_ocr().
+            pdf_dst = Path(tmp) / f"{ia_id}.pdf"
+            shutil.copy2(str(pdf_path), str(pdf_dst))
             meta_path = Path(tmp) / "raw_meta.json"
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
 
@@ -93,7 +98,7 @@ class InternetArchivePublisher:
                 subprocess.run(
                     [
                         "ia", "upload", ia_id,
-                        str(pdf_path), str(meta_path),
+                        str(pdf_dst), str(meta_path),
                         "--metadata", f"title:{lei_data.get('titulo', 'Lei')}",
                         "--metadata", "mediatype:texts",
                         "--metadata", f"subject:leis;leizilla;{ente}",

--- a/src/leizilla/robots.py
+++ b/src/leizilla/robots.py
@@ -1,0 +1,39 @@
+"""Verificação de robots.txt — rejeição é permanente (ADR-0008, princípio #10).
+
+Cache em memória por processo (lru_cache). robots.txt é lido uma vez por host.
+Fallback fail-open: ausência de robots.txt = acesso permitido.
+"""
+
+import urllib.parse
+import urllib.robotparser
+from functools import lru_cache
+from typing import Optional
+
+_LEIZILLA_AGENT = "leizilla"
+
+
+@lru_cache(maxsize=512)
+def _load_robots(robots_url: str) -> Optional[urllib.robotparser.RobotFileParser]:
+    """Carrega e parseia robots.txt de robots_url. Cached por URL."""
+    rp = urllib.robotparser.RobotFileParser(robots_url)
+    try:
+        rp.read()
+        return rp
+    except Exception:
+        return None  # sem robots.txt → fail-open
+
+
+def is_allowed(url: str) -> bool:
+    """Retorna True se leizilla-crawler pode acessar url.
+
+    False é permanente — não tente novamente essa URL (ADR-0008).
+    URL malformada retorna False.
+    """
+    parsed = urllib.parse.urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return False
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+    parser = _load_robots(robots_url)
+    if parser is None:
+        return True  # fail-open: sem robots.txt = permitido
+    return bool(parser.can_fetch(_LEIZILLA_AGENT, url))

--- a/src/leizilla/robots.py
+++ b/src/leizilla/robots.py
@@ -9,7 +9,7 @@ import urllib.robotparser
 from functools import lru_cache
 from typing import Optional
 
-_LEIZILLA_AGENT = "leizilla"
+_LEIZILLA_AGENT = "leizilla-crawler"
 
 
 @lru_cache(maxsize=512)

--- a/src/leizilla/wayback.py
+++ b/src/leizilla/wayback.py
@@ -55,7 +55,7 @@ def save_page(url: str, timeout: int = 60) -> bool:
 
     Fail-open: retorna False sem exceção se Wayback não responder.
     """
-    save_url = _SAVE_URL_TMPL.format(url)
+    save_url = _SAVE_URL_TMPL.format(urllib.parse.quote(url, safe=":/"))
     req = urllib.request.Request(save_url)
     req.add_header("User-Agent", _USER_AGENT)
     try:

--- a/src/leizilla/wayback.py
+++ b/src/leizilla/wayback.py
@@ -1,0 +1,76 @@
+"""Cliente Wayback Machine — fetch via snapshot com fallback direto (ADR-0004).
+
+Princípio #9: dispara Wayback save + fetch do snapshot. Fail-open para download
+direto se Wayback falhar.
+"""
+
+import json
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
+_AVAILABILITY_API = "https://archive.org/wayback/available"
+_SAVE_URL_TMPL = "https://web.archive.org/save/{}"
+_USER_AGENT = "leizilla-crawler/0.1 (legal-indexer; https://github.com/franklinbaldo/leizilla)"
+_MAX_AGE_SECONDS = 24 * 3600
+
+
+def check_available(url: str, max_age_seconds: int = _MAX_AGE_SECONDS) -> Optional[str]:
+    """Retorna URL do snapshot Wayback mais recente se fresco (< max_age_seconds).
+
+    None se não existe snapshot, se expirou, ou se a API falhar (fail-open).
+    """
+    try:
+        api_url = f"{_AVAILABILITY_API}?url={urllib.parse.quote(url, safe='')}"
+        req = urllib.request.Request(api_url)
+        req.add_header("User-Agent", _USER_AGENT)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data: dict = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+
+    snapshot = data.get("archived_snapshots", {}).get("closest", {})
+    if not snapshot or snapshot.get("status") != "200":
+        return None
+
+    timestamp_str: str = snapshot.get("timestamp", "")
+    if not timestamp_str:
+        return None
+
+    try:
+        snapshot_dt = datetime.strptime(timestamp_str, "%Y%m%d%H%M%S").replace(
+            tzinfo=timezone.utc
+        )
+        age = (datetime.now(tz=timezone.utc) - snapshot_dt).total_seconds()
+        if age <= max_age_seconds:
+            return str(snapshot.get("url", ""))
+    except ValueError:
+        pass
+    return None
+
+
+def save_page(url: str, timeout: int = 60) -> bool:
+    """Dispara Wayback save para url. Retorna True se aceito (200/302).
+
+    Fail-open: retorna False sem exceção se Wayback não responder.
+    """
+    save_url = _SAVE_URL_TMPL.format(url)
+    req = urllib.request.Request(save_url)
+    req.add_header("User-Agent", _USER_AGENT)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status in (200, 302)
+    except Exception:
+        return False
+
+
+def fetch_bytes(url: str, timeout: int = 60) -> Optional[bytes]:
+    """Baixa conteúdo de um URL (Wayback ou direto) e retorna bytes. None em falha."""
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", _USER_AGENT)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return bytes(resp.read())
+    except Exception:
+        return None

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,90 @@
+"""Testes unitários para leizilla.publisher — funções puras sem IA."""
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from leizilla.publisher import _raw_identifier, _bundle_identifier, build_raw_meta
+
+
+class TestRawIdentifier:
+    def test_format(self):
+        assert _raw_identifier("ro", "casacivil", "coddoc-00042") == (
+            "leizilla-raw-ro-casacivil-coddoc-00042"
+        )
+
+    def test_federal(self):
+        assert _raw_identifier("federal", "planalto", "lei-14133-2021") == (
+            "leizilla-raw-federal-planalto-lei-14133-2021"
+        )
+
+
+class TestBundleIdentifier:
+    def test_format_uses_iso_week(self):
+        dt = datetime(2026, 5, 22, tzinfo=timezone.utc)
+        iso = dt.isocalendar()
+        expected = f"leizilla-bundle-ro-casacivil-{iso[0]}-W{iso[1]:02d}"
+        assert _bundle_identifier("ro", "casacivil", dt) == expected
+
+    def test_defaults_to_current_date(self):
+        result = _bundle_identifier("ro", "casacivil")
+        assert result.startswith("leizilla-bundle-ro-casacivil-")
+        assert "-W" in result
+
+
+class TestBuildRawMeta:
+    def _law(self) -> dict:
+        return {
+            "ente": "ro",
+            "fonte": "casacivil",
+            "chave": "coddoc-00042",
+            "url_original": "https://ditel.casacivil.ro.gov.br/cotel/livros?coddoc=42",
+            "titulo": "Lei 42/1990",
+        }
+
+    def test_meta_version(self):
+        meta = build_raw_meta(self._law(), b"pdf", "wayback")
+        assert meta["leizilla_meta_version"] == "0.1"
+
+    def test_ente_fonte_chave(self):
+        meta = build_raw_meta(self._law(), b"pdf", "wayback")
+        assert meta["ente"] == "ro"
+        assert meta["fonte"] == "casacivil"
+        assert meta["chave"] == "coddoc-00042"
+
+    def test_hash_pdf_sha256(self):
+        pdf = b"binary pdf content"
+        meta = build_raw_meta(self._law(), pdf, "wayback")
+        expected = f"sha256:{hashlib.sha256(pdf).hexdigest()}"
+        assert meta["hash_pdf"] == expected
+
+    def test_fetched_from_wayback(self):
+        meta = build_raw_meta(
+            self._law(), b"pdf", "wayback",
+            wayback_url="https://web.archive.org/web/20260522/https://example"
+        )
+        assert meta["provenance_wayback"]["fetched_from"] == "wayback"
+        assert meta["provenance_wayback"]["wayback_url"] == (
+            "https://web.archive.org/web/20260522/https://example"
+        )
+
+    def test_fetched_from_source_fallback(self):
+        meta = build_raw_meta(self._law(), b"pdf", "source-fallback")
+        assert meta["provenance_wayback"]["fetched_from"] == "source-fallback"
+        assert meta["provenance_wayback"]["wayback_url"] is None
+
+    def test_ia_id_bundle_present(self):
+        meta = build_raw_meta(self._law(), b"pdf", "wayback")
+        assert meta["ia_id_bundle"].startswith("leizilla-bundle-ro-casacivil-")
+
+    def test_data_captura_is_iso8601(self):
+        meta = build_raw_meta(self._law(), b"pdf", "wayback")
+        dt = datetime.fromisoformat(meta["data_captura"])
+        assert dt.tzinfo is not None
+
+    def test_falls_back_to_id_when_no_chave(self):
+        law = {"ente": "ro", "fonte": "casacivil", "id": "ro-casacivil-coddoc-00042"}
+        meta = build_raw_meta(law, b"pdf", "wayback")
+        assert meta["chave"] == "ro-casacivil-coddoc-00042"

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,0 +1,72 @@
+"""Testes unitários para leizilla.robots — sem rede (mocked)."""
+
+import urllib.robotparser
+from unittest.mock import patch
+
+import pytest
+
+from leizilla import robots
+
+
+def _make_parser(
+    disallow: list[str] | None = None,
+    allow: list[str] | None = None,
+    agent: str = "*",
+) -> urllib.robotparser.RobotFileParser:
+    lines = [f"User-agent: {agent}"]
+    for path in allow or []:
+        lines.append(f"Allow: {path}")
+    for path in disallow or []:
+        lines.append(f"Disallow: {path}")
+    rp = urllib.robotparser.RobotFileParser()
+    rp.parse(lines)
+    return rp
+
+
+class TestIsAllowed:
+    def test_allowed_when_no_disallow_rules(self):
+        parser = _make_parser()
+        with patch.object(robots, "_load_robots", return_value=parser):
+            assert robots.is_allowed("https://example.gov.br/leis/1") is True
+
+    def test_blocked_by_wildcard_disallow(self):
+        parser = _make_parser(disallow=["/leis/"])
+        with patch.object(robots, "_load_robots", return_value=parser):
+            assert robots.is_allowed("https://example.gov.br/leis/1") is False
+
+    def test_allowed_outside_disallowed_path(self):
+        parser = _make_parser(disallow=["/admin/"])
+        with patch.object(robots, "_load_robots", return_value=parser):
+            assert robots.is_allowed("https://example.gov.br/leis/1") is True
+
+    def test_allowed_when_robots_txt_missing(self):
+        with patch.object(robots, "_load_robots", return_value=None):
+            assert robots.is_allowed("https://example.gov.br/leis/1") is True
+
+    def test_malformed_url_returns_false(self):
+        assert robots.is_allowed("not-a-url") is False
+
+    def test_empty_url_returns_false(self):
+        assert robots.is_allowed("") is False
+
+    def test_constructs_robots_url_from_host(self):
+        captured: list[str] = []
+
+        def capture(url: str) -> urllib.robotparser.RobotFileParser:
+            captured.append(url)
+            return _make_parser()
+
+        with patch.object(robots, "_load_robots", side_effect=capture):
+            robots.is_allowed("https://casacivil.ro.gov.br/cotel/leis/42")
+
+        assert captured == ["https://casacivil.ro.gov.br/robots.txt"]
+
+    def test_disallow_all_blocks_any_path(self):
+        parser = _make_parser(disallow=["/"])
+        with patch.object(robots, "_load_robots", return_value=parser):
+            assert robots.is_allowed("https://example.gov.br/leis/1") is False
+
+    def test_specific_agent_disallow(self):
+        parser = _make_parser(disallow=["/leis/"], agent="leizilla")
+        with patch.object(robots, "_load_robots", return_value=parser):
+            assert robots.is_allowed("https://example.gov.br/leis/1") is False

--- a/tests/test_wayback.py
+++ b/tests/test_wayback.py
@@ -1,0 +1,135 @@
+"""Testes unitários para leizilla.wayback — HTTP mockado, sem rede."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from leizilla import wayback
+
+
+def _mock_urlopen(data: dict, status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = json.dumps(data).encode()
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _ts(delta_hours: float = 0.0) -> str:
+    dt = datetime.now(tz=timezone.utc) - timedelta(hours=delta_hours)
+    return dt.strftime("%Y%m%d%H%M%S")
+
+
+class TestCheckAvailable:
+    def test_returns_url_for_fresh_snapshot(self):
+        data = {
+            "archived_snapshots": {
+                "closest": {
+                    "status": "200",
+                    "timestamp": _ts(1),
+                    "url": "https://web.archive.org/web/20260522/https://example.gov.br",
+                }
+            }
+        }
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(data)):
+            result = wayback.check_available("https://example.gov.br")
+        assert result == "https://web.archive.org/web/20260522/https://example.gov.br"
+
+    def test_returns_none_for_expired_snapshot(self):
+        data = {
+            "archived_snapshots": {
+                "closest": {
+                    "status": "200",
+                    "timestamp": _ts(25),  # 25h atrás > 24h limite
+                    "url": "https://web.archive.org/web/old/https://example.gov.br",
+                }
+            }
+        }
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(data)):
+            result = wayback.check_available("https://example.gov.br")
+        assert result is None
+
+    def test_returns_none_when_no_snapshot(self):
+        data = {"archived_snapshots": {}}
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(data)):
+            result = wayback.check_available("https://example.gov.br")
+        assert result is None
+
+    def test_returns_none_when_snapshot_status_not_200(self):
+        data = {
+            "archived_snapshots": {
+                "closest": {"status": "404", "timestamp": _ts(1), "url": "..."}
+            }
+        }
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(data)):
+            result = wayback.check_available("https://example.gov.br")
+        assert result is None
+
+    def test_returns_none_on_network_error(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            result = wayback.check_available("https://example.gov.br")
+        assert result is None
+
+    def test_custom_max_age(self):
+        data = {
+            "archived_snapshots": {
+                "closest": {
+                    "status": "200",
+                    "timestamp": _ts(2),  # 2h atrás
+                    "url": "https://web.archive.org/web/x/https://example.gov.br",
+                }
+            }
+        }
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(data)):
+            # max_age de 1h → snapshot de 2h é expirado
+            assert wayback.check_available("https://example.gov.br", max_age_seconds=3600) is None
+            # max_age de 3h → snapshot de 2h é fresco
+            assert wayback.check_available("https://example.gov.br", max_age_seconds=10800) is not None
+
+
+class TestSavePage:
+    def test_returns_true_on_200(self):
+        resp = MagicMock()
+        resp.status = 200
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=resp):
+            assert wayback.save_page("https://example.gov.br") is True
+
+    def test_returns_true_on_302(self):
+        resp = MagicMock()
+        resp.status = 302
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=resp):
+            assert wayback.save_page("https://example.gov.br") is True
+
+    def test_returns_false_on_network_error(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            assert wayback.save_page("https://example.gov.br") is False
+
+    def test_returns_false_on_exception(self):
+        with patch("urllib.request.urlopen", side_effect=Exception("unexpected")):
+            assert wayback.save_page("https://example.gov.br") is False
+
+
+class TestFetchBytes:
+    def test_returns_bytes_on_success(self):
+        resp = MagicMock()
+        resp.read.return_value = b"%PDF-1.4 binary content"
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = wayback.fetch_bytes("https://web.archive.org/web/x/https://lei.pdf")
+        assert result == b"%PDF-1.4 binary content"
+
+    def test_returns_none_on_error(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("404")):
+            assert wayback.fetch_bytes("https://web.archive.org/web/x/https://lei.pdf") is None
+
+    def test_returns_none_on_timeout(self):
+        with patch("urllib.request.urlopen", side_effect=TimeoutError()):
+            assert wayback.fetch_bytes("https://web.archive.org/web/x/https://lei.pdf") is None


### PR DESCRIPTION
## Summary

- **`wayback.py`** — cliente Wayback Machine com stdlib puro (sem nova dep). Três funções fail-open: `check_available` (snapshot fresco < 24h via availability API), `save_page` (dispara save), `fetch_bytes` (baixa bytes de URL). Implementa ADR-0004 e princípio #9.
- **`robots.py`** — verificador de robots.txt com `lru_cache` por host. `is_allowed(url)` retorna False permanentemente para URLs bloqueadas (princípio #10, ADR-0008). Fail-open: sem robots.txt = permitido.
- **`publisher.py`** — identifier format correto (`leizilla-raw-{ente}-{fonte}-{chave}`), bundle semanal (`leizilla-bundle-{ente}-{fonte}-YYYY-WXX`), `build_raw_meta()` constrói `raw_meta.json` conforme SCHEMA.md §2.1, `upload_raw()` envia PDF + sidecar no mesmo IA item.
- **34 novos testes** — HTTP mockado via `unittest.mock`, sem rede.
- **IMPLEMENTATION.md** — M2.1 marcado in-progress, log de decisões atualizado.

## Trade-offs aceitos

- **stdlib over httpx**: urllib.request basta para as 3 operações simples do Wayback. Evita adicionar dep enquanto o crawler (Playwright vs. sync) não está definido para M2 restante. Revisitar quando `scrape` for implementado.
- **Stacked em PR #14 (M1)**: base branch é `claude/practical-galileo-YcBNT`. Após M1 mergear, retargetar para `main`.
- **upload_raw() não testado end-to-end**: testa as funções puras (`build_raw_meta`, `_raw_identifier`, `_bundle_identifier`) mas não o subprocess `ia upload` (requer IA credentials). Aceitável — IA upload é IO externo sem valor em unit test.

## Test plan

- [x] `uv run pytest tests/test_wayback.py` — 13 testes passam (HTTP mockado)
- [x] `uv run pytest tests/test_robots.py` — 9 testes passam
- [x] `uv run pytest tests/test_publisher.py` — 12 testes passam
- [x] `uv run pytest` — 132 total passam, 12 skipped (xmllint/xsltproc)

## Próximos passos (M2 restante)

- `crawler.py` atualizado: orquestra `robots.is_allowed` → `wayback.save_page` + `check_available` → `wayback.fetch_bytes` (fallback direto se Wayback falhar) → `publisher.upload_raw`
- CLI `scrape --ente ro --fonte casacivil --start-coddoc N --end-coddoc M`
- `fontes/{ente}.py` para estados além de RO

https://claude.ai/code/session_01MdxaG14tgZrdq7j5dRfrSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdxaG14tgZrdq7j5dRfrSY)_