### PR TITLE
feat(M2.2): scraper.py + comando scrape + ids corretos no crawler

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -13,8 +13,9 @@
 | **M0.2b** — Redesign first-principles | 🟢 done | #8 #9 #10 #12 | SCHEMA.md reescrito + XSD enxuto + 6 fixtures + consistency checker + CI wire + XSLT Leizilla→LexML validado contra XSD oficial bundled (PRs #8-#12 merged). |
 | **M0.3** — URN canônica + close pendentes §8 | 🟢 done | #13 | URN LEX contra spec CGPID 2008 oficial; política re-scrape; robots.txt princípio. 3 pendentes deferidos para M2/M4. |
 | **M1** — Foundation (package + ADRs + entes + fontes) | 🟡 in-progress | #14 | Package `src/leizilla/`; ADRs 0004–0009; rename `origem→ente`; `entes.py`; `fontes/ro.py`. |
-| **M2.1** — Wayback client + robots.txt + publisher sidecar | 🟡 in-progress | TBD | `wayback.py` (check_available/save_page/fetch_bytes) + `robots.py` (is_allowed, lru_cache) + `publisher.build_raw_meta` + `raw_meta.json` sidecar. Stacked em cima de M1. |
-| M2 — Crawler real + Raw upload (restante) | ⚪ todo | — | Bloqueado por M1+M2.1. Próximo: `scrape` CLI, integração wayback→upload no pipeline. |
+| **M2.1** — Wayback client + robots.txt + publisher sidecar | 🟡 in-progress | #15 | `wayback.py` (check_available/save_page/fetch_bytes) + `robots.py` (is_allowed, lru_cache) + `publisher.build_raw_meta` + `raw_meta.json` sidecar. Stacked em cima de M1. |
+| **M2.2** — scraper.py + `scrape` CLI + fix ids no crawler | 🟡 in-progress | TBD | `scraper.scrape_one()` orquestra robots→wayback→fetch→upload_raw. CLI `scrape` para assembleia/RO. `crawler.py` adiciona `fonte`+`chave` no output. 10 testes. |
+| M2 restante — casacivil discovery + outros entes | ⚪ todo | — | Bloqueado por M2.2. Próximo: discovery casacivil.ro.gov.br; adicionar fontes/{sp,federal}.py. |
 | M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
 | M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |
@@ -74,6 +75,32 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-22 — M2.2: scraper.py + `scrape` CLI + ids corretos no crawler
+
+`scraper.scrape_one(fonte_url, pdf_url, lei_data, publisher, rate_limiter)`:
+implementa o pipeline M2 conforme princípios #9 e #10. robots check é permanente
+(caller não retenta URL bloqueada). Wayback como primário; fallback direto com
+rate_limiter() antes da chamada. Fail-open em todos os passos da rede. temp file
+para upload e cleanup garantido em finally.
+
+`make_rate_limiter(min_interval=1.0)` — closure com monotonic para garantir 1 req/s
+entre chamadas diretas (princípio #10). Passado pelo caller para permitir mock em testes.
+
+`crawler.discover_rondonia_laws()` — corrigido: id de `ro-casacivil-coddoc-N`
+para `ro-assembleia-coddoc-N` (estava scrapeando ALRO mas usando slug errado);
+adicionados campos `fonte: "assembleia"` e `chave: "coddoc-{N:05d}"` necessários
+para `publisher._raw_identifier()` construir IA id correto sem duplicar prefixos.
+
+CLI `scrape --ente ro --fonte assembleia --start-coddoc N --end-coddoc M`: 
+discovery async (Playwright) + scrape_one sync para cada lei. Fontes além de
+assembleia/ro delegam NotImplemented com mensagem clara.
+
+Testes: 10 unitários em `tests/test_scraper.py`, HTTP 100% mockado.
+
+**Próximos M2**: discovery casacivil.ro.gov.br (padrão de URL a auditar);
+atualizar `rondonia_crawler.yml` para chamar `uv run leizilla scrape` em vez
+do script `run_rondonia_crawler.py`; rate-limit por host (não global).
 
 ### 2026-05-22 — M1: package `src/leizilla/`, rename origem→ente, ADRs, catálogo entes
 
@@ -408,15 +435,26 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 - [x] **Robots.txt + rate-limit** como princípio load-bearing #10 em IMPLEMENTATION.md.
 - [x] **Deferred** pendentes (§8.3): compressão Parquet → M4, granularidade ZIP → M2, custo LLM → M2/M3.
 
-**M1 — Foundation** (este PR):
+**M1 — Foundation** ✅ (PR #14):
 - [x] Package restructure `src/` → `src/leizilla/` + `pyproject.toml` com `packages.find`.
 - [x] ADRs 0004–0009 em `docs/adr/`.
 - [x] Migração `origem` → `ente` em `cli.py` + `storage.py` + `test_storage.py`.
 - [x] `src/leizilla/entes.py` com catálogo (federal + 26 UFs + DF).
 - [x] `src/leizilla/fontes/ro.py` stub com fontes de Rondônia declaradas.
 
-**M2 — Crawler real + Raw upload** (próximo):
-- [ ] `crawler.py`: robots.txt check + Wayback Machine fetch (ADR-0004).
-- [ ] `publisher.py`: IA identifiers conforme ADR-0005 + raw_meta.json sidecar.
-- [ ] CLI: comando `scrape` substitui `discover`; `parse` e `consolidate` adicionados.
-- [ ] Testes de integração com mock do Wayback e IA.
+**M2.1 — Wayback + robots + publisher sidecar** ✅ (PR #15):
+- [x] `wayback.py`: check_available + save_page + fetch_bytes.
+- [x] `robots.py`: is_allowed com lru_cache por host.
+- [x] `publisher.upload_raw()` + `build_raw_meta()` + `_raw_identifier()`.
+
+**M2.2 — scraper.py + `scrape` CLI** (este PR):
+- [x] `scraper.scrape_one()`: pipeline robots→wayback→fetch→upload_raw.
+- [x] `scraper.make_rate_limiter()`: 1 req/s entre fallbacks diretos.
+- [x] `crawler.discover_rondonia_laws()`: `fonte`+`chave` corretos no output.
+- [x] CLI `scrape --ente ro --fonte assembleia --start-coddoc N --end-coddoc M`.
+- [x] 10 testes unitários (HTTP mockado).
+
+**M2 restante** (próximo):
+- [ ] Discovery para `casacivil.ro.gov.br` (auditar padrão URL + campos).
+- [ ] Atualizar `rondonia_crawler.yml` para usar `uv run leizilla scrape`.
+- [ ] Rate-limit por host (não global) — preparação para múltiplas fontes em paralelo.

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -147,6 +147,57 @@ def cmd_upload(
         raise typer.Exit(1)
 
 
+@app.command("scrape")
+def cmd_scrape(
+    ente: str = typer.Option("ro", help="Ente federativo"),
+    fonte: str = typer.Option("assembleia", help="Fonte (assembleia, casacivil)"),
+    start_coddoc: int = typer.Option(1, help="ID inicial"),
+    end_coddoc: int = typer.Option(10, help="ID final"),
+) -> None:
+    """Scrape leis: discover → robots → wayback → upload_raw para IA."""
+    echo(f"Scraping {ente}/{fonte} coddoc {start_coddoc}–{end_coddoc}")
+
+    try:
+        from leizilla.crawler import LeisCrawler
+        from leizilla.publisher import InternetArchivePublisher
+        from leizilla.scraper import make_rate_limiter, scrape_one
+
+        publisher = InternetArchivePublisher()
+        rate_limiter = make_rate_limiter()
+
+        async def run() -> None:
+            if ente == "ro" and fonte == "assembleia":
+                crawler = LeisCrawler(crawler_type="playwright")
+                laws = await crawler.discover_rondonia_laws(
+                    start_coddoc=start_coddoc,
+                    end_coddoc=end_coddoc,
+                )
+            else:
+                echo(f"Fonte '{fonte}' para '{ente}' ainda não implementada")
+                raise typer.Exit(1)
+
+            ok = 0
+            for law in laws:
+                pdf_url = law.get("url_pdf_original")
+                fonte_url = law.get("url_original")
+                if not pdf_url or not fonte_url:
+                    echo(f"  Sem URL PDF: {law.get('id', 'N/A')}")
+                    continue
+                result = scrape_one(fonte_url, pdf_url, law, publisher, rate_limiter)
+                if result.get("success"):
+                    echo(f"  OK: {result.get('ia_id', '?')}")
+                    ok += 1
+                else:
+                    echo(f"  Falha [{result.get('reason', '?')}]: {law.get('id', 'N/A')}")
+
+            echo(f"Scraping concluído: {ok}/{len(laws)} com sucesso")
+
+        asyncio.run(run())
+    except Exception as e:
+        echo(f"Erro: {e}")
+        raise typer.Exit(1)
+
+
 @app.command("export")
 def cmd_export(
     ente: str = typer.Option("ro", help="Ente federativo"),

--- a/src/leizilla/crawler.py
+++ b/src/leizilla/crawler.py
@@ -62,9 +62,11 @@ class LeisCrawler:
                             pdf_url = urljoin(base_url, pdf_url)
 
                     law: Dict[str, Any] = {
-                        "id": f"ro-casacivil-coddoc-{coddoc:05d}",
-                        "titulo": title.strip(),
+                        "id": f"ro-assembleia-coddoc-{coddoc:05d}",
                         "ente": "ro",
+                        "fonte": "assembleia",
+                        "chave": f"coddoc-{coddoc:05d}",
+                        "titulo": title.strip(),
                         "url_original": url,
                         "url_pdf_original": pdf_url,
                         "coddoc": coddoc,

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -1,0 +1,89 @@
+"""Pipeline de scraping: robots → wayback save/fetch → upload_raw (ADR-0004, ADR-0005).
+
+Princípio #9: Wayback como caminho primário; fallback direto se Wayback falhar.
+Princípio #10: robots.txt é permanente (sem retry em URL bloqueada); rate-limit
+               em fallback direto.
+"""
+
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from leizilla import robots, wayback
+from leizilla.publisher import InternetArchivePublisher
+
+_RATE_LIMIT_S = 1.0
+
+
+def scrape_one(
+    fonte_url: str,
+    pdf_url: str,
+    lei_data: Dict[str, Any],
+    publisher: InternetArchivePublisher,
+    rate_limiter: Optional[Callable[[], None]] = None,
+) -> Dict[str, Any]:
+    """Scrape um PDF: robots check → wayback save → fetch → upload_raw.
+
+    Retorna dict com 'success' + ('ia_id', 'ia_url') ou ('reason') em falha.
+    Robots bloqueado é permanente — caller NÃO deve re-tentar a mesma URL.
+    """
+    if not robots.is_allowed(fonte_url):
+        return {"success": False, "reason": "robots-blocked", "url": fonte_url}
+    if not robots.is_allowed(pdf_url):
+        return {"success": False, "reason": "robots-blocked", "url": pdf_url}
+
+    # Wayback save (fire-and-forget, fail-open)
+    wayback.save_page(fonte_url)
+    wayback.save_page(pdf_url)
+
+    # Wayback fetch (primário)
+    wb_url = wayback.check_available(pdf_url)
+    fetched_from: str
+    pdf_bytes: Optional[bytes]
+
+    if wb_url:
+        pdf_bytes = wayback.fetch_bytes(wb_url)
+        fetched_from = "wayback"
+    else:
+        pdf_bytes = None
+        wb_url = None
+
+    if pdf_bytes is None:
+        # Fallback direto com rate-limit (princípio #10)
+        if rate_limiter is not None:
+            rate_limiter()
+        pdf_bytes = wayback.fetch_bytes(pdf_url)
+        fetched_from = "source-fallback"
+        wb_url = None
+
+    if pdf_bytes is None:
+        return {"success": False, "reason": "fetch-failed", "url": pdf_url}
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+        f.write(pdf_bytes)
+        tmp_path = Path(f.name)
+
+    try:
+        return publisher.upload_raw(
+            tmp_path,
+            lei_data,
+            pdf_bytes,
+            fetched_from=fetched_from,
+            wayback_url=wb_url,
+        )
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def make_rate_limiter(min_interval: float = _RATE_LIMIT_S) -> Callable[[], None]:
+    """Cria rate limiter simples: garante >= min_interval entre chamadas."""
+    last: list[float] = [0.0]
+
+    def limiter() -> None:
+        elapsed = time.monotonic() - last[0]
+        if elapsed < min_interval:
+            time.sleep(min_interval - elapsed)
+        last[0] = time.monotonic()
+
+    return limiter

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -77,6 +77,8 @@ def scrape_one(
             fetched_from=fetched_from,
             wayback_url=wb_url,
         )
+    except Exception as exc:
+        return {"success": False, "reason": "upload-failed", "error": str(exc)}
     finally:
         tmp_path.unlink(missing_ok=True)
 

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -33,9 +33,14 @@ def scrape_one(
     if not robots.is_allowed(pdf_url):
         return {"success": False, "reason": "robots-blocked", "url": pdf_url}
 
-    # Wayback save (fire-and-forget, fail-open)
-    wayback.save_page(fonte_url)
-    wayback.save_page(pdf_url)
+    # Wayback save — fire-and-forget; exceções swallowadas explicitamente
+    # para que falhas de rede (DNS, timeout) não abortem o scrape
+    # das URLs que importam (fetch + upload).
+    try:
+        wayback.save_page(fonte_url)
+        wayback.save_page(pdf_url)
+    except Exception:
+        pass
 
     # Wayback fetch (primário)
     wb_url = wayback.check_available(pdf_url)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,120 @@
+"""Testes para scraper.py — robots → wayback → fetch → upload_raw."""
+
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+from leizilla.scraper import make_rate_limiter, scrape_one
+
+_LEI = {
+    "id": "ro-assembleia-coddoc-00001",
+    "ente": "ro",
+    "fonte": "assembleia",
+    "chave": "coddoc-00001",
+    "titulo": "Lei de Teste",
+}
+_FONTE_URL = "https://www.al.ro.leg.br/legislacao/leis/1"
+_PDF_URL = "https://www.al.ro.leg.br/legislacao/leis/1.pdf"
+_WB_URL = "https://web.archive.org/web/20260101000000/" + _PDF_URL
+_PDF_BYTES = b"%PDF-fake"
+
+
+def _make_publisher(success: bool = True) -> MagicMock:
+    pub = MagicMock()
+    if success:
+        pub.upload_raw.return_value = {
+            "success": True,
+            "ia_id": "leizilla-raw-ro-assembleia-coddoc-00001",
+            "ia_url": "https://archive.org/details/leizilla-raw-ro-assembleia-coddoc-00001",
+        }
+    else:
+        pub.upload_raw.return_value = {"success": False, "error": "IA error"}
+    return pub
+
+
+class TestScrapeOne:
+    @patch("leizilla.scraper.robots.is_allowed", return_value=False)
+    def test_fonte_url_robots_blocked(self, _mock: Any) -> None:
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, _make_publisher())
+        assert result == {"success": False, "reason": "robots-blocked", "url": _FONTE_URL}
+
+    @patch("leizilla.scraper.robots.is_allowed", side_effect=[True, False])
+    def test_pdf_url_robots_blocked(self, _mock: Any) -> None:
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, _make_publisher())
+        assert result == {"success": False, "reason": "robots-blocked", "url": _PDF_URL}
+
+    @patch("leizilla.scraper.wayback.check_available", return_value=_WB_URL)
+    @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
+    @patch("leizilla.scraper.wayback.save_page", return_value=True)
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    def test_wayback_fetch_success(self, _r: Any, _s: Any, _f: Any, _c: Any) -> None:
+        pub = _make_publisher()
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub)
+        assert result["success"] is True
+        call_kwargs = pub.upload_raw.call_args
+        assert call_kwargs.kwargs["fetched_from"] == "wayback"
+        assert call_kwargs.kwargs["wayback_url"] == _WB_URL
+
+    @patch("leizilla.scraper.wayback.check_available", return_value=None)
+    @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
+    @patch("leizilla.scraper.wayback.save_page", return_value=False)
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    def test_fallback_direct_fetch(self, _r: Any, _s: Any, _f: Any, _c: Any) -> None:
+        pub = _make_publisher()
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub)
+        assert result["success"] is True
+        call_kwargs = pub.upload_raw.call_args
+        assert call_kwargs.kwargs["fetched_from"] == "source-fallback"
+        assert call_kwargs.kwargs["wayback_url"] is None
+
+    @patch("leizilla.scraper.wayback.check_available", return_value=None)
+    @patch("leizilla.scraper.wayback.fetch_bytes", return_value=None)
+    @patch("leizilla.scraper.wayback.save_page", return_value=False)
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    def test_fetch_failed(self, _r: Any, _s: Any, _f: Any, _c: Any) -> None:
+        pub = _make_publisher()
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub)
+        assert result == {"success": False, "reason": "fetch-failed", "url": _PDF_URL}
+        pub.upload_raw.assert_not_called()
+
+    @patch("leizilla.scraper.wayback.check_available", return_value=_WB_URL)
+    @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
+    @patch("leizilla.scraper.wayback.save_page", return_value=True)
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    def test_upload_failure_propagated(self, _r: Any, _s: Any, _f: Any, _c: Any) -> None:
+        pub = _make_publisher(success=False)
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub)
+        assert result["success"] is False
+        assert "error" in result
+
+    @patch("leizilla.scraper.wayback.check_available", return_value=_WB_URL)
+    @patch("leizilla.scraper.wayback.fetch_bytes", side_effect=[None, _PDF_BYTES])
+    @patch("leizilla.scraper.wayback.save_page", return_value=True)
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    def test_wayback_bytes_none_then_fallback(self, _r: Any, _s: Any, _f: Any, _c: Any) -> None:
+        """Wayback URL existe mas fetch retorna None → fallback direto."""
+        pub = _make_publisher()
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub)
+        assert result["success"] is True
+        call_kwargs = pub.upload_raw.call_args
+        assert call_kwargs.kwargs["fetched_from"] == "source-fallback"
+
+    @patch("leizilla.scraper.wayback.check_available", return_value=None)
+    @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
+    @patch("leizilla.scraper.wayback.save_page", return_value=False)
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    def test_rate_limiter_called_on_fallback(self, _r: Any, _s: Any, _f: Any, _c: Any) -> None:
+        pub = _make_publisher()
+        rate_mock = MagicMock()
+        scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub, rate_limiter=rate_mock)
+        rate_mock.assert_called_once()
+
+
+class TestMakeRateLimiter:
+    def test_returns_callable(self) -> None:
+        limiter = make_rate_limiter(0.0)
+        assert callable(limiter)
+
+    def test_callable_runs_without_error(self) -> None:
+        limiter = make_rate_limiter(0.0)
+        limiter()
+        limiter()


### PR DESCRIPTION
## Summary

- **`scraper.scrape_one()`**: pipeline M2 completo para uma lei — robots check permanente → Wayback save (fire-and-forget, fail-open) → Wayback fetch → fallback direto com rate-limit → `upload_raw` com `raw_meta.json` sidecar. Rate limiter é injetável para facilitar testes e preparar rate-limit por host futuro.
- **`scraper.make_rate_limiter()`**: closure monotonic-safe que garante `min_interval` (default 1 req/s) entre chamadas diretas à fonte. Implementa princípio load-bearing #10.
- **`crawler.discover_rondonia_laws()`**: corrigido slug `ro-casacivil-coddoc-N` → `ro-assembleia-coddoc-N` (estava usando fonte errada no id); adicionados `fonte: "assembleia"` e `chave: "coddoc-{N:05d}"` no dict de saída — necessários para `_raw_identifier()` construir `leizilla-raw-ro-assembleia-coddoc-00001` sem duplicar prefixos.
- **CLI `scrape`**: `leizilla scrape --ente ro --fonte assembleia --start-coddoc N --end-coddoc M` — discovery async (Playwright) + `scrape_one` sync por lei. Fontes não implementadas dão erro descritivo em vez de travar silencioso.
- **IMPLEMENTATION.md**: M2.1 marcado com PR #15; M2.2 em-progress; próximos passos atualizados (casacivil discovery, workflow update).

## Trade-offs aceitos

- **Stacked em PR #15 (M2.1)**: base branch é `claude/m2-wayback-scraper`. Após M1 (#14) e M2.1 (#15) mergearem, retargetar para `main`.
- **Discovery casacivil não implementada**: `leizilla scrape --fonte casacivil` retorna erro descritivo. Será implementada quando auditarmos o padrão de URL de `casacivil.ro.gov.br`.
- **Rate-limit global por agora**: `make_rate_limiter` cria um limiter compartilhado por sessão de scrape. Rate-limit por host vem no próximo PR (quando múltiplas fontes rodarem em paralelo).
- **Scrape síncrono**: `scrape_one` é síncrono (stdlib HTTP). O CLI roda o discovery async e chama scrape_one sync em loop. Não bloqueia event loop porque discovery já terminou antes do scrape começar.

## Test plan

- [x] `uv run pytest tests/test_scraper.py -v` — 10 testes passam
- [x] `uv run pytest` — 142 passed, 12 skipped (xmllint/xsltproc)
- [x] `uv run leizilla scrape --help` — comando disponível e help correto

## Próximos passos (M2 restante)

- [ ] Discovery `casacivil.ro.gov.br`: auditar padrão URL, campos de descoberta, PDF links
- [ ] `rondonia_crawler.yml`: substituir `python scripts/run_rondonia_crawler.py` por `uv run leizilla scrape --ente ro --fonte assembleia`
- [ ] Rate-limit por host (`dict[str, limiter]` no caller) para permitir fontes paralelas
- [ ] Testes e2e com Playwright (marcados skip sem `--runslow`)

https://claude.ai/code/session_01EF6hhPSxefkqB921KheJZ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EF6hhPSxefkqB921KheJZ3)_