### PR TITLE
chore(M2.3): CI workflow atualizado + internetarchive dep + IMPLEMENTATION.md sync

### DIFF
--- a/.github/workflows/rondonia_crawler.yml
+++ b/.github/workflows/rondonia_crawler.yml
@@ -2,44 +2,38 @@ name: Crawl Rondônia Laws
 
 on:
   schedule:
-    - cron: "0 0 * * 0" # Runs every Sunday at midnight UTC
-  workflow_dispatch: # Allows manual triggering
+    - cron: "0 0 * * 0"  # Weekly on Sunday midnight UTC
+  workflow_dispatch:
+    inputs:
+      start_coddoc:
+        description: "Primeiro coddoc (ALRO)"
+        default: "1"
+      end_coddoc:
+        description: "Último coddoc (ALRO)"
+        default: "100"
 
 jobs:
-  crawl_and_upload:
+  scrape:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12" # Should match project.requires-python from pyproject.toml
+      - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv sync --system
-
-      - name: Install Internet Archive CLI
-        run: pip install internetarchive
+        run: uv sync
 
       - name: Install Playwright browsers
-        run: playwright install chromium --with-deps
+        run: uv run playwright install chromium --with-deps
 
-      - name: Run Rondônia Crawler
+      - name: Scrape Rondônia — assembleia (ALRO)
         env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-          PYTHONPATH: ${{ github.workspace }}/src # Add src to PYTHONPATH so modules can be imported
-        run: python scripts/run_rondonia_crawler.py
-
-      - name: Backup DuckDB Database to Internet Archive
-        if: always() # Run even if previous steps fail, to ensure DB backup attempt
-        env:
-          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
-          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-          PYTHONPATH: ${{ github.workspace }}/src
-        run: python scripts/backup_database.py # New script dedicated to DB backup
+        run: |
+          uv run leizilla scrape \
+            --ente ro \
+            --fonte assembleia \
+            --start-coddoc ${{ inputs.start_coddoc || '1' }} \
+            --end-coddoc ${{ inputs.end_coddoc || '100' }}

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -12,11 +12,15 @@
 | **M0.2a** — Schema v1 (tentativa) | 🔴 superseded | #7 | XSD `header` + `rotulo` + `<bloco-livre>` + etc. Substituído pelo redesign first-principles. Fica como referência histórica. |
 | **M0.2b** — Redesign first-principles | 🟢 done | #8 #9 #10 #12 | SCHEMA.md reescrito + XSD enxuto + 6 fixtures + consistency checker + CI wire + XSLT Leizilla→LexML validado contra XSD oficial bundled (PRs #8-#12 merged). |
 | **M0.3** — URN canônica + close pendentes §8 | 🟢 done | #13 | URN LEX contra spec CGPID 2008 oficial; política re-scrape; robots.txt princípio. 3 pendentes deferidos para M2/M4. |
-| **M1** — Foundation (package + ADRs + entes + fontes) | 🟡 in-progress | #14 | Package `src/leizilla/`; ADRs 0004–0009; rename `origem→ente`; `entes.py`; `fontes/ro.py`. |
-| **M2.1** — Wayback client + robots.txt + publisher sidecar | 🟡 in-progress | #15 | `wayback.py` (check_available/save_page/fetch_bytes) + `robots.py` (is_allowed, lru_cache) + `publisher.build_raw_meta` + `raw_meta.json` sidecar. Stacked em cima de M1. |
-| **M2.2** — scraper.py + `scrape` CLI + fix ids no crawler | 🟡 in-progress | TBD | `scraper.scrape_one()` orquestra robots→wayback→fetch→upload_raw. CLI `scrape` para assembleia/RO. `crawler.py` adiciona `fonte`+`chave` no output. 10 testes. |
-| M2 restante — casacivil discovery + outros entes | ⚪ todo | — | Bloqueado por M2.2. Próximo: discovery casacivil.ro.gov.br; adicionar fontes/{sp,federal}.py. |
-| M3 — OCR fetch + LLM parse + Leizilla XML | ⚪ todo | — | Bloqueado por M2 |
+| **M1** — Foundation (package + ADRs + entes + fontes) | 🟢 done | #14 | Package `src/leizilla/`; ADRs 0004–0009; rename `origem→ente`; `entes.py`; `fontes/ro.py`. |
+| **M2.1** — Wayback client + robots.txt + publisher sidecar | 🟢 done | #15 | `wayback.py` (check_available/save_page/fetch_bytes) + `robots.py` (is_allowed, lru_cache) + `publisher.build_raw_meta` + `raw_meta.json` sidecar. |
+| **M2.2** — scraper.py + `scrape` CLI + fix ids no crawler | 🟢 done | #18 | `scraper.scrape_one()` orquestra robots→wayback→fetch→upload_raw. CLI `scrape` para assembleia/RO. 10 testes. |
+| **M2.3** — CI workflow + `internetarchive` dep | 🟢 done | este PR | `rondonia_crawler.yml` atualizado para `uv run leizilla scrape`. `internetarchive` em pyproject.toml. |
+| **M3.1** — OCR fetch + LLM parse → parser.py | 🟡 in-progress | #17 | `parser.fetch_ocr` + `parser.parse_law` (Haiku, cache ephemeral). 27 testes. Aguardando merge. |
+| **M3.2** — publisher.upload_parsed() | 🟡 in-progress | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. Aguardando merge. |
+| M3 restante — `parse --upload` + `parse-all` batch | ⚪ todo | — | Bloqueado por #17+#19. CLI `parse --upload` integra parser→publisher. `parse-all` itera raw items sem parsed_meta. |
+| M2 restante — casacivil discovery + outros entes | ⚪ todo | — | casacivil.ro.gov.br (padrão de URL a auditar); fontes/{sp,federal}.py. Rate-limit por host. |
+| M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |
 | M6 — GitHub Actions | ⚪ todo | — | Depende de M2–M5 |
@@ -101,6 +105,26 @@ Testes: 10 unitários em `tests/test_scraper.py`, HTTP 100% mockado.
 **Próximos M2**: discovery casacivil.ro.gov.br (padrão de URL a auditar);
 atualizar `rondonia_crawler.yml` para chamar `uv run leizilla scrape` em vez
 do script `run_rondonia_crawler.py`; rate-limit por host (não global).
+
+### 2026-05-22 — M2.3: CI workflow atualizado + internetarchive em deps
+
+`rondonia_crawler.yml` reescrito do zero. Versão antiga chamava
+`python scripts/run_rondonia_crawler.py` (script legado, usava `upload_pdf`
+e `download_pdf` — métodos que não existem mais) e `python scripts/backup_database.py`
+(backup de DuckDB que não é mais o storage primário).
+
+Nova versão: `uv run leizilla scrape --ente ro --fonte assembleia`. O comando
+`scrape` (M2.2) orquestra tudo: robots check → Wayback → fetch → upload_raw.
+Sem step de backup: DuckDB é staging local, não primary storage em CI.
+
+`internetarchive` adicionado como dependência explícita em `pyproject.toml`.
+Antes era instalado via `pip install internetarchive` no workflow — inconsistente
+com o modelo uv. Com a dep declarada, `uv sync` instala o pacote no venv e
+`ia` fica disponível para subprocess.run(["ia", "upload", ...]) dentro de
+`uv run leizilla scrape`.
+
+Adicionado `workflow_dispatch.inputs` (start_coddoc/end_coddoc) para trigger
+manual com range configurável — útil para re-scrapes parciais e debugging.
 
 ### 2026-05-22 — M1: package `src/leizilla/`, rename origem→ente, ADRs, catálogo entes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "anyio",
     "beautifulsoup4",
     "duckdb",
+    "internetarchive",
     "playwright",
     "requests",
     "typer",

--- a/uv.lock
+++ b/uv.lock
@@ -282,6 +282,42 @@ wheels = [
 ]
 
 [[package]]
+name = "internetarchive"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpatch" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/e6/594ecd2469fca16f92e9538c40c010c87cc1d5b166dea67d266b405b08e3/internetarchive-5.8.0.tar.gz", hash = "sha256:0dff14d51bafa3da587f32a8cb6478327e20c2d040a61fbfb4ad30d592062cc2", size = 135263, upload-time = "2026-02-18T22:54:17.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/6f/22c2a8ced6c0c5e2786c14ad15871567ac4cbe4511cb38f3f7d5b8c47878/internetarchive-5.8.0-py3-none-any.whl", hash = "sha256:2f86eed71e11ad0c8f7ac3a339a2e0d0ee8316151be1257950df5e472ff62d8b", size = 119781, upload-time = "2026-02-18T22:54:15.909Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
 name = "leizilla"
 version = "0.1.0"
 source = { editable = "." }
@@ -289,6 +325,7 @@ dependencies = [
     { name = "anyio" },
     { name = "beautifulsoup4" },
     { name = "duckdb" },
+    { name = "internetarchive" },
     { name = "playwright" },
     { name = "requests" },
     { name = "typer" },
@@ -312,6 +349,7 @@ requires-dist = [
     { name = "anyio" },
     { name = "beautifulsoup4" },
     { name = "duckdb" },
+    { name = "internetarchive" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "playwright" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -556,6 +594,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **`rondonia_crawler.yml` reescrito**: substitui `python scripts/run_rondonia_crawler.py` (script legado com métodos inexistentes `upload_pdf`/`download_pdf`) por `uv run leizilla scrape --ente ro --fonte assembleia`. Remove step `backup_database.py` — DuckDB não é primary storage em CI.
- **`workflow_dispatch.inputs`**: `start_coddoc`/`end_coddoc` configuráveis em triggers manuais — útil para re-scrapes parciais e debugging de ranges específicos.
- **`internetarchive` em `pyproject.toml`**: era instalado via `pip install internetarchive` avulso no workflow. Com a dep declarada, `uv sync` instala o pacote no venv e `ia` fica disponível para `subprocess.run(["ia", "upload", ...])` dentro de `uv run leizilla scrape`.
- **`IMPLEMENTATION.md` sincronizado**: M1/M2.1/M2.2 → 🟢 done; M3.1 (#17) e M3.2 (#19) → 🟡 in-progress; M2.3 registrado; log de decisão com raciocínio do rewrite.

## Trade-offs aceitos

- Scripts legados (`scripts/run_rondonia_crawler.py`, `scripts/backup_database.py`) mantidos no repo — não são chamados mais, mas têm valor histórico e podem ser úteis para debugging manual. Remoção pode vir em PR de limpeza separado.
- `setup-uv@v5` em vez de `@v1` do workflow antigo — versão mais recente, melhor suporte a lock files.

## Test plan

- [x] `uv run pytest` — 142 passam, 12 skipped (xmllint/xsltproc sem markup diff)
- [x] `uv sync` instala `internetarchive` no venv local sem erros
- [x] `uv run leizilla scrape --help` — comando disponível com `--ente`, `--fonte`, `--start-coddoc`, `--end-coddoc`
- [ ] CI workflow acionado via `workflow_dispatch` — verificar na próxima sessão após merge

## Próximos passos

- Aguardar merge de #17 (M3.1) e #19 (M3.2)
- M3 restante: CLI `parse --upload` + `leizilla parse-all --ente ro` (batch)
- M2 restante: casacivil.ro.gov.br discovery (padrão de URL a auditar)

https://claude.ai/code/session_01U7YY75EdnXru6KbKWav8kx

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7YY75EdnXru6KbKWav8kx)_