### PR TITLE
feat(M3.3): parse --upload + XSD gate + parse-all batch

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -16,9 +16,9 @@
 | **M2.1** — Wayback client + robots.txt + publisher sidecar | 🟢 done | #15 | `wayback.py` + `robots.py` + `publisher.upload_raw` + PDF renomeado para {ia_id}.pdf. 34 testes. |
 | **M2.2** — scraper.py + `scrape` CLI + fix ids no crawler | 🟢 done | #18 | `scraper.scrape_one()` orquestra robots→wayback→fetch→upload_raw. CLI `scrape` para assembleia/RO. 10 testes. |
 | **M2.3** — CI workflow + `internetarchive` dep | 🟢 done | #20 | `rondonia_crawler.yml` atualizado para `uv run leizilla scrape`. `internetarchive` em pyproject.toml. |
-| **M3.1** — OCR fetch + LLM parse → parser.py | 🟡 in-progress | #17 | `parser.fetch_ocr` + `parse_law` (Haiku, fail-closed: confidence/tipo/numero/ano obrigatórios). 27 testes. |
-| **M3.2** — publisher.upload_parsed() | 🟡 in-progress | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. |
-| M3 restante — `parse --upload` + `parse-all` batch | ⚪ todo | — | Bloqueado por #17+#19. CLI `parse --upload` integra parser→publisher. `parse-all` itera raw items sem parsed_meta. |
+| **M3.1** — OCR fetch + LLM parse → parser.py | 🟢 done | #17 | `parser.fetch_ocr` + `parse_law` (Haiku, fail-closed: confidence/tipo/numero/ano obrigatórios). 27 testes. |
+| **M3.2** — publisher.upload_parsed() | 🟢 done | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. |
+| **M3 restante** — `parse --upload` + XSD gate + `parse-all` batch | 🟡 in-progress | TBD | CLI `parse --upload` integra parser→publisher; `_xsd_gate` via xmllint; `parse-all` itera range coddoc. 15 testes. |
 | M2 restante — casacivil discovery + outros entes | ⚪ todo | — | casacivil.ro.gov.br (padrão de URL a auditar); fontes/{sp,federal}.py. Rate-limit por host. |
 | M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |
@@ -78,6 +78,39 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-22 — M3 restante: `parse --upload` + XSD gate + `parse-all` batch
+
+Integra M3.1 (`parser.py`) e M3.2 (`publisher.upload_parsed`) via CLI, completando
+o pipeline Etapa 2 end-to-end: OCR fetch → LLM parse → XSD validate → IA upload.
+
+**`_xsd_gate(xml_content)`** — helper em `cli.py`:
+- Localiza `docs/schemas/leizilla-v0.1.xsd` via `Path(__file__).parents[2]`.
+- Escreve XML em tmp file; roda `xmllint --schema ... --noout`; apaga tmp em `finally`.
+- Fail-open: schema ausente ou `xmllint` não instalado → avisa + retorna True.
+- Retorna False (e printa aviso) se xmllint retorna non-zero (validação falhou).
+
+**`parse --upload/--no-upload`** (default `--no-upload`):
+- Com `--upload`: chama `_xsd_gate`, depois `InternetArchivePublisher().upload_parsed()`.
+- Upload falhou → exit code 1 com mensagem "Upload falhou: {error}".
+- Sem `--upload`: comportamento existente (stdout XML) — zero breaking change.
+
+**`parse-all`** — novo comando batch:
+- `--start-coddoc / --end-coddoc / --ente / --fonte / --model / --upload/--no-upload / --limit`.
+- Itera `leizilla-raw-{ente}-{fonte}-coddoc-{N:05d}` no range; skip silencioso se OCR ausente.
+- Conta falhas de parse sem abortar; relatório final: "Batch concluído: N parseados, N falhos[, N uploaded]".
+- Default `--upload` (True) para uso batch; `--no-upload` para dry-run.
+
+**Decisões**:
+- `parse-all` usa range coddoc (não query DuckDB) porque `scraper.scrape_one()` não
+  insere `ia_id_raw` no DuckDB, e o schema atual não tem essa coluna. Range coddoc
+  é o mesmo mecanismo que o `scrape` CLI usa — consistente e sem dependência nova.
+  Limitação documentada: gaps no range (coddocs sem raw item) resultam em "OCR indisponível
+  — skip" sem erro, o que é comportamento correto para um range parcialmente populado.
+- `_xsd_gate` é fail-open por design: xmllint não é dependência hard; CI/CD pode não
+  ter xmllint instalado e o pipeline deve continuar. Aviso no stderr é suficiente.
+- 15 testes em `tests/test_cli_parse.py` cobrem todos os branches de `_xsd_gate`,
+  `parse --upload`, e `parse-all` (skip OCR, limit, no-upload, failure counting).
 
 ### 2026-05-22 — M3.1: OCR fetch + LLM parse → Leizilla XML
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -107,10 +107,14 @@ o pipeline Etapa 2 end-to-end: OCR fetch → LLM parse → XSD validate → IA u
   é o mesmo mecanismo que o `scrape` CLI usa — consistente e sem dependência nova.
   Limitação documentada: gaps no range (coddocs sem raw item) resultam em "OCR indisponível
   — skip" sem erro, o que é comportamento correto para um range parcialmente populado.
-- `_xsd_gate` é fail-open por design: xmllint não é dependência hard; CI/CD pode não
-  ter xmllint instalado e o pipeline deve continuar. Aviso no stderr é suficiente.
-- 15 testes em `tests/test_cli_parse.py` cobrem todos os branches de `_xsd_gate`,
-  `parse --upload`, e `parse-all` (skip OCR, limit, no-upload, failure counting).
+- `_xsd_gate` é fail-open apenas para ferramentas ausentes: `xmllint` não instalado
+  ou schema não encontrado → retorna True (pipeline continua). Quando `xmllint`
+  está presente e encontra erros → retorna False e o upload é **bloqueado** (exit 1 em
+  `parse --upload`; skip + contagem de erro em `parse-all`). Distinção importante:
+  fail-open é para falta de ferramental, não para XML inválido detectado.
+- `parse-all` exit 1 se qualquer upload falhou (seja por XSD inválido ou por falha de rede/IA).
+  Falhas de parse (LLM confiança baixa) não propagam exit 1 — são esperadas em batches parciais.
+- 18 testes em `tests/test_cli_parse.py` cobrem todos os branches.
 
 ### 2026-05-22 — M3.1: OCR fetch + LLM parse → Leizilla XML
 

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -355,7 +355,8 @@ def cmd_parse(
 
         if upload:
             if not _xsd_gate(result.xml):
-                echo("XSD inválido — upload prosseguindo (fail-open)")
+                echo("XSD inválido — upload bloqueado")
+                raise typer.Exit(1)
             from leizilla.publisher import InternetArchivePublisher
 
             pub = InternetArchivePublisher()
@@ -405,6 +406,7 @@ def cmd_parse_all(
         parsed_ok = 0
         parsed_fail = 0
         uploaded_ok = 0
+        upload_fail = 0
 
         for coddoc in coddocs:
             raw_id = f"leizilla-raw-{ente}-{fonte}-coddoc-{coddoc:05d}"
@@ -428,22 +430,28 @@ def cmd_parse_all(
 
             if pub:
                 if not _xsd_gate(result.xml, warn_prefix="  "):
-                    echo("  upload prosseguindo apesar de XSD inválido (fail-open)")
-                upload_result = pub.upload_parsed(
-                    result.ia_id_parsed, result.xml, result.parsed_meta
-                )
-                if upload_result["success"]:
-                    echo(f"  ↑ {upload_result['ia_url']}")
-                    uploaded_ok += 1
+                    echo("  XSD inválido — skip upload")
+                    upload_fail += 1
                 else:
-                    echo(
-                        f"  Upload falhou: {upload_result.get('error', 'erro desconhecido')}"
+                    upload_result = pub.upload_parsed(
+                        result.ia_id_parsed, result.xml, result.parsed_meta
                     )
+                    if upload_result["success"]:
+                        echo(f"  ↑ {upload_result['ia_url']}")
+                        uploaded_ok += 1
+                    else:
+                        echo(
+                            f"  Upload falhou: {upload_result.get('error', 'erro desconhecido')}"
+                        )
+                        upload_fail += 1
 
         echo(
             f"\nBatch concluído: {parsed_ok} parseados, {parsed_fail} falhos"
             + (f", {uploaded_ok} uploaded" if upload else "")
+            + (f", {upload_fail} erros de upload" if upload and upload_fail else "")
         )
+        if upload_fail > 0:
+            raise typer.Exit(1)
     except typer.Exit:
         raise
     except RuntimeError as e:

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -401,7 +401,7 @@ def cmd_parse_all(
         pub = InternetArchivePublisher() if upload else None
         coddocs = range(start_coddoc, end_coddoc + 1)
         if limit is not None:
-            coddocs = list(coddocs)[:limit]
+            coddocs = coddocs[:limit]
 
         parsed_ok = 0
         parsed_fail = 0

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -286,11 +287,15 @@ def _xsd_gate(xml_content: str, warn_prefix: str = "") -> bool:
     if not schema.exists():
         echo(f"{warn_prefix}XSD schema não encontrado — skip validação")
         return True
-    tmp = Path(schema.parent) / "_xsd_gate_tmp.xml"
+    tmp_path: Optional[Path] = None
     try:
-        tmp.write_text(xml_content, encoding="utf-8")
+        with tempfile.NamedTemporaryFile(
+            suffix=".xml", mode="w", encoding="utf-8", delete=False
+        ) as tmp:
+            tmp.write(xml_content)
+            tmp_path = Path(tmp.name)
         result = subprocess.run(
-            ["xmllint", "--schema", str(schema), "--noout", str(tmp)],
+            ["xmllint", "--schema", str(schema), "--noout", str(tmp_path)],
             capture_output=True,
             text=True,
         )
@@ -302,7 +307,8 @@ def _xsd_gate(xml_content: str, warn_prefix: str = "") -> bool:
         echo(f"{warn_prefix}xmllint não disponível — skip validação XSD")
         return True
     finally:
-        tmp.unlink(missing_ok=True)
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
 
 
 @app.command("parse")
@@ -348,7 +354,8 @@ def cmd_parse(
             echo(result.xml)
 
         if upload:
-            _xsd_gate(result.xml)
+            if not _xsd_gate(result.xml):
+                echo("XSD inválido — upload prosseguindo (fail-open)")
             from leizilla.publisher import InternetArchivePublisher
 
             pub = InternetArchivePublisher()
@@ -420,7 +427,8 @@ def cmd_parse_all(
             parsed_ok += 1
 
             if pub:
-                _xsd_gate(result.xml, warn_prefix="  ")
+                if not _xsd_gate(result.xml, warn_prefix="  "):
+                    echo("  upload prosseguindo apesar de XSD inválido (fail-open)")
                 upload_result = pub.upload_parsed(
                     result.ia_id_parsed, result.xml, result.parsed_meta
                 )

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -412,14 +412,19 @@ def cmd_parse_all(
             raw_id = f"leizilla-raw-{ente}-{fonte}-coddoc-{coddoc:05d}"
             echo(f"[{coddoc}] {raw_id}")
 
-            ocr = fetch_ocr(raw_id)
-            if not ocr:
-                echo("  OCR indisponível — skip")
-                continue
+            try:
+                ocr = fetch_ocr(raw_id)
+                if not ocr:
+                    echo("  OCR indisponível — skip")
+                    continue
 
-            result = parse_law(ocr, raw_id, ente, model=model)
-            if not result:
-                echo("  Parse falhou — skip")
+                result = parse_law(ocr, raw_id, ente, model=model)
+                if not result:
+                    echo("  Parse falhou — skip")
+                    parsed_fail += 1
+                    continue
+            except Exception as item_exc:
+                echo(f"  Erro inesperado: {item_exc} — skip")
                 parsed_fail += 1
                 continue
 

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -280,6 +280,31 @@ def cmd_stats() -> None:
         raise typer.Exit(1)
 
 
+def _xsd_gate(xml_content: str, warn_prefix: str = "") -> bool:
+    """Valida XML contra leizilla-v0.1.xsd via xmllint. Fail-open: só avisa, não aborta."""
+    schema = Path(__file__).parents[2] / "docs" / "schemas" / "leizilla-v0.1.xsd"
+    if not schema.exists():
+        echo(f"{warn_prefix}XSD schema não encontrado — skip validação")
+        return True
+    tmp = Path(schema.parent) / "_xsd_gate_tmp.xml"
+    try:
+        tmp.write_text(xml_content, encoding="utf-8")
+        result = subprocess.run(
+            ["xmllint", "--schema", str(schema), "--noout", str(tmp)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            echo(f"{warn_prefix}XSD aviso: {result.stderr.strip()}")
+            return False
+        return True
+    except FileNotFoundError:
+        echo(f"{warn_prefix}xmllint não disponível — skip validação XSD")
+        return True
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
 @app.command("parse")
 def cmd_parse(
     raw_id: str = typer.Option(..., help="IA raw item ID (leizilla-raw-...)"),
@@ -288,6 +313,7 @@ def cmd_parse(
     output: Optional[Path] = typer.Option(
         None, help="Salvar XML em arquivo (default: stdout)"
     ),
+    upload: bool = typer.Option(False, "--upload/--no-upload", help="Upload para IA após parse"),
 ) -> None:
     """Parsear OCR de raw IA item → Leizilla XML via LLM (Etapa 2)."""
     try:
@@ -318,8 +344,98 @@ def cmd_parse(
         if output:
             output.write_text(result.xml, encoding="utf-8")
             echo(f"XML salvo em {output}")
-        else:
+        elif not upload:
             echo(result.xml)
+
+        if upload:
+            _xsd_gate(result.xml)
+            from leizilla.publisher import InternetArchivePublisher
+
+            pub = InternetArchivePublisher()
+            upload_result = pub.upload_parsed(
+                result.ia_id_parsed, result.xml, result.parsed_meta
+            )
+            if upload_result["success"]:
+                echo(f"Uploaded: {upload_result['ia_url']}")
+            else:
+                echo(f"Upload falhou: {upload_result.get('error', 'erro desconhecido')}")
+                raise typer.Exit(1)
+    except typer.Exit:
+        raise
+    except RuntimeError as e:
+        echo(f"Erro de configuração: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        echo(f"Erro: {e}")
+        raise typer.Exit(1)
+
+
+@app.command("parse-all")
+def cmd_parse_all(
+    ente: str = typer.Option("ro", help="Ente federativo"),
+    fonte: str = typer.Option("assembleia", help="Fonte (assembleia, casacivil, ...)"),
+    start_coddoc: int = typer.Option(1, help="Primeiro coddoc"),
+    end_coddoc: int = typer.Option(100, help="Último coddoc"),
+    model: str = typer.Option("claude-haiku-4-5", help="Claude model para parse"),
+    upload: bool = typer.Option(True, "--upload/--no-upload", help="Upload para IA após parse"),
+    limit: Optional[int] = typer.Option(None, help="Máx de itens a processar"),
+) -> None:
+    """Batch parse: coddoc range → OCR → LLM → (upload para IA).
+
+    Itera leizilla-raw-{ente}-{fonte}-coddoc-NNNNN para cada coddoc no range.
+    Items sem OCR disponível são pulados silenciosamente (IA ainda processando).
+    Items com parse falho são contados como falha mas não abortam o batch.
+    """
+    try:
+        from leizilla.parser import fetch_ocr, parse_law
+        from leizilla.publisher import InternetArchivePublisher
+
+        pub = InternetArchivePublisher() if upload else None
+        coddocs = range(start_coddoc, end_coddoc + 1)
+        if limit is not None:
+            coddocs = list(coddocs)[:limit]
+
+        parsed_ok = 0
+        parsed_fail = 0
+        uploaded_ok = 0
+
+        for coddoc in coddocs:
+            raw_id = f"leizilla-raw-{ente}-{fonte}-coddoc-{coddoc:05d}"
+            echo(f"[{coddoc}] {raw_id}")
+
+            ocr = fetch_ocr(raw_id)
+            if not ocr:
+                echo("  OCR indisponível — skip")
+                continue
+
+            result = parse_law(ocr, raw_id, ente, model=model)
+            if not result:
+                echo("  Parse falhou — skip")
+                parsed_fail += 1
+                continue
+
+            echo(
+                f"  OK confiança={result.confidence:.2f} → {result.ia_id_parsed}"
+            )
+            parsed_ok += 1
+
+            if pub:
+                _xsd_gate(result.xml, warn_prefix="  ")
+                upload_result = pub.upload_parsed(
+                    result.ia_id_parsed, result.xml, result.parsed_meta
+                )
+                if upload_result["success"]:
+                    echo(f"  ↑ {upload_result['ia_url']}")
+                    uploaded_ok += 1
+                else:
+                    echo(
+                        f"  Upload falhou: {upload_result.get('error', 'erro desconhecido')}"
+                    )
+
+        echo(
+            f"\nBatch concluído: {parsed_ok} parseados, {parsed_fail} falhos"
+            + (f", {uploaded_ok} uploaded" if upload else "")
+        )
     except typer.Exit:
         raise
     except RuntimeError as e:

--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -221,6 +221,8 @@ def parse_law(
         "leizilla_meta_version": "0.1",
         "ia_id_raw": ia_id,
         "ia_id_parsed": ia_id_parsed,
+        "ente": ente,
+        "tipo": tipo,
         "parse_method": model,
         "confianca_parse_global": confidence,
         "parse_timestamp": datetime.now(tz=timezone.utc).isoformat(),

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -40,22 +40,16 @@ class TestXsdGate:
                 result = _xsd_gate("<lei/>")
         assert result is True
 
-    def test_returns_true_on_xmllint_success(self, tmp_path):
-        schema = tmp_path / "leizilla-v0.1.xsd"
-        schema.write_text("<xs:schema/>")
+    def test_returns_true_on_xmllint_success(self):
         with patch("subprocess.run") as mock_run, \
-             patch.object(Path, "exists", return_value=True), \
-             patch.object(Path, "write_text"), \
-             patch.object(Path, "unlink"):
+             patch.object(Path, "exists", return_value=True):
             mock_run.return_value = MagicMock(returncode=0, stderr="")
             result = _xsd_gate("<lei/>")
         assert result is True
 
-    def test_returns_false_on_xmllint_failure(self, tmp_path):
+    def test_returns_false_on_xmllint_failure(self):
         with patch("subprocess.run") as mock_run, \
-             patch.object(Path, "exists", return_value=True), \
-             patch.object(Path, "write_text"), \
-             patch.object(Path, "unlink"):
+             patch.object(Path, "exists", return_value=True):
             mock_run.return_value = MagicMock(returncode=1, stderr="validation error")
             result = _xsd_gate("<bad/>")
         assert result is False

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -218,6 +218,25 @@ class TestCmdParseAll:
         mock_upload.assert_not_called()
 
 
+    def test_api_exception_per_item_counted_not_abort(self):
+        """Exceção da API (timeout, rate-limit) em um item conta como falha sem abortar o batch."""
+        call_count = {"n": 0}
+
+        def flaky_parse(*args, **kwargs):
+            call_count["n"] += 1
+            raise ConnectionError("API timeout")
+
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr"), \
+             patch("leizilla.parser.parse_law", side_effect=flaky_parse):
+            result = runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "3", "--no-upload"],
+            )
+        assert result.exit_code == 0
+        assert "3 falhos" in result.output
+        assert call_count["n"] == 3  # todos os itens tentados
+
+
 class TestCmdParseXsdGateBlocking:
     def test_parse_upload_blocked_when_xsd_fails(self):
         with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -1,0 +1,199 @@
+"""Testes para cmd_parse --upload, cmd_parse_all, e _xsd_gate."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from leizilla.cli import app, _xsd_gate
+
+runner = CliRunner()
+
+_PARSE_RESULT = MagicMock(
+    xml="<lei/>",
+    parsed_meta={"ente": "ro", "tipo": "lei"},
+    confidence=0.9,
+    ia_id_parsed="leizilla-ro-lei-00042-1990",
+    input_tokens=100,
+    output_tokens=200,
+)
+
+_UPLOAD_OK = {"success": True, "ia_id": "leizilla-ro-lei-00042-1990", "ia_url": "https://archive.org/details/leizilla-ro-lei-00042-1990"}
+_UPLOAD_FAIL = {"success": False, "error": "network error", "ia_id": "leizilla-ro-lei-00042-1990"}
+
+
+class TestXsdGate:
+    def test_returns_true_when_schema_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "leizilla.cli.Path",
+            lambda *a, **kw: tmp_path / "nonexistent_schema.xsd",
+        )
+        assert _xsd_gate("<lei/>") is True
+
+    def test_returns_true_when_xmllint_not_found(self, tmp_path):
+        schema = tmp_path / "leizilla-v0.1.xsd"
+        schema.write_text("<xs:schema/>")
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with patch("leizilla.cli.Path") as mock_path:
+                mock_path.return_value.__truediv__ = MagicMock(return_value=schema)
+                mock_path.return_value.parents = [None, None, tmp_path]
+                result = _xsd_gate("<lei/>")
+        assert result is True
+
+    def test_returns_true_on_xmllint_success(self, tmp_path):
+        schema = tmp_path / "leizilla-v0.1.xsd"
+        schema.write_text("<xs:schema/>")
+        with patch("subprocess.run") as mock_run, \
+             patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "write_text"), \
+             patch.object(Path, "unlink"):
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            result = _xsd_gate("<lei/>")
+        assert result is True
+
+    def test_returns_false_on_xmllint_failure(self, tmp_path):
+        with patch("subprocess.run") as mock_run, \
+             patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "write_text"), \
+             patch.object(Path, "unlink"):
+            mock_run.return_value = MagicMock(returncode=1, stderr="validation error")
+            result = _xsd_gate("<bad/>")
+        assert result is False
+
+
+class TestCmdParseUpload:
+    def _mock_parse(self, ocr_return="OCR text", parse_return=_PARSE_RESULT):
+        return {
+            "leizilla.cli.fetch_ocr": ocr_return,
+            "leizilla.cli.parse_law": parse_return,
+        }
+
+    def test_parse_without_upload_outputs_xml(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT):
+            result = runner.invoke(
+                app, ["parse", "--raw-id", "leizilla-raw-ro-assembleia-coddoc-00042"]
+            )
+        assert result.exit_code == 0
+        assert "<lei/>" in result.output
+
+    def test_upload_flag_calls_upload_parsed(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed", return_value=_UPLOAD_OK), \
+             patch("leizilla.cli._xsd_gate", return_value=True):
+            result = runner.invoke(
+                app,
+                ["parse", "--raw-id", "leizilla-raw-ro-assembleia-coddoc-00042", "--upload"],
+            )
+        assert result.exit_code == 0
+        assert "Uploaded" in result.output
+        assert "archive.org" in result.output
+
+    def test_upload_flag_exits_1_on_upload_failure(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed", return_value=_UPLOAD_FAIL), \
+             patch("leizilla.cli._xsd_gate", return_value=True):
+            result = runner.invoke(
+                app,
+                ["parse", "--raw-id", "leizilla-raw-ro-assembleia-coddoc-00042", "--upload"],
+            )
+        assert result.exit_code == 1
+        assert "Upload falhou" in result.output
+
+    def test_no_upload_without_flag(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed") as mock_upload:
+            runner.invoke(
+                app, ["parse", "--raw-id", "leizilla-raw-ro-assembleia-coddoc-00042"]
+            )
+        mock_upload.assert_not_called()
+
+    def test_exits_1_on_missing_ocr(self):
+        with patch("leizilla.parser.fetch_ocr", return_value=None):
+            result = runner.invoke(
+                app, ["parse", "--raw-id", "leizilla-raw-ro-assembleia-coddoc-99999"]
+            )
+        assert result.exit_code == 1
+        assert "OCR não disponível" in result.output
+
+    def test_exits_1_on_parse_failure(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr"), \
+             patch("leizilla.parser.parse_law", return_value=None):
+            result = runner.invoke(
+                app, ["parse", "--raw-id", "leizilla-raw-ro-assembleia-coddoc-00001"]
+            )
+        assert result.exit_code == 1
+        assert "Parse falhou" in result.output
+
+
+class TestCmdParseAll:
+    def test_processes_range_and_reports_summary(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed", return_value=_UPLOAD_OK), \
+             patch("leizilla.cli._xsd_gate", return_value=True):
+            result = runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "3", "--ente", "ro"],
+            )
+        assert result.exit_code == 0
+        assert "parseados" in result.output
+
+    def test_skips_items_without_ocr(self):
+        call_count = {"n": 0}
+
+        def ocr_side_effect(raw_id: str) -> str | None:
+            call_count["n"] += 1
+            return None  # all items missing OCR
+
+        with patch("leizilla.parser.fetch_ocr", side_effect=ocr_side_effect), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed") as mock_upload:
+            result = runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "5"],
+            )
+        mock_upload.assert_not_called()
+        assert "0 parseados" in result.output
+
+    def test_limit_parameter(self):
+        fetched: list[str] = []
+
+        def track_ocr(raw_id: str) -> str | None:
+            fetched.append(raw_id)
+            return "ocr"
+
+        with patch("leizilla.parser.fetch_ocr", side_effect=track_ocr), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed", return_value=_UPLOAD_OK), \
+             patch("leizilla.cli._xsd_gate", return_value=True):
+            runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "100", "--limit", "3"],
+            )
+        assert len(fetched) == 3
+
+    def test_no_upload_with_no_upload_flag(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed") as mock_upload:
+            runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "2", "--no-upload"],
+            )
+        mock_upload.assert_not_called()
+
+    def test_counts_parse_failures_without_abort(self):
+        def flaky_parse(*args, **kwargs):
+            return None  # always fails
+
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr"), \
+             patch("leizilla.parser.parse_law", side_effect=flaky_parse):
+            result = runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "3", "--no-upload"],
+            )
+        assert result.exit_code == 0
+        assert "3 falhos" in result.output

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -191,3 +191,43 @@ class TestCmdParseAll:
             )
         assert result.exit_code == 0
         assert "3 falhos" in result.output
+
+    def test_exits_1_on_upload_failure(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed", return_value=_UPLOAD_FAIL), \
+             patch("leizilla.cli._xsd_gate", return_value=True):
+            result = runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "2", "--ente", "ro"],
+            )
+        assert result.exit_code == 1
+        assert "erros de upload" in result.output
+
+    def test_exits_1_when_xsd_gate_blocks_upload(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed") as mock_upload, \
+             patch("leizilla.cli._xsd_gate", return_value=False):
+            result = runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "2", "--ente", "ro"],
+            )
+        assert result.exit_code == 1
+        assert "XSD inválido" in result.output
+        mock_upload.assert_not_called()
+
+
+class TestCmdParseXsdGateBlocking:
+    def test_parse_upload_blocked_when_xsd_fails(self):
+        with patch("leizilla.parser.fetch_ocr", return_value="ocr text"), \
+             patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT), \
+             patch("leizilla.publisher.InternetArchivePublisher.upload_parsed") as mock_upload, \
+             patch("leizilla.cli._xsd_gate", return_value=False):
+            result = runner.invoke(
+                app,
+                ["parse", "--raw-id", "leizilla-raw-ro-assembleia-coddoc-00042", "--upload"],
+            )
+        assert result.exit_code == 1
+        assert "XSD inválido" in result.output
+        mock_upload.assert_not_called()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -141,6 +141,8 @@ class TestParseLaw:
         assert meta["leizilla_meta_version"] == "0.1"
         assert meta["ia_id_raw"] == _IA_ID
         assert meta["ia_id_parsed"] == "leizilla-ro-lei-09999-1999"
+        assert meta["ente"] == "ro"
+        assert meta["tipo"] == "lei"
         assert meta["parse_method"] == parser._HAIKU
         assert meta["tem_divergencia"] is False
         assert "parse_timestamp" in meta


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`_xsd_gate(xml_content)`**: valida XML contra `leizilla-v0.1.xsd` via `xmllint`; fail-open se schema ausente ou `xmllint` não instalado; retorna `False` + aviso se validação falha
- **`parse --upload/--no-upload`**: com `--upload` chama `_xsd_gate` depois `InternetArchivePublisher.upload_parsed()`; exit code 1 em falha de upload; `--no-upload` mantém comportamento existente (stdout XML) — zero breaking change
- **`parse-all`**: batch sobre range de coddocs; skip silencioso quando OCR ausente; conta falhas de parse sem abortar; relatório final "Batch concluído: N parseados, N falhos[, N uploaded]"; usa range coddoc (não DuckDB) por consistência com o `scrape` CLI
- **15 testes** em `tests/test_cli_parse.py` cobrindo todos os branches dos 3 itens acima
- **IMPLEMENTATION.md**: M3.1 + M3.2 → 🟢 done; M3 restante → 🟡 in-progress; decision log com justificativa do range coddoc

Completa o pipeline Etapa 2 end-to-end: OCR fetch → LLM parse → XSD validate → IA upload.

## Test plan

- [ ] `uv run pytest tests/test_cli_parse.py -v` — 15 testes passam
- [ ] `uv run pytest --tb=short -q` — 190 passed, 12 skipped
- [ ] `uv run ruff check src/leizilla/cli.py tests/test_cli_parse.py` — sem erros
- [ ] Revisar `_xsd_gate` fail-open: schema ausente → True, xmllint ausente → True, xmllint falha → False
- [ ] Revisar `parse-all` com `--no-upload` não chama `upload_parsed`
- [ ] Revisar que `parse` sem `--upload` continua outputando XML para stdout

## Notas de revisão

`parse-all` usa range coddoc (não query DuckDB) porque `scraper.scrape_one()` não insere `ia_id_raw` no DuckDB e o schema atual não tem essa coluna. Gaps no range resultam em "OCR indisponível — skip" (comportamento correto para range parcialmente populado). Ver decision log em IMPLEMENTATION.md para detalhes.

https://claude.ai/code/session_015H479L7io8DuvzYKvc9pZg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015H479L7io8DuvzYKvc9pZg)_