### PR TITLE
refactor(M2.4): rate-limit por host em vez de global

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -19,7 +19,7 @@
 | **M3.1** — OCR fetch + LLM parse → parser.py | 🟢 done | #17 | `parser.fetch_ocr` + `parse_law` (Haiku, fail-closed: confidence/tipo/numero/ano obrigatórios). 27 testes. |
 | **M3.2** — publisher.upload_parsed() | 🟢 done | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. |
 | **M3 restante** — `parse --upload` + XSD gate + `parse-all` batch | 🟢 done | #21 | CLI integra parser→publisher; `_xsd_gate` via xmllint (bloqueia upload quando inválido); `parse-all` itera range coddoc. 15 testes. |
-| **M2.4** — Rate-limit por host | 🟢 done | #23 | `make_rate_limiter` por `hostname`: scraping paralelo de múltiplas fontes sem serializar. 12 testes. |
+| **M2.4** — Rate-limit por host | 🟢 done | #25 | `make_rate_limiter` por `hostname`: scraping paralelo de múltiplas fontes sem serializar. 12 testes. |
 | M2 restante — casacivil discovery + outros entes | ⚪ todo | — | casacivil.ro.gov.br (padrão de URL a auditar); fontes/{sp,federal}.py. |
 | M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -18,8 +18,9 @@
 | **M2.3** — CI workflow + `internetarchive` dep | 🟢 done | #20 | `rondonia_crawler.yml` atualizado para `uv run leizilla scrape`. `internetarchive` em pyproject.toml. |
 | **M3.1** — OCR fetch + LLM parse → parser.py | 🟢 done | #17 | `parser.fetch_ocr` + `parse_law` (Haiku, fail-closed: confidence/tipo/numero/ano obrigatórios). 27 testes. |
 | **M3.2** — publisher.upload_parsed() | 🟢 done | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. |
-| **M3 restante** — `parse --upload` + XSD gate + `parse-all` batch | 🟡 in-progress | TBD | CLI `parse --upload` integra parser→publisher; `_xsd_gate` via xmllint; `parse-all` itera range coddoc. 15 testes. |
-| M2 restante — casacivil discovery + outros entes | ⚪ todo | — | casacivil.ro.gov.br (padrão de URL a auditar); fontes/{sp,federal}.py. Rate-limit por host. |
+| **M3 restante** — `parse --upload` + XSD gate + `parse-all` batch | 🟢 done | #21 | CLI integra parser→publisher; `_xsd_gate` via xmllint (bloqueia upload quando inválido); `parse-all` itera range coddoc. 15 testes. |
+| **M2.4** — Rate-limit por host | 🟢 done | #23 | `make_rate_limiter` por `hostname`: scraping paralelo de múltiplas fontes sem serializar. 12 testes. |
+| M2 restante — casacivil discovery + outros entes | ⚪ todo | — | casacivil.ro.gov.br (padrão de URL a auditar); fontes/{sp,federal}.py. |
 | M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |
 | M6 — GitHub Actions | ⚪ todo | — | Depende de M2–M5 |
@@ -79,6 +80,24 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
 
+### 2026-05-22 — M2.4: Rate-limit por host (supersede M2.2 global limiter)
+
+`make_rate_limiter()` agora retorna `Callable[[str], None]` (recebe URL) em vez de
+`Callable[[], None]`. Closure mantém `Dict[str, float]` com `last[host]` por `urlparse(url).hostname` (normalizado, sem port ou credenciais no key).
+
+**Por que**: M2 restante inclui casacivil + assembleia scraping em paralelo. Rate-limit
+global serializaria as duas fontes mesmo quando são hosts distintos — cada fonte
+ficaria esperando o cooldown da outra. Com tracking por host, `al.ro.leg.br` e
+`casacivil.ro.gov.br` têm buckets independentes.
+
+**Interface**: `scrape_one(..., rate_limiter)` agora passa `pdf_url` para o limiter
+(era chamada sem args). Callers existentes que usam `make_rate_limiter()` recebem o
+comportamento correto automaticamente — a CLI cria o limiter e passa para `scrape_one`.
+
+**Sem breaking change real**: nenhum código externo chamava `limiter()` diretamente
+(era criado e passado como opaque callable). Testes atualizados para verificar que
+`rate_mock` é chamado com `_PDF_URL`.
+
 ### 2026-05-22 — M3 restante: `parse --upload` + XSD gate + `parse-all` batch
 
 Integra M3.1 (`parser.py`) e M3.2 (`publisher.upload_parsed`) via CLI, completando
@@ -114,7 +133,7 @@ o pipeline Etapa 2 end-to-end: OCR fetch → LLM parse → XSD validate → IA u
   fail-open é para falta de ferramental, não para XML inválido detectado.
 - `parse-all` exit 1 se qualquer upload falhou (seja por XSD inválido ou por falha de rede/IA).
   Falhas de parse (LLM confiança baixa) não propagam exit 1 — são esperadas em batches parciais.
-- 18 testes em `tests/test_cli_parse.py` cobrem todos os branches.
+- 15 testes em `tests/test_cli_parse.py` cobrem todos os branches.
 
 ### 2026-05-22 — M3.1: OCR fetch + LLM parse → Leizilla XML
 

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -2,13 +2,14 @@
 
 Princípio #9: Wayback como caminho primário; fallback direto se Wayback falhar.
 Princípio #10: robots.txt é permanente (sem retry em URL bloqueada); rate-limit
-               em fallback direto.
+               em fallback direto, por host (não global).
 """
 
 import tempfile
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
+from urllib.parse import urlparse
 
 from leizilla import robots, wayback
 from leizilla.publisher import InternetArchivePublisher
@@ -21,12 +22,13 @@ def scrape_one(
     pdf_url: str,
     lei_data: Dict[str, Any],
     publisher: InternetArchivePublisher,
-    rate_limiter: Optional[Callable[[], None]] = None,
+    rate_limiter: Optional[Callable[[str], None]] = None,
 ) -> Dict[str, Any]:
     """Scrape um PDF: robots check → wayback save → fetch → upload_raw.
 
     Retorna dict com 'success' + ('ia_id', 'ia_url') ou ('reason') em falha.
     Robots bloqueado é permanente — caller NÃO deve re-tentar a mesma URL.
+    rate_limiter recebe a URL do fallback para tracking por host.
     """
     if not robots.is_allowed(fonte_url):
         return {"success": False, "reason": "robots-blocked", "url": fonte_url}
@@ -55,9 +57,9 @@ def scrape_one(
         wb_url = None
 
     if pdf_bytes is None:
-        # Fallback direto com rate-limit (princípio #10)
+        # Fallback direto com rate-limit por host (princípio #10)
         if rate_limiter is not None:
-            rate_limiter()
+            rate_limiter(pdf_url)
         pdf_bytes = wayback.fetch_bytes(pdf_url)
         fetched_from = "source-fallback"
         wb_url = None
@@ -83,14 +85,19 @@ def scrape_one(
         tmp_path.unlink(missing_ok=True)
 
 
-def make_rate_limiter(min_interval: float = _RATE_LIMIT_S) -> Callable[[], None]:
-    """Cria rate limiter simples: garante >= min_interval entre chamadas."""
-    last: list[float] = [0.0]
+def make_rate_limiter(min_interval: float = _RATE_LIMIT_S) -> Callable[[str], None]:
+    """Rate limiter por host: garante >= min_interval entre baterias diretas no mesmo host.
 
-    def limiter() -> None:
-        elapsed = time.monotonic() - last[0]
+    Hosts diferentes não bloqueiam uns aos outros — permite scraping paralelo
+    de múltiplas fontes (assembleia + casacivil + ...) sem serializar por fonte.
+    """
+    last: Dict[str, float] = {}
+
+    def limiter(url: str) -> None:
+        host = urlparse(url).netloc
+        elapsed = time.monotonic() - last.get(host, 0.0)
         if elapsed < min_interval:
             time.sleep(min_interval - elapsed)
-        last[0] = time.monotonic()
+        last[host] = time.monotonic()
 
     return limiter

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -94,7 +94,7 @@ def make_rate_limiter(min_interval: float = _RATE_LIMIT_S) -> Callable[[str], No
     last: Dict[str, float] = {}
 
     def limiter(url: str) -> None:
-        host = urlparse(url).netloc
+        host = urlparse(url).hostname or ""
         elapsed = time.monotonic() - last.get(host, 0.0)
         if elapsed < min_interval:
             time.sleep(min_interval - elapsed)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -130,7 +130,7 @@ class TestMakeRateLimiter:
         limiter("https://host-a.gov.br/doc.pdf")
         limiter("https://host-b.gov.br/doc.pdf")  # host diferente — não deve sleep
         elapsed = time.monotonic() - t0
-        assert elapsed < 5.0, f"Hosts distintos serializaram indevidamente ({elapsed:.2f}s)"
+        assert elapsed < 5.0, f"Hosts distintos serializaram indevidamente ({elapsed:.3f}s)"
 
     def test_same_host_respects_interval(self) -> None:
         """Mesmo host é rate-limitado corretamente."""

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -102,11 +102,13 @@ class TestScrapeOne:
     @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
     @patch("leizilla.scraper.wayback.save_page", return_value=False)
     @patch("leizilla.scraper.robots.is_allowed", return_value=True)
-    def test_rate_limiter_called_on_fallback(self, _r: Any, _s: Any, _f: Any, _c: Any) -> None:
+    def test_rate_limiter_called_with_pdf_url_on_fallback(
+        self, _r: Any, _s: Any, _f: Any, _c: Any
+    ) -> None:
         pub = _make_publisher()
         rate_mock = MagicMock()
         scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub, rate_limiter=rate_mock)
-        rate_mock.assert_called_once()
+        rate_mock.assert_called_once_with(_PDF_URL)
 
 
 class TestMakeRateLimiter:
@@ -116,5 +118,27 @@ class TestMakeRateLimiter:
 
     def test_callable_runs_without_error(self) -> None:
         limiter = make_rate_limiter(0.0)
-        limiter()
-        limiter()
+        limiter("https://host-a.gov.br/doc.pdf")
+        limiter("https://host-a.gov.br/doc2.pdf")
+
+    def test_different_hosts_independent(self) -> None:
+        """Hosts distintos não bloqueiam uns aos outros."""
+        import time
+
+        limiter = make_rate_limiter(min_interval=60.0)  # intervalo longo
+        t0 = time.monotonic()
+        limiter("https://host-a.gov.br/doc.pdf")
+        limiter("https://host-b.gov.br/doc.pdf")  # host diferente — não deve sleep
+        elapsed = time.monotonic() - t0
+        assert elapsed < 5.0, f"Hosts distintos serializaram indevidamente ({elapsed:.2f}s)"
+
+    def test_same_host_respects_interval(self) -> None:
+        """Mesmo host é rate-limitado corretamente."""
+        import time
+
+        limiter = make_rate_limiter(min_interval=0.05)
+        t0 = time.monotonic()
+        limiter("https://host-a.gov.br/doc1.pdf")
+        limiter("https://host-a.gov.br/doc2.pdf")  # mesmo host → deve aguardar
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 0.04, f"Rate limit não respeitado ({elapsed:.3f}s)"


### PR DESCRIPTION
## Summary

- `make_rate_limiter()` agora retorna `Callable[[str], None]` (recebe URL) em vez de `Callable[[], None]` — closure mantém `Dict[str, float]` com `last[host]` por `urlparse(url).hostname` (normalizado, sem port/credenciais)
- `scrape_one()` passa `pdf_url` ao rate limiter no fallback direto, para tracking por host
- Sem breaking change real: CLI cria e passa o limiter de forma opaca; nenhum caller chamava `limiter()` diretamente

**Por que agora**: M2 restante inclui casacivil.ro.gov.br + al.ro.leg.br em paralelo. Rate-limit global serializaria fontes distintas — `al.ro.leg.br` esperaria cooldown de `casacivil.ro.gov.br` mesmo sem relação. Com tracking por host, cada fonte tem bucket independente.

## Trade-offs aceitos

- Interface mudou de `Callable[[], None]` para `Callable[[str], None]` — mas limiter nunca foi chamado fora de `scrape_one`, então o impacto é zero na prática
- Rate-limit ainda é por processo (não persistido entre execuções) — aceitável para o pipeline atual

## Test plan

- [x] `uv run pytest tests/test_scraper.py -v` — 12 testes passam (incluindo 2 novos: `test_different_hosts_independent`, `test_same_host_respects_interval`)
- [x] `test_rate_limiter_called_with_pdf_url_on_fallback` verifica que URL é passada ao limiter
- [x] `uv run pytest --tb=short -q` — todos os testes passam
- [x] `test_different_hosts_independent`: dois hosts distintos com intervalo de 60s não serializam (elapsed < 5s)
- [x] `test_same_host_respects_interval`: mesmo host com intervalo 0.05s é respeitado (elapsed >= 0.04s)

## Notas

Substitui #23 (conflito de rebase após merge de #21; nova branch rebased sobre main atual).

https://claude.ai/code/session_01YRYo9uWqmo6x12Bs84S7C7

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRYo9uWqmo6x12Bs84S7C7)_