### PR TITLE
feat(M2.5): casacivil discovery — enumeração direta sem Playwright

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -16,11 +16,14 @@
 | **M2.1** — Wayback client + robots.txt + publisher sidecar | 🟢 done | #15 | `wayback.py` + `robots.py` + `publisher.upload_raw` + PDF renomeado para {ia_id}.pdf. 34 testes. |
 | **M2.2** — scraper.py + `scrape` CLI + fix ids no crawler | 🟢 done | #18 | `scraper.scrape_one()` orquestra robots→wayback→fetch→upload_raw. CLI `scrape` para assembleia/RO. 10 testes. |
 | **M2.3** — CI workflow + `internetarchive` dep | 🟢 done | #20 | `rondonia_crawler.yml` atualizado para `uv run leizilla scrape`. `internetarchive` em pyproject.toml. |
+| **M2.4** — Rate-limit por host | 🟡 in-progress | #25 | `make_rate_limiter` por `hostname`: scraping paralelo de múltiplas fontes sem serializar. 12 testes. |
+| **M2.5** — casacivil discovery | 🟡 in-progress | TBD | `discover_casacivil_laws(tipo, start_num, end_num)` + CLI `scrape --fonte casacivil --tipo lei|lc`. URL: ditel.casacivil.ro.gov.br. 15 testes. |
 | **M3.1** — OCR fetch + LLM parse → parser.py | 🟢 done | #17 | `parser.fetch_ocr` + `parse_law` (Haiku, fail-closed: confidence/tipo/numero/ano obrigatórios). 27 testes. |
 | **M3.2** — publisher.upload_parsed() | 🟢 done | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. |
-| **M3 restante** — `parse --upload` + XSD gate + `parse-all` batch | 🟢 done | #21 | CLI integra parser→publisher; `_xsd_gate` via xmllint; `parse-all` itera range coddoc. |
-| **M2.4** — Rate-limit por host | 🟡 in-progress | #23 | `make_rate_limiter` por host: scraping paralelo de múltiplas fontes sem serializar. 12 testes. |
-| M2 restante — casacivil discovery + outros entes | ⚪ todo | — | casacivil.ro.gov.br (padrão de URL a auditar); fontes/{sp,federal}.py. |
+| **M3 restante** — `parse --upload` + XSD gate + `parse-all` batch | 🟢 done | #21 | CLI integra parser→publisher; `_xsd_gate` via xmllint (bloqueia upload quando inválido); `parse-all` itera range coddoc. 15 testes. |
+| **M2.4** — Rate-limit por host | 🟢 done | 66aa4ac | `make_rate_limiter` por `hostname`: scraping paralelo de múltiplas fontes sem serializar. 12 testes. |
+| **M2.5** — casacivil discovery | 🟡 in-progress | #26 | `discover_casacivil_laws(tipo, start_num, end_num)` + CLI `scrape --fonte casacivil --tipo lei|lc`. URL: ditel.casacivil.ro.gov.br. 15 testes. |
+| M2 restante — outros entes (sp, federal) | ⚪ todo | — | fontes/{sp,federal}.py. Depende de M2.4+M2.5. |
 | M4 — Parquet + release dataset | ⚪ todo | — | Bloqueado por M3 |
 | M5 — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4 |
 | M6 — GitHub Actions | ⚪ todo | — | Depende de M2–M5 |
@@ -80,6 +83,38 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
 
+### 2026-05-22 — M2.5: casacivil discovery via enumeração direta (sem Playwright)
+
+**Auditoria do portal**: `www.casacivil.ro.gov.br/leis` → redireciona para
+`ditel.casacivil.ro.gov.br/COTEL/Livros/listleiord.aspx?ano=YYYY`, que retorna
+403 de ambientes externos. Porém, PDFs individuais são acessíveis diretamente:
+`HEAD http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/L5120.pdf` → 200.
+
+**Padrão de URL descoberto** via Google cache + HEAD requests:
+- Leis ordinárias: `L{N}.pdf` (ex: `L5120.pdf`, `L3830 - COMPILADA.pdf`)
+- Leis complementares: `LC{N}.pdf` (ex: `LC1209 - COMPILADO.pdf`, `LC748.pdf`)
+- A versão `COMPILADA` (texto consolidado vigente) tem sufixo variável — não
+  tentamos enumerar variações; o Wayback Machine frequentemente tem a base `L{N}.pdf`
+  que é suficiente para OCR (compiladas são frequentemente scanned igualmente).
+
+**Decisão de design**: `discover_casacivil_laws` é função standalone (não método
+de `LeisCrawler`), pois não precisa de Playwright. Retorna URLs candidatas sem
+verificar existência — `scrape_one` trata 404/timeout via Wayback fail-open.
+
+**Chave**: `lei-{N:05d}` para ordinária, `lc-{N:05d}` para complementar.
+`IA id`: `leizilla-raw-ro-casacivil-lei-{N:05d}` ou `lc-{N:05d}`.
+
+**CLI**: `scrape --fonte casacivil --tipo lei|lc --start-coddoc N --end-coddoc M`
+(reuso semântico de `--start-coddoc` como "número inicial", sem breaking change
+para assembleia que continua usando coddoc).
+
+**Descobertas notáveis**:
+- Portal DITEL usa ASP.NET WebForms (`listleiord.aspx`) — script da década de 2000.
+- Leis Rondônia chegam a L6000+ (ordinárias); LC chega a ~1300+.
+- Alguns PDFs têm sufixos: `_compressed`, `- PL` (projetos), `- COMPILADA`.
+  Para o pipeline v0 aceitamos o URL base e deixamos Wayback/IA lidar com
+  disponibilidade.
+
 ### 2026-05-22 — M2.4: Rate-limit por host (supersede M2.2 global limiter)
 
 `make_rate_limiter()` agora retorna `Callable[[str], None]` (recebe URL) em vez de
@@ -98,15 +133,39 @@ comportamento correto automaticamente — a CLI cria o limiter e passa para `scr
 (era criado e passado como opaque callable). Testes atualizados para verificar que
 `rate_mock` é chamado com `_PDF_URL`.
 
-### 2026-05-22 — M3 restante: `parse --upload` + XSD gate + `parse-all` batch (merged #21)
+### 2026-05-22 — M3 restante: `parse --upload` + XSD gate + `parse-all` batch
 
 Integra M3.1 (`parser.py`) e M3.2 (`publisher.upload_parsed`) via CLI, completando
 o pipeline Etapa 2 end-to-end: OCR fetch → LLM parse → XSD validate → IA upload.
 
-**`_xsd_gate(xml_content)`**: fail-open para ferramental ausente (xmllint/schema);
-bloqueia upload quando xmllint detecta XML inválido. **`parse --upload`**: integra
-gate + publisher; exit 1 em falha. **`parse-all`**: batch coddoc-range com per-item
-try/except, `parsed_meta` inclui ente/tipo, exit 1 se qualquer upload falhou.
+**`_xsd_gate(xml_content)`** — helper em `cli.py`:
+- Localiza `docs/schemas/leizilla-v0.1.xsd` via `Path(__file__).parents[2]`.
+- Escreve XML em tmp file; roda `xmllint --schema ... --noout`; apaga tmp em `finally`.
+- Fail-open: schema ausente ou `xmllint` não instalado → avisa + retorna True.
+- Retorna False (e printa aviso) se xmllint retorna non-zero (validação falhou).
+
+**`parse --upload/--no-upload`** (default `--no-upload`):
+- Com `--upload`: chama `_xsd_gate`, depois `InternetArchivePublisher().upload_parsed()`.
+- Upload falhou → exit code 1 com mensagem "Upload falhou: {error}".
+- Sem `--upload`: comportamento existente (stdout XML) — zero breaking change.
+
+**`parse-all`** — novo comando batch:
+- `--start-coddoc / --end-coddoc / --ente / --fonte / --model / --upload/--no-upload / --limit`.
+- Itera `leizilla-raw-{ente}-{fonte}-coddoc-{N:05d}` no range; skip silencioso se OCR ausente.
+- Conta falhas de parse sem abortar; relatório final: "Batch concluído: N parseados, N falhos[, N uploaded]".
+- Default `--upload` (True) para uso batch; `--no-upload` para dry-run.
+
+**Decisões**:
+- `parse-all` usa range coddoc (não query DuckDB) porque `scraper.scrape_one()` não
+  insere `ia_id_raw` no DuckDB, e o schema atual não tem essa coluna. Range coddoc
+  é o mesmo mecanismo que o `scrape` CLI usa — consistente e sem dependência nova.
+- `_xsd_gate` é fail-open apenas para ferramentas ausentes: `xmllint` não instalado
+  ou schema não encontrado → retorna True (pipeline continua). Quando `xmllint`
+  está presente e encontra erros → retorna False e o upload é **bloqueado** (exit 1 em
+  `parse --upload`; skip + contagem de erro em `parse-all`).
+- `parse-all` exit 1 se qualquer upload falhou (seja por XSD inválido ou por falha de rede/IA).
+  Falhas de parse (LLM confiança baixa) não propagam exit 1 — são esperadas em batches parciais.
+- 15 testes em `tests/test_cli_parse.py` cobrem todos os branches.
 
 ### 2026-05-22 — M3.1: OCR fetch + LLM parse → Leizilla XML
 

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -134,7 +134,9 @@ def cmd_upload(
                 if not pdf_path.exists():
                     continue
                 pdf_bytes = pdf_path.read_bytes()
-                result = publisher.upload_raw(pdf_path, law, pdf_bytes, fetched_from="source-fallback")
+                result = publisher.upload_raw(
+                    pdf_path, law, pdf_bytes, fetched_from="source-fallback"
+                )
                 if result.get("success"):
                     db.update_lei(law["id"], {"url_pdf_ia": result["ia_url"]})
                     uploaded += 1
@@ -154,14 +156,19 @@ def cmd_upload(
 def cmd_scrape(
     ente: str = typer.Option("ro", help="Ente federativo"),
     fonte: str = typer.Option("assembleia", help="Fonte (assembleia, casacivil)"),
-    start_coddoc: int = typer.Option(1, help="ID inicial"),
+    start_coddoc: int = typer.Option(
+        1, help="ID inicial (coddoc para assembleia; número de lei para casacivil)"
+    ),
     end_coddoc: int = typer.Option(10, help="ID final"),
+    tipo: str = typer.Option(
+        "lei", help="Tipo de lei para casacivil: lei (ordinária) ou lc (complementar)"
+    ),
 ) -> None:
     """Scrape leis: discover → robots → wayback → upload_raw para IA."""
-    echo(f"Scraping {ente}/{fonte} coddoc {start_coddoc}–{end_coddoc}")
+    echo(f"Scraping {ente}/{fonte} {start_coddoc}–{end_coddoc}")
 
     try:
-        from leizilla.crawler import LeisCrawler
+        from leizilla.crawler import LeisCrawler, discover_casacivil_laws
         from leizilla.publisher import InternetArchivePublisher
         from leizilla.scraper import make_rate_limiter, scrape_one
 
@@ -174,6 +181,12 @@ def cmd_scrape(
                 laws = await crawler.discover_rondonia_laws(
                     start_coddoc=start_coddoc,
                     end_coddoc=end_coddoc,
+                )
+            elif ente == "ro" and fonte == "casacivil":
+                laws = discover_casacivil_laws(
+                    tipo=tipo,
+                    start_num=start_coddoc,
+                    end_num=end_coddoc,
                 )
             else:
                 echo(f"Fonte '{fonte}' para '{ente}' ainda não implementada")
@@ -191,7 +204,9 @@ def cmd_scrape(
                     echo(f"  OK: {result.get('ia_id', '?')}")
                     ok += 1
                 else:
-                    echo(f"  Falha [{result.get('reason', '?')}]: {law.get('id', 'N/A')}")
+                    echo(
+                        f"  Falha [{result.get('reason', '?')}]: {law.get('id', 'N/A')}"
+                    )
 
             echo(f"Scraping concluído: {ok}/{len(laws)} com sucesso")
 

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -165,6 +165,10 @@ def cmd_scrape(
     ),
 ) -> None:
     """Scrape leis: discover → robots → wayback → upload_raw para IA."""
+    if tipo != "lei" and fonte != "casacivil":
+        echo(f"--tipo só é válido com --fonte casacivil (recebido: --tipo {tipo} --fonte {fonte})")
+        raise typer.Exit(1)
+
     echo(f"Scraping {ente}/{fonte} {start_coddoc}–{end_coddoc}")
 
     try:

--- a/src/leizilla/crawler.py
+++ b/src/leizilla/crawler.py
@@ -5,13 +5,54 @@ import logging
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 from urllib.parse import urljoin
 
 import requests
 from playwright.async_api import Browser, Page, async_playwright
 
 from leizilla import config
+
+_CASACIVIL_FILES_BASE = "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files"
+_CASACIVIL_FONTE_URL = "http://ditel.casacivil.ro.gov.br/COTEL/Livros/"
+
+
+def discover_casacivil_laws(
+    tipo: str = "lei",
+    start_num: int = 1,
+    end_num: int = 100,
+) -> List[Dict[str, Any]]:
+    """Enumera leis da Casa Civil de Rondônia por número sequencial.
+
+    Não usa Playwright — PDFs disponíveis diretamente via HTTP sem JS.
+    URL pattern: ditel.casacivil.ro.gov.br/COTEL/Livros/Files/{prefix}{N}.pdf
+      tipo="lei" → prefix "L"  (leis ordinárias)
+      tipo="lc"  → prefix "LC" (leis complementares)
+
+    Não verifica existência aqui — scrape_one resolve via Wayback/direct e
+    falha graciosamente se o arquivo não existir.
+    """
+    if tipo not in ("lei", "lc"):
+        raise ValueError(f"tipo deve ser 'lei' ou 'lc', recebeu '{tipo}'")
+
+    prefix = "L" if tipo == "lei" else "LC"
+    nome = "Lei Complementar" if tipo == "lc" else "Lei"
+    laws: List[Dict[str, Any]] = []
+
+    for num in range(start_num, end_num + 1):
+        chave = f"{tipo}-{num:05d}"
+        law: Dict[str, Any] = {
+            "id": f"ro-casacivil-{chave}",
+            "ente": "ro",
+            "fonte": "casacivil",
+            "chave": chave,
+            "titulo": f"{nome} nº {num} (Rondônia)",
+            "url_original": _CASACIVIL_FONTE_URL,
+            "url_pdf_original": f"{_CASACIVIL_FILES_BASE}/{prefix}{num}.pdf",
+        }
+        laws.append(law)
+
+    return laws
 
 
 class LeisCrawler:
@@ -81,7 +122,9 @@ class LeisCrawler:
                     await asyncio.sleep(self.delay_ms / 1000)
 
                 except Exception as exc:
-                    logging.getLogger(__name__).debug("coddoc %d skipped: %s", coddoc, exc)
+                    logging.getLogger(__name__).debug(
+                        "coddoc %d skipped: %s", coddoc, exc
+                    )
                     continue
 
             await browser.close()
@@ -92,7 +135,9 @@ class LeisCrawler:
         """Baixa PDF da URL para destino local. Retorna True em sucesso."""
         for attempt in range(self.retries):
             try:
-                response = requests.get(url, timeout=self.timeout_ms / 1000, stream=True)
+                response = requests.get(
+                    url, timeout=self.timeout_ms / 1000, stream=True
+                )
                 response.raise_for_status()
                 with open(dest, "wb") as f:
                     for chunk in response.iter_content(chunk_size=8192):

--- a/src/leizilla/crawler.py
+++ b/src/leizilla/crawler.py
@@ -35,6 +35,13 @@ def discover_casacivil_laws(
     if tipo not in ("lei", "lc"):
         raise ValueError(f"tipo deve ser 'lei' ou 'lc', recebeu '{tipo}'")
 
+    if start_num > end_num:
+        logging.getLogger(__name__).warning(
+            "discover_casacivil_laws: start_num=%d > end_num=%d — range vazio",
+            start_num,
+            end_num,
+        )
+
     prefix = "L" if tipo == "lei" else "LC"
     nome = "Lei Complementar" if tipo == "lc" else "Lei"
     laws: List[Dict[str, Any]] = []

--- a/tests/test_casacivil_discovery.py
+++ b/tests/test_casacivil_discovery.py
@@ -1,0 +1,86 @@
+"""Testes para discover_casacivil_laws — enumeração sem Playwright."""
+
+import pytest
+
+from leizilla.crawler import (
+    _CASACIVIL_FILES_BASE,
+    _CASACIVIL_FONTE_URL,
+    discover_casacivil_laws,
+)
+
+
+class TestDiscoverCasacivilLaws:
+    def test_lei_url_pattern(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=42, end_num=42)
+        assert laws[0]["url_pdf_original"] == f"{_CASACIVIL_FILES_BASE}/L42.pdf"
+
+    def test_lc_url_pattern(self) -> None:
+        laws = discover_casacivil_laws(tipo="lc", start_num=748, end_num=748)
+        assert laws[0]["url_pdf_original"] == f"{_CASACIVIL_FILES_BASE}/LC748.pdf"
+
+    def test_lei_chave(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=1, end_num=1)
+        assert laws[0]["chave"] == "lei-00001"
+
+    def test_lc_chave(self) -> None:
+        laws = discover_casacivil_laws(tipo="lc", start_num=1, end_num=1)
+        assert laws[0]["chave"] == "lc-00001"
+
+    def test_chave_zero_padded_to_5_digits(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=99, end_num=99)
+        assert laws[0]["chave"] == "lei-00099"
+
+    def test_id_matches_chave(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=5, end_num=5)
+        assert laws[0]["id"] == "ro-casacivil-lei-00005"
+
+    def test_ente_and_fonte(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=1, end_num=1)
+        assert laws[0]["ente"] == "ro"
+        assert laws[0]["fonte"] == "casacivil"
+
+    def test_fonte_url_is_directory(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=1, end_num=1)
+        assert laws[0]["url_original"] == _CASACIVIL_FONTE_URL
+
+    def test_range_length(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=1, end_num=10)
+        assert len(laws) == 10
+
+    def test_range_single(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=5, end_num=5)
+        assert len(laws) == 1
+
+    def test_range_empty_when_start_greater_than_end(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=10, end_num=5)
+        assert laws == []
+
+    def test_invalid_tipo_raises(self) -> None:
+        with pytest.raises(ValueError, match="tipo deve ser"):
+            discover_casacivil_laws(tipo="decreto", start_num=1, end_num=1)
+
+    def test_titulo_lei(self) -> None:
+        laws = discover_casacivil_laws(tipo="lei", start_num=3830, end_num=3830)
+        assert "Lei" in laws[0]["titulo"]
+        assert "3830" in laws[0]["titulo"]
+
+    def test_titulo_lc(self) -> None:
+        laws = discover_casacivil_laws(tipo="lc", start_num=748, end_num=748)
+        assert "Complementar" in laws[0]["titulo"]
+        assert "748" in laws[0]["titulo"]
+
+    def test_no_http_requests_made(self) -> None:
+        """Discovery é puramente local — sem I/O."""
+        import socket
+
+        original_getaddrinfo = socket.getaddrinfo
+
+        def block_dns(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise AssertionError("discover_casacivil_laws fez I/O inesperado")
+
+        socket.getaddrinfo = block_dns
+        try:
+            laws = discover_casacivil_laws(tipo="lei", start_num=1, end_num=5)
+            assert len(laws) == 5
+        finally:
+            socket.getaddrinfo = original_getaddrinfo


### PR DESCRIPTION
## Summary

- **`discover_casacivil_laws(tipo, start_num, end_num)`**: função standalone em `crawler.py` — enumera URLs candidatas para leis da Casa Civil RO sem fazer I/O. URL pattern: `http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/{L|LC}{N}.pdf`. Verificação de existência delegada ao `scrape_one` via Wayback fail-open.
- **CLI `scrape --fonte casacivil`**: nova branch `elif ente == "ro" and fonte == "casacivil"` em `cmd_scrape`. Parâmetro `--tipo lei|lc` para discriminar ordinária vs complementar. Reuso semântico de `--start-coddoc/--end-coddoc` como número de lei — sem breaking change para assembleia.
- **IMPLEMENTATION.md atualizado**: M2.4 → done (66aa4ac); M2.5 → in-progress #27; entradas de decisão técnica para M2.5 e M2.4 adicionadas no log cronológico.
- **15 testes** em `tests/test_casacivil_discovery.py` — incluindo `test_no_http_requests_made` que garante que discovery é puramente local.

## Test plan

- [x] `uv run pytest tests/test_casacivil_discovery.py -v` — 15 testes passam
- [x] `uv run pytest --tb=short -q` — zero regressões
- [x] `test_no_http_requests_made` confirma que discover é O(1) sem I/O
- [x] `test_invalid_tipo_raises` confirma ValueError em tipo inválido

Substitui #26 (conflito de rebase após merge de M2.4 em main; nova branch rebased sobre main atual).

https://claude.ai/code/session_01YRYo9uWqmo6x12Bs84S7C7

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRYo9uWqmo6x12Bs84S7C7)_