### PR TITLE
feat(M3.4): parse_law aceita HTML além de OCR + fetch_html

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -23,6 +23,7 @@
 | **M3.1** — OCR fetch + LLM parse → parser.py | 🟢 done | #17 | `parser.fetch_ocr` + `parse_law` (Haiku, fail-closed: confidence/tipo/numero/ano obrigatórios). 27 testes. |
 | **M3.2** — publisher.upload_parsed() | 🟢 done | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. |
 | **M3.3** — `parse --upload` + XSD gate + `parse-all` batch | 🟢 done | #21 | CLI integra parser→publisher; `_xsd_gate` via xmllint (bloqueia upload quando inválido); `parse-all` itera range coddoc. 15 testes. |
+| **M3.4** — `parse_law` aceita HTML + `fetch_html` | 🟡 in-progress | — | `input_type="html"` em `parse_law`; `fetch_html(url)`; prompt adaptado; `_HTML_CHAR_LIMIT=32000`. Desbloqueia scraping federal (Planalto). 33 testes. |
 | **M4.1** — ETL XML→Parquet (etl.py + consolidate CLI) | 🟡 in-progress | #28 | `xml_to_rows` + `write_parquet` + CLI `consolidate`. 76 testes. Aguardando CI + merge. |
 | **M4.2** — release-dataset CLI + publisher.upload_dataset | 🟡 in-progress | #29 | Sobe dataset Parquet para IA; benchmark local §3.4. Aguardando merge de #28 primeiro. |
 | **M4.3** — benchmark DuckDB-WASM real + gatilhos §3.4 | ⚪ todo | — | Bloqueado por M4.1+M4.2. |
@@ -83,6 +84,33 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-22 — M3.4: parse_law aceita HTML além de OCR
+
+`parse_law` recebe novo parâmetro `input_type: str = "ocr"` (padrão retrocompatível).
+`fetch_html(url)` adicionado — análogo a `fetch_ocr`, mas recebe URL direta em vez de ia_id.
+
+**Por que**: Planalto (fonte canônica federal) serve HTML, não PDF. Pipeline M3 existente
+(`fetch_ocr` → IA `_djvu.txt`) não se aplica a HTML. Solução mínima: aceitar HTML como
+texto de entrada em `parse_law` com prompt ligeiramente diferente e limite de caracteres maior.
+
+**Mudanças em parser.py**:
+- `_SYSTEM_INTRO_OCR` / `_SYSTEM_INTRO_HTML`: constantes de introdução de prompt distintas.
+  HTML version orienta o LLM a ignorar nav, header, footer, scripts — só extrair normativo.
+- `_SYSTEM` usa `{input_intro}` no primeiro parágrafo.
+- `_HTML_CHAR_LIMIT = 32000` (vs `_OCR_CHAR_LIMIT = 8000`): HTML tem overhead de markup;
+  mais caracteres necessários para cobrir o texto normativo completo. Estimativa conservadora
+  para Haiku (200K context window).
+- `parse_method` em `parsed_meta` agora é `f"{model}+{input_type}"` (ex: `claude-haiku-4-5+ocr`
+  ou `claude-haiku-4-5+html`). Breaking change no campo (era só `model`); nenhum consumidor
+  externo ainda — M4.1/4.2 não dependem desse campo.
+
+**Testes**: 33 testes em `tests/test_parser.py`. Adicionados:
+- `TestFetchHtml`: 3 testes (sucesso, erro de rede, user-agent header).
+- `TestParseLaw`: 3 testes HTML (`input_type="html"` — char limit, parse_method, url no user msg).
+
+**Não feito aqui**: integração na CLI `parse` com `--input-type html` fica para próxima sessão
+quando federal scraping for implementado (não há consumidor ainda).
 
 ### 2026-05-22 — M2 restante: fontes SP e federal — stubs com mapeamento de portais
 

--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -24,6 +24,7 @@ _OCR_URL = "https://archive.org/download/{ia_id}/{ia_id}_djvu.txt"
 _USER_AGENT = "leizilla-crawler/0.1"
 _MIN_CONFIDENCE = 0.5
 _OCR_CHAR_LIMIT = 8000
+_HTML_CHAR_LIMIT = 32000  # HTML has markup overhead; more chars needed
 
 # URN local name per ente code (CGPID §5.6)
 _ENTE_URN: Dict[str, str] = {
@@ -35,8 +36,17 @@ _ENTE_URN: Dict[str, str] = {
     "federal": "federal",
 }
 
+_SYSTEM_INTRO_OCR = (
+    "Parse Brazilian law OCR text into a JSON object."
+)
+_SYSTEM_INTRO_HTML = (
+    "Parse Brazilian law HTML page into a JSON object. "
+    "Ignore navigation bars, headers, footers, and script elements; "
+    "extract only the normative text (ementa, artigos, parágrafos, incisos)."
+)
+
 _SYSTEM = """\
-Parse Brazilian law OCR text into a JSON object. Output ONLY valid JSON — no markdown fences, no explanation.
+{input_intro} Output ONLY valid JSON — no markdown fences, no explanation.
 
 Required fields:
 - "xml": complete Leizilla XML v0.1 string (see format below)
@@ -107,6 +117,21 @@ def fetch_ocr(ia_id: str, timeout: int = 30) -> Optional[str]:
         return None
 
 
+def fetch_html(url: str, timeout: int = 30) -> Optional[str]:
+    """Fetch HTML content from an official law portal. Returns None on failure.
+
+    Used for sources like Planalto that publish HTML, not PDF (M3.4).
+    Caller is responsible for rate-limiting and robots.txt (same as fetch_ocr).
+    """
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", _USER_AGENT)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except Exception:
+        return None
+
+
 def _extract_json(text: str) -> Optional[Dict[str, Any]]:
     """Extract JSON from LLM response, handling wrapped or embedded JSON.
 
@@ -148,8 +173,16 @@ def parse_law(
     ia_id: str,
     ente: str,
     model: str = _HAIKU,
+    input_type: str = "ocr",
 ) -> Optional[ParseResult]:
-    """Parse OCR text → Leizilla XML via Claude.
+    """Parse law text → Leizilla XML via Claude.
+
+    Args:
+        ocr_text: Source text — OCR text from IA (_djvu.txt) or raw HTML.
+        ia_id: IA raw item ID (for ocr) or source identifier (for html).
+        ente: Federative entity code (ro, sp, federal, …).
+        model: Claude model ID.
+        input_type: "ocr" (default) or "html". Adjusts prompt and char limit.
 
     Returns None when confidence < _MIN_CONFIDENCE or output is malformed.
     Raises RuntimeError when ANTHROPIC_API_KEY is not configured.
@@ -158,9 +191,20 @@ def parse_law(
     if not api_key:
         raise RuntimeError("ANTHROPIC_API_KEY not configured")
 
+    if input_type == "html":
+        char_limit = _HTML_CHAR_LIMIT
+        input_intro = _SYSTEM_INTRO_HTML
+        user_prefix = f"Parse this law HTML page (ente={ente}, url={ia_id})"
+    else:
+        char_limit = _OCR_CHAR_LIMIT
+        input_intro = _SYSTEM_INTRO_OCR
+        user_prefix = f"Parse this law OCR text (ente={ente}, raw-id={ia_id})"
+
     today = date.today().isoformat()
     ente_name = _ENTE_URN.get(ente, ente)
-    system = _SYSTEM.format(today=today, ia_id=ia_id, ente_name=ente_name)
+    system = _SYSTEM.format(
+        input_intro=input_intro, today=today, ia_id=ia_id, ente_name=ente_name
+    )
 
     client = anthropic.Anthropic(api_key=api_key)
     message = client.messages.create(
@@ -176,10 +220,7 @@ def parse_law(
         messages=[
             {
                 "role": "user",
-                "content": (
-                    f"Parse this law OCR text (ente={ente}, raw-id={ia_id}):\n\n"
-                    f"{ocr_text[:_OCR_CHAR_LIMIT]}"
-                ),
+                "content": f"{user_prefix}:\n\n{ocr_text[:char_limit]}",
             }
         ],
     )
@@ -223,7 +264,7 @@ def parse_law(
         "ia_id_parsed": ia_id_parsed,
         "ente": ente,
         "tipo": tipo,
-        "parse_method": model,
+        "parse_method": f"{model}+{input_type}",
         "confianca_parse_global": confidence,
         "parse_timestamp": datetime.now(tz=timezone.utc).isoformat(),
         "fontes_consultadas": [ia_id],

--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -126,12 +126,12 @@ def fetch_html(url: str, timeout: int = 30) -> Optional[str]:
     urllib raises HTTPError (subclass of URLError) for non-2xx responses,
     so no explicit status-code check is needed.
     """
-    req = urllib.request.Request(url)
-    req.add_header("User-Agent", _USER_AGENT)
     try:
+        req = urllib.request.Request(url)
+        req.add_header("User-Agent", _USER_AGENT)
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.read().decode("utf-8", errors="replace")
-    except (urllib.error.URLError, OSError):
+    except (urllib.error.URLError, OSError, ValueError):
         return None
 
 

--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -9,6 +9,7 @@ Princípio load-bearing #3: Etapa 2 pluggable; model é parâmetro.
 
 import json
 import math
+import urllib.error
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
@@ -122,13 +123,15 @@ def fetch_html(url: str, timeout: int = 30) -> Optional[str]:
 
     Used for sources like Planalto that publish HTML, not PDF (M3.4).
     Caller is responsible for rate-limiting and robots.txt (same as fetch_ocr).
+    urllib raises HTTPError (subclass of URLError) for non-2xx responses,
+    so no explicit status-code check is needed.
     """
     req = urllib.request.Request(url)
     req.add_header("User-Agent", _USER_AGENT)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.read().decode("utf-8", errors="replace")
-    except Exception:
+    except (urllib.error.URLError, OSError):
         return None
 
 
@@ -190,6 +193,9 @@ def parse_law(
     api_key = config.ANTHROPIC_API_KEY
     if not api_key:
         raise RuntimeError("ANTHROPIC_API_KEY not configured")
+
+    if input_type not in ("ocr", "html"):
+        raise ValueError(f"input_type deve ser 'ocr' ou 'html', got {input_type!r}")
 
     if input_type == "html":
         char_limit = _HTML_CHAR_LIMIT

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,6 +98,11 @@ class TestFetchHtml:
         with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
             assert parser.fetch_html("https://example.gov.br/lei/1") is None
 
+    def test_returns_none_on_url_error(self):
+        import urllib.error
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("name not found")):
+            assert parser.fetch_html("https://example.gov.br/lei/1") is None
+
     def test_sets_user_agent_header(self):
         captured_req: list = []
 
@@ -346,3 +351,8 @@ class TestParseLaw:
         _, kwargs = client.messages.create.call_args
         user_content = kwargs["messages"][0]["content"]
         assert url in user_content
+
+    def test_invalid_input_type_raises(self):
+        with patch.object(parser.config, "ANTHROPIC_API_KEY", "test-key"):
+            with pytest.raises(ValueError, match="input_type"):
+                parser.parse_law("content", "id", "ro", input_type="htlm")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -86,6 +86,31 @@ class TestFetchOcr:
         assert captured == [expected]
 
 
+class TestFetchHtml:
+    def test_returns_html_on_success(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_resp("<html>Lei texto</html>"),
+        ):
+            assert parser.fetch_html("https://example.gov.br/lei/1") == "<html>Lei texto</html>"
+
+    def test_returns_none_on_network_error(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            assert parser.fetch_html("https://example.gov.br/lei/1") is None
+
+    def test_sets_user_agent_header(self):
+        captured_req: list = []
+
+        def capture(req, **kw):  # type: ignore[no-untyped-def]
+            captured_req.append(req)
+            raise OSError("stop")
+
+        with patch("urllib.request.urlopen", side_effect=capture):
+            parser.fetch_html("https://example.gov.br/lei/1")
+
+        assert captured_req[0].get_header("User-agent") == parser._USER_AGENT
+
+
 class TestExtractJson:
     def test_direct_json(self):
         result = parser._extract_json('{"a": 1}')
@@ -143,7 +168,7 @@ class TestParseLaw:
         assert meta["ia_id_parsed"] == "leizilla-ro-lei-09999-1999"
         assert meta["ente"] == "ro"
         assert meta["tipo"] == "lei"
-        assert meta["parse_method"] == parser._HAIKU
+        assert meta["parse_method"] == f"{parser._HAIKU}+ocr"
         assert meta["tem_divergencia"] is False
         assert "parse_timestamp" in meta
 
@@ -287,3 +312,37 @@ class TestParseLaw:
         user_content = kwargs["messages"][0]["content"]
         assert len(user_content) < 20000 + 100  # headers + truncated body
         assert "x" * (parser._OCR_CHAR_LIMIT + 1) not in user_content
+
+    def test_html_input_type_uses_html_char_limit(self):
+        long_html = "<p>" + "x" * 40000 + "</p>"
+        client = _make_anthropic_client(_LLM_OK)
+        with patch("anthropic.Anthropic", return_value=client):
+            with patch.object(parser.config, "ANTHROPIC_API_KEY", "test-key"):
+                parser.parse_law(long_html, "https://example.gov.br/lei/1", "federal", input_type="html")
+
+        _, kwargs = client.messages.create.call_args
+        user_content = kwargs["messages"][0]["content"]
+        assert "x" * (parser._HTML_CHAR_LIMIT + 1) not in user_content
+        assert len(user_content) <= parser._HTML_CHAR_LIMIT + 200
+
+    def test_html_input_type_sets_parse_method(self):
+        client = _make_anthropic_client(_LLM_OK)
+        with patch("anthropic.Anthropic", return_value=client):
+            with patch.object(parser.config, "ANTHROPIC_API_KEY", "test-key"):
+                result = parser.parse_law(
+                    "html content", "https://example.gov.br/lei/1", "ro", input_type="html"
+                )
+
+        assert result is not None
+        assert result.parsed_meta["parse_method"] == f"{parser._HAIKU}+html"
+
+    def test_html_input_type_includes_url_in_user_message(self):
+        url = "https://example.gov.br/lei/9999"
+        client = _make_anthropic_client(_LLM_OK)
+        with patch("anthropic.Anthropic", return_value=client):
+            with patch.object(parser.config, "ANTHROPIC_API_KEY", "test-key"):
+                parser.parse_law("html content", url, "ro", input_type="html")
+
+        _, kwargs = client.messages.create.call_args
+        user_content = kwargs["messages"][0]["content"]
+        assert url in user_content

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -103,6 +103,9 @@ class TestFetchHtml:
         with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("name not found")):
             assert parser.fetch_html("https://example.gov.br/lei/1") is None
 
+    def test_returns_none_on_malformed_url(self):
+        assert parser.fetch_html("not-a-url-at-all") is None
+
     def test_sets_user_agent_header(self):
         captured_req: list = []
 


### PR DESCRIPTION
## Summary

- Adiciona `input_type="html"` a `parse_law` (padrão `"ocr"`, retrocompatível — zero breaking change em callers existentes)
- Adiciona `fetch_html(url)` para fontes que servem HTML em vez de PDF (ex: Planalto federal)
- Prompt adaptado: `_SYSTEM_INTRO_HTML` orienta LLM a ignorar nav/header/footer/scripts e extrair só o normativo
- `_HTML_CHAR_LIMIT = 32000` (4× OCR limit) para absorver overhead de markup HTML
- `parse_method` em `parsed_meta` agora é `"{model}+{input_type}"` (ex: `claude-haiku-4-5+html`)

## Motivação

Planalto (fonte canônica federal) serve texto consolidado em HTML, não PDF. O pipeline M3 atual (`fetch_ocr` → IA `_djvu.txt`) não se aplica. Esta PR é o desbloqueador mínimo para implementar scraping federal em M2 restante.

## Test plan

- [ ] `uv run pytest tests/test_parser.py -q` → 33 passed
- [ ] `uv run pytest -q` → 228 passed, 12 skipped
- [ ] `TestFetchHtml`: sucesso, OSError, User-Agent header correto
- [ ] `TestParseLaw` HTML: char limit respeitado, `parse_method` = `haiku+html`, URL no user message

https://claude.ai/code/session_016AKDrxiCj3dFbaRZsHGfTm

---
_Generated by [Claude Code](https://claude.ai/code/session_016AKDrxiCj3dFbaRZsHGfTm)_