### PR TITLE
feat(M3.5): CLI parse --input-type html + fetch_ia_html

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -23,11 +23,14 @@
 | **M3.1** — OCR fetch + LLM parse → parser.py | 🟢 done | #17 | `parser.fetch_ocr` + `parse_law` (Haiku, fail-closed: confidence/tipo/numero/ano obrigatórios). 27 testes. |
 | **M3.2** — publisher.upload_parsed() | 🟢 done | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. |
 | **M3.3** — `parse --upload` + XSD gate + `parse-all` batch | 🟢 done | #21 | CLI integra parser→publisher; `_xsd_gate` via xmllint (bloqueia upload quando inválido); `parse-all` itera range coddoc. 15 testes. |
-| **M3.4** — `parse_law` aceita HTML + `fetch_html` | 🟡 in-progress | — | `input_type="html"` em `parse_law`; `fetch_html(url)`; prompt adaptado; `_HTML_CHAR_LIMIT=32000`. Desbloqueia scraping federal (Planalto). 33 testes. |
-| **M4.1** — ETL XML→Parquet (etl.py + consolidate CLI) | 🟡 in-progress | #28 | `xml_to_rows` + `write_parquet` + CLI `consolidate`. 76 testes. Aguardando CI + merge. |
-| **M4.2** — release-dataset CLI + publisher.upload_dataset | 🟡 in-progress | #29 | Sobe dataset Parquet para IA; benchmark local §3.4. Aguardando merge de #28 primeiro. |
-| **M4.3** — benchmark DuckDB-WASM real + gatilhos §3.4 | ⚪ todo | — | Bloqueado por M4.1+M4.2. |
-| **M5** — Frontend Astro+Svelte+Pico | ⚪ todo | — | Pode rodar em paralelo a M4. |
+| **M3.4** — `parse_law` aceita HTML + `fetch_html` | 🟢 done | cc00676 | `input_type="html"` em `parse_law`; `fetch_html(url)`; prompt adaptado; `_HTML_CHAR_LIMIT=32000`. 35 testes. |
+| **M3.5** — CLI `parse --input-type html` + `fetch_ia_html` | 🟡 in-progress | — | `fetch_ia_html(ia_id)` busca `{ia_id}.html` do IA; `--input-type ocr\|html` em `cmd_parse`; 3 testes novos (TestFetchIaHtml + TestCmdParseUpload). Desbloqueia pipeline federal após M2.7. |
+| **M4.1** — ETL XML→Parquet (etl.py + consolidate CLI) | 🟢 done | #28 | `xml_to_rows` + `write_parquet` + CLI `consolidate`. 76 testes. |
+| **M4.2** — release-dataset CLI + publisher.upload_dataset | 🟡 in-progress | #29 | Sobe dataset Parquet para IA; benchmark local §3.4. CI verde; P2 Codex endereçado (ValueError capturado na CLI). Pronto para merge após CI rerun. |
+| **M4.3** — benchmark DuckDB-WASM real + gatilhos §3.4 | ⚪ todo | — | Bloqueado por M4.2 merge. |
+| **M5.1** — Frontend Astro+Svelte+DuckDB-WASM (foundation) | 🟡 in-progress | #33 | `web/` Astro4+Svelte5+Pico2+DuckDB-WASM1.32. CI verde; P1+P2 Codex endereçados (retry DB init; stale search fix). Pronto para merge após CI rerun. |
+| **M5.2** — TanStack Query + paginação + filtros | ⚪ todo | — | Bloqueado por M5.1 merge. |
+| **M2.7** — Planalto federal HTML pipeline | 🟡 in-progress | #34 | `discover_planalto_laws` + `upload_raw_html` + `scrape_one_html` + CLI `scrape --ente federal`. 24 testes. CI Kilo in_progress. |
 | **M6** — GitHub Actions produção | ⚪ todo | — | Depende de M2–M5. |
 | **M7** — Claude Code routines | ⚪ todo | — | Depende de M6. |
 
@@ -84,6 +87,45 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-22 — M3.5: CLI parse --input-type html + fetch_ia_html
+
+`fetch_ia_html(ia_id)` adicionada em `parser.py` — thin wrapper sobre `fetch_html`
+que constrói `https://archive.org/download/{ia_id}/{ia_id}.html`. Pattern simétrico
+a `fetch_ocr` que usa `{ia_id}_djvu.txt`.
+
+CLI `cmd_parse` recebe `--input-type` (valores: `ocr` | `html`; default: `ocr`).
+- `ocr`: comportamento existente — `fetch_ocr(raw_id)` → `parse_law(..., input_type="ocr")`
+- `html`: `fetch_ia_html(raw_id)` → `parse_law(..., input_type="html")`
+- Valor inválido: exit 1 com mensagem clara (não levanta `ValueError` não capturado).
+
+**Por que agora**: M3.4 (parser.py) já aceitava `input_type="html"` mas a CLI continuava
+hard-coded em `fetch_ocr`. M2.7 (#34) cria IA items com `.html` para Planalto federal.
+Sem esta mudança, `parse` e o pipeline Etapa 2 são inutilizáveis para fontes HTML.
+A M3.4 explicitou o deferimento; agora há consumidor real.
+
+**Não feito aqui**: `parse-all --input-type html` fica para M2.8 — requer também
+ajuste no padrão de chave (federal usa `lei-NNNNN`, não `coddoc-NNNNN`).
+
+**Testes**: 3 novos em `TestFetchIaHtml` (URL correta, sucesso, erro de rede) +
+3 novos em `TestCmdParseUpload` (html path, html 404, input_type inválido). 314 total.
+
+### 2026-05-22 — Triagem de PRs: fixes P1/P2 em #29 e #33
+
+**PR #29 (M4.2) — P2**: `cmd_release_dataset` não capturava `ValueError` de
+`upload_dataset` (ex: `--ente RO` causava traceback não controlado). Fix: `try/except
+ValueError` com mesmo fluxo de erro (`echo + typer.Exit(1)`). Teste
+`test_invalid_ente_exits_nonzero` adicionado a `TestReleaseDatasetCli`.
+
+**PR #33 (M5.1) — P1**: `_initPromise` ficava permanentemente rejected após falha
+transitória de CORS/WASM. Fix: rejection handler limpa `_initPromise = null` para
+permitir retry na próxima chamada.
+
+**PR #33 (M5.1) — P2**: resultados stale quando duas buscas concorrentes resolviam
+fora de ordem. Fix: `searchSeq` incrementa por chamada; updates de state só aplicados
+se o seq local ainda for o mais recente.
+
+**PR #34 (M2.7)**: Kilo in_progress na chegada desta sessão — skip, próxima sessão pega.
 
 ### 2026-05-22 — M3.4: parse_law aceita HTML além de OCR
 
@@ -688,24 +730,23 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 ## Próximos passos imediatos
 
-**M0–M3: todos concluídos** ✅
+**M0–M4.1 concluídos** ✅ | **M3.5, M4.2, M5.1, M2.7 em PRs abertas**
 
 **PRs abertas agora** (em decantação — não auto-merge):
-- **#28** M4.1: ETL XML→Parquet. CI verde. Aguardando review humano.
-- **#29** M4.2: release-dataset CLI. CI verde. Depende do merge de #28 para smoke test end-to-end.
-- **#30** M2 restante: fontes/sp.py + federal.py. CI verde. Aguardando merge.
+- **#29** M4.2: release-dataset CLI. CI verde (pós-fix P2 ValueError). Aguardando CI rerun + review.
+- **#33** M5.1: Frontend foundation. CI verde (pós-fix P1+P2 retry/stale). Aguardando CI rerun + review.
+- **#34** M2.7: Planalto federal HTML pipeline. Kilo in_progress na última sessão.
+- **M3.5** (branch `claude/cool-cerf-qPCfV`): CLI `parse --input-type html` + `fetch_ia_html`. 314 testes passando. PR desta sessão.
 
-**M4.3** (próximo após #28 e #29 mergearem):
-- Benchmark DuckDB-WASM real (não apenas local) contra §3.4 gatilhos.
-- Avisa se file_mb > 50, row_count > 500k, ou full-text latência > 500ms.
+**M4.3** (próximo após #29 mergear):
+- Benchmark DuckDB-WASM real contra §3.4 gatilhos.
+- Avisa se file_mb > 100, row_count > 2M, ou full-text latência > 1s.
 
-**M5 — Frontend** (pode começar em paralelo a M4.3):
-- Astro + Svelte + Pico CSS + DuckDB-WASM.
-- Carrega `versoes.parquet` do IA via HTTP.
-- Busca full-text com DuckDB-WASM no browser.
-- Deploy: GitHub Pages.
+**M5.2** (após #33 mergear):
+- Integrar TanStack Query para cache + prefetch.
+- Paginação de resultados.
+- Filtro por ente/ano.
 
-**M3.4** (desbloqueia federal):
-- Adaptar `parse_law` para aceitar HTML além de OCR text.
-- Planalto serve compilados em HTML — pipeline M3 não se aplica diretamente sem essa adaptação.
-- Documentado em `fontes/federal.py` como bloqueador explícito.
+**M2.8** (após #34 mergear):
+- `parse-all --input-type html --tipo lei|lcp|decreto` para iterar range federal.
+- Requer ajuste no padrão de chave (federal usa `lei-NNNNN`, não `coddoc-NNNNN`).

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -382,21 +382,41 @@ def cmd_parse(
     upload: bool = typer.Option(
         False, "--upload/--no-upload", help="Upload para IA após parse"
     ),
+    input_type: str = typer.Option(
+        "ocr", "--input-type", help="Tipo de entrada do raw item: ocr (PDF via IA) ou html (HTML armazenado no IA)"
+    ),
 ) -> None:
-    """Parsear OCR de raw IA item → Leizilla XML via LLM (Etapa 2)."""
-    try:
-        from leizilla.parser import fetch_ocr, parse_law
+    """Parsear raw IA item → Leizilla XML via LLM (Etapa 2).
 
-        echo(f"Buscando OCR para {raw_id}...")
-        ocr = fetch_ocr(raw_id)
-        if not ocr:
-            echo(
-                f"OCR não disponível para {raw_id} (IA ainda processando ou item inexistente)"
-            )
+    Para fontes PDF (assembleia, casacivil): --input-type ocr (default).
+    Para fontes HTML (federal/planalto após M2.7): --input-type html.
+    """
+    try:
+        from leizilla.parser import fetch_ia_html, fetch_ocr, parse_law
+
+        if input_type == "html":
+            echo(f"Buscando HTML para {raw_id}...")
+            raw_text = fetch_ia_html(raw_id)
+            if not raw_text:
+                echo(
+                    f"HTML não disponível para {raw_id} (item inexistente ou upload pendente)"
+                )
+                raise typer.Exit(1)
+        elif input_type == "ocr":
+            echo(f"Buscando OCR para {raw_id}...")
+            raw_text = fetch_ocr(raw_id)
+            if not raw_text:
+                echo(
+                    f"OCR não disponível para {raw_id} (IA ainda processando ou item inexistente)"
+                )
+                raise typer.Exit(1)
+        else:
+            echo(f"--input-type inválido: {input_type!r}. Use 'ocr' ou 'html'.")
             raise typer.Exit(1)
 
-        echo(f"Parseando com {model} ({len(ocr)} chars de OCR)...")
-        result = parse_law(ocr, raw_id, ente, model=model)
+        label = "HTML" if input_type == "html" else "OCR"
+        echo(f"Parseando com {model} ({len(raw_text)} chars de {label})...")
+        result = parse_law(raw_text, raw_id, ente, model=model, input_type=input_type)
         if not result:
             echo(
                 "Parse falhou: confiança insuficiente ou OCR ilegível. Sem parsed item publicado."

--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -22,6 +22,7 @@ from leizilla import config
 
 _HAIKU = "claude-haiku-4-5"
 _OCR_URL = "https://archive.org/download/{ia_id}/{ia_id}_djvu.txt"
+_IA_HTML_URL = "https://archive.org/download/{ia_id}/{ia_id}.html"
 _USER_AGENT = "leizilla-crawler/0.1"
 _MIN_CONFIDENCE = 0.5
 _OCR_CHAR_LIMIT = 8000
@@ -133,6 +134,16 @@ def fetch_html(url: str, timeout: int = 30) -> Optional[str]:
             return resp.read().decode("utf-8", errors="replace")
     except (urllib.error.URLError, OSError, ValueError):
         return None
+
+
+def fetch_ia_html(ia_id: str, timeout: int = 30) -> Optional[str]:
+    """Fetch HTML from IA raw item (for HTML sources like Planalto, M2.7+).
+
+    IA stores HTML as {ia_id}.html alongside raw_meta.json when uploaded via
+    upload_raw_html. Delegates to fetch_html for uniform error handling.
+    """
+    url = _IA_HTML_URL.format(ia_id=ia_id)
+    return fetch_html(url, timeout=timeout)
 
 
 def _extract_json(text: str) -> Optional[Dict[str, Any]]:

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -151,6 +151,40 @@ class TestCmdParseUpload:
         assert result.exit_code == 1
         assert "OCR não disponível" in result.output
 
+    def test_input_type_html_uses_fetch_ia_html(self):
+        """--input-type html usa fetch_ia_html e passa input_type='html' ao parse_law."""
+        raw_id = "leizilla-raw-federal-planalto-lei-09503"
+        with (
+            patch("leizilla.parser.fetch_ia_html", return_value="<html>lei</html>") as mock_html,
+            patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT) as mock_parse,
+        ):
+            result = runner.invoke(
+                app, ["parse", "--raw-id", raw_id, "--input-type", "html"]
+            )
+        assert result.exit_code == 0
+        mock_html.assert_called_once_with(raw_id)
+        _, kwargs = mock_parse.call_args
+        assert kwargs.get("input_type") == "html"
+
+    def test_input_type_html_exits_1_when_html_unavailable(self):
+        """Exit 1 quando HTML não está disponível no IA."""
+        with patch("leizilla.parser.fetch_ia_html", return_value=None):
+            result = runner.invoke(
+                app,
+                ["parse", "--raw-id", "leizilla-raw-federal-planalto-lei-09503", "--input-type", "html"],
+            )
+        assert result.exit_code == 1
+        assert "HTML não disponível" in result.output
+
+    def test_invalid_input_type_exits_1(self):
+        """Valor inválido para --input-type retorna exit 1 com mensagem clara."""
+        result = runner.invoke(
+            app,
+            ["parse", "--raw-id", "leizilla-raw-ro-assembleia-coddoc-00001", "--input-type", "pdf"],
+        )
+        assert result.exit_code == 1
+        assert "inválido" in result.output
+
     def test_exits_1_on_parse_failure(self):
         with (
             patch("leizilla.parser.fetch_ocr", return_value="ocr"),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -119,6 +119,32 @@ class TestFetchHtml:
         assert captured_req[0].get_header("User-agent") == parser._USER_AGENT
 
 
+class TestFetchIaHtml:
+    def test_constructs_ia_html_url(self):
+        captured: list[str] = []
+
+        def capture(req, **kw):  # type: ignore[no-untyped-def]
+            captured.append(req.get_full_url())
+            raise OSError("stop")
+
+        with patch("urllib.request.urlopen", side_effect=capture):
+            parser.fetch_ia_html(_IA_ID)
+
+        expected = f"https://archive.org/download/{_IA_ID}/{_IA_ID}.html"
+        assert captured == [expected]
+
+    def test_returns_html_on_success(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_resp("<html>Lei federal</html>"),
+        ):
+            assert parser.fetch_ia_html(_IA_ID) == "<html>Lei federal</html>"
+
+    def test_returns_none_on_network_error(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            assert parser.fetch_ia_html(_IA_ID) is None
+
+
 class TestExtractJson:
     def test_direct_json(self):
         result = parser._extract_json('{"a": 1}')


### PR DESCRIPTION
## Summary

- **`parser.fetch_ia_html(ia_id)`**: thin wrapper sobre `fetch_html` que constrói `https://archive.org/download/{ia_id}/{ia_id}.html` — simétrico a `fetch_ocr` que usa `{ia_id}_djvu.txt`. Armazenado pelo `upload_raw_html` de M2.7 (#34).
- **`parse --input-type ocr|html`**: nova opção em `cmd_parse`. Default `ocr` retrocompatível. Quando `html`: usa `fetch_ia_html` e passa `input_type="html"` ao `parse_law`. Valor inválido: exit 1 com mensagem descritiva.
- **`IMPLEMENTATION.md`**: status table corrigido (M3.4/M4.1 marcados done; M5.1/M2.7 in-progress adicionados); M3.5 adicionado; log desta sessão com triagem dos fixes #29/#33.

## Por que agora

M3.4 implementou `parse_law(input_type="html")` mas a CLI ficou hard-coded em `fetch_ocr`. M2.7 (#34) criará IA items com `.html` para Planalto federal — sem esta mudança o pipeline Etapa 2 é inutilizável para fontes HTML. A condição do deferimento original ("não há consumidor ainda") foi atendida.

## Trade-offs aceitos

- **`parse-all --input-type html` não está aqui**: requer ajuste no padrão de chave (federal usa `lei-NNNNN`, não `coddoc-NNNNN`). Fica para M2.8 após #34 mergear.
- **`fetch_ia_html` é wrapper, não refator**: `fetch_html(url)` continua existindo para fetch direto de URL (ex: Wayback). `fetch_ia_html` encapsula a convenção de URL do IA. Sem deduplicação forçada.

## Test plan

- [x] `uv run pytest tests/test_parser.py tests/test_cli_parse.py -v` → 61 passed
- [x] `uv run pytest -q` → 314 passed, 13 skipped
- [ ] Smoke test manual (requer M2.7 #34 mergear primeiro): `leizilla parse --raw-id leizilla-raw-federal-planalto-lei-09503 --ente federal --input-type html`

## Próximos passos

- #34 (M2.7) merge → smoke test end-to-end federal scrape → parse html
- M2.8: `parse-all --input-type html` com suporte a chave federal
- #29 (M4.2) merge → M4.3 benchmark DuckDB-WASM
- #33 (M5.1) merge → M5.2 TanStack Query + paginação

https://claude.ai/code/session_01ExMNzL7EejtGZtVsTTBm4V

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExMNzL7EejtGZtVsTTBm4V)_