### PR TITLE
feat(M2.7): Planalto federal HTML pipeline — discover + upload_raw_html + scrape_one_html

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -19,18 +19,20 @@
 | **M2.4** — Rate-limit por host | 🟢 done | 66aa4ac | `make_rate_limiter` por `hostname`: scraping paralelo de múltiplas fontes sem serializar. 12 testes. |
 | **M2.5** — casacivil discovery | 🟢 done | #27 | `discover_casacivil_laws(tipo, start_num, end_num)` + CLI `scrape --fonte casacivil --tipo lei|lc`. URL: ditel.casacivil.ro.gov.br. 15 testes. (PR #26 fechado por conflito; #27 merged.) |
 | **M2.6** — casacivil job no workflow | 🟢 done | #31 | `rondonia_crawler.yml` expandido com passos casacivil lei + lc; inputs `casacivil_start`/`casacivil_end`. |
-| **M2 restante** — fontes SP + federal (stubs) | 🟢 done | #30 | `fontes/sp.py` + `fontes/federal.py`. Scraping sp/federal bloqueado por M3.4 (HTML parser). |
+| **M2 restante** — fontes SP + federal (stubs) | 🟢 done | #30 | `fontes/sp.py` + `fontes/federal.py`. SP pendente de auditoria de URL. |
+| **M2.7** — Planalto federal HTML pipeline | 🟡 in-progress | — | `discover_planalto_laws` + `upload_raw_html` + `scrape_one_html`. 24 testes. CLI: `scrape --ente federal --fonte planalto --tipo lei\|lcp\|decreto`. |
 | **M3.1** — OCR fetch + LLM parse → parser.py | 🟢 done | #17 | `parser.fetch_ocr` + `parse_law` (Haiku, fail-closed: confidence/tipo/numero/ano obrigatórios). 27 testes. |
 | **M3.2** — publisher.upload_parsed() | 🟢 done | #19 | Sobe `law.xml` + `parsed_meta.json` para IA item canônico. 18 testes. |
 | **M3.3** — `parse --upload` + XSD gate + `parse-all` batch | 🟢 done | #21 | CLI integra parser→publisher; `_xsd_gate` via xmllint (bloqueia upload quando inválido); `parse-all` itera range coddoc. 15 testes. |
 | **M3.4** — `parse_law` aceita HTML + `fetch_html` | 🟢 done | cc00676 | `input_type="html"` em `parse_law`; `fetch_html(url)`; prompt adaptado; `_HTML_CHAR_LIMIT=32000`. 35 testes. |
-| **M3.5** — CLI `parse --input-type html` + `fetch_ia_html` | 🟡 in-progress | — | `fetch_ia_html(ia_id)` busca `{ia_id}.html` do IA; `--input-type ocr\|html` em `cmd_parse`; 3 testes novos (TestFetchIaHtml + TestCmdParseUpload). Desbloqueia pipeline federal após M2.7. |
+| **M3.5** — CLI `parse --input-type html` + `fetch_ia_html` | 🟢 done | #35 | `fetch_ia_html(ia_id)` busca `{ia_id}.html` do IA; `--input-type ocr\|html` em `cmd_parse`. 314 testes. |
 | **M4.1** — ETL XML→Parquet (etl.py + consolidate CLI) | 🟢 done | #28 | `xml_to_rows` + `write_parquet` + CLI `consolidate`. 76 testes. |
-| **M4.2** — release-dataset CLI + publisher.upload_dataset | 🟡 in-progress | #29 | Sobe dataset Parquet para IA; benchmark local §3.4. CI verde; P2 Codex endereçado (ValueError capturado na CLI). Pronto para merge após CI rerun. |
+| **M4.2** — release-dataset CLI + publisher.upload_dataset | 🟡 in-progress | #36 | Sobe dataset Parquet para IA; benchmark local §3.4. CI pendente. |
 | **M4.3** — benchmark DuckDB-WASM real + gatilhos §3.4 | ⚪ todo | — | Bloqueado por M4.2 merge. |
-| **M5.1** — Frontend Astro+Svelte+DuckDB-WASM (foundation) | 🟡 in-progress | #33 | `web/` Astro4+Svelte5+Pico2+DuckDB-WASM1.32. CI verde; P1+P2 Codex endereçados (retry DB init; stale search fix). Pronto para merge após CI rerun. |
+| **M5.1** — Frontend Astro+Svelte+DuckDB-WASM (foundation) | 🟡 in-progress | #33 | `web/` Astro4+Svelte5+Pico2+DuckDB-WASM1.32. Fixes P1/P2 pushed. CI pendente. |
 | **M5.2** — TanStack Query + paginação + filtros | ⚪ todo | — | Bloqueado por M5.1 merge. |
-| **M2.7** — Planalto federal HTML pipeline | 🟡 in-progress | #34 | `discover_planalto_laws` + `upload_raw_html` + `scrape_one_html` + CLI `scrape --ente federal`. 24 testes. CI Kilo in_progress. |
+| **M2.7** — Planalto federal HTML pipeline | 🟢 done | #34 | `discover_planalto_laws` + `upload_raw_html` + `scrape_one_html` + CLI `scrape --ente federal`. 24 testes. URLs legadas (pré-2002); year-scoped em M2.8. |
+| **M2.8** — Planalto year-scoped URLs + `parse-all html` | ⚪ todo | — | URLs `_ato{Y}-{Y}/{ano}/lei/l{num}.htm` via API Câmara; `parse-all --input-type html --tipo lei`. Desbloqueia leis federais pós-2002. |
 | **M6** — GitHub Actions produção | ⚪ todo | — | Depende de M2–M5. |
 | **M7** — Claude Code routines | ⚪ todo | — | Depende de M6. |
 
@@ -88,6 +90,36 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
 
+### 2026-05-22 — M2.7: Planalto federal HTML pipeline (desbloqueado pelo M3.4)
+
+M3.4 (`fetch_html` + `parse_law(input_type="html")`) desbloqueou o scraping de
+fontes que servem HTML em vez de PDF. Planalto é a fonte canônica federal (compilados
+vigentes) — equivalente federal da casacivil RO.
+
+**Decisão principal — raw HTML item no IA**: princípio #1 ("duas etapas no IA,
+sempre separadas") exige raw e parsed como IA items distintos. Para fontes HTML
+(sem PDF), o raw item armazena `{ia_id}.html` + `raw_meta.json` sidecar.
+IA não faz OCR em HTML (princípio #2 não se aplica — HTML já é texto).
+A Etapa 2 usa `fetch_html(fonte_url)` diretamente, não um `_djvu.txt` do IA.
+
+**Identificadores sem mudança**: `leizilla-raw-{ente}-{fonte}-{chave}` idêntico
+ao raw PDF. Tooling downstream não precisa saber o tipo de conteúdo.
+
+**`raw_meta_html`**: campo `content_type: "html"` + `hash_html` (vs `hash_pdf`).
+
+**URL patterns Planalto (leis pré-2002)**:
+- Leis ordinárias: `https://www.planalto.gov.br/ccivil_03/leis/L{N}.htm`
+- Leis complementares: `https://www.planalto.gov.br/ccivil_03/leis/lcp/Lcp{N}.htm`
+- Decretos: `https://www.planalto.gov.br/ccivil_03/decreto/D{N}.htm`
+
+Leis pós-2002 usam year-scoped paths (`_ato{Y}-{Y}/{ano}/lei/l{num}.htm`) —
+M2.8 cobrirá via API Câmara. Fail-open em 404 garante sem crash no pipeline.
+
+**CLI `scrape`**: ramo `ente=federal, fonte=planalto` usa `scrape_one_html` em vez
+de `scrape_one`. Zero breaking change para ro/assembleia e ro/casacivil.
+
+24 testes em `tests/test_planalto_pipeline.py`.
+
 ### 2026-05-22 — M3.5: CLI parse --input-type html + fetch_ia_html
 
 `fetch_ia_html(ia_id)` adicionada em `parser.py` — thin wrapper sobre `fetch_html`
@@ -97,35 +129,16 @@ a `fetch_ocr` que usa `{ia_id}_djvu.txt`.
 CLI `cmd_parse` recebe `--input-type` (valores: `ocr` | `html`; default: `ocr`).
 - `ocr`: comportamento existente — `fetch_ocr(raw_id)` → `parse_law(..., input_type="ocr")`
 - `html`: `fetch_ia_html(raw_id)` → `parse_law(..., input_type="html")`
-- Valor inválido: exit 1 com mensagem clara (não levanta `ValueError` não capturado).
+- Valor inválido: exit 1 com mensagem clara.
 
 **Por que agora**: M3.4 (parser.py) já aceitava `input_type="html"` mas a CLI continuava
 hard-coded em `fetch_ocr`. M2.7 (#34) cria IA items com `.html` para Planalto federal.
 Sem esta mudança, `parse` e o pipeline Etapa 2 são inutilizáveis para fontes HTML.
-A M3.4 explicitou o deferimento; agora há consumidor real.
 
 **Não feito aqui**: `parse-all --input-type html` fica para M2.8 — requer também
 ajuste no padrão de chave (federal usa `lei-NNNNN`, não `coddoc-NNNNN`).
 
-**Testes**: 3 novos em `TestFetchIaHtml` (URL correta, sucesso, erro de rede) +
-3 novos em `TestCmdParseUpload` (html path, html 404, input_type inválido). 314 total.
-
-### 2026-05-22 — Triagem de PRs: fixes P1/P2 em #29 e #33
-
-**PR #29 (M4.2) — P2**: `cmd_release_dataset` não capturava `ValueError` de
-`upload_dataset` (ex: `--ente RO` causava traceback não controlado). Fix: `try/except
-ValueError` com mesmo fluxo de erro (`echo + typer.Exit(1)`). Teste
-`test_invalid_ente_exits_nonzero` adicionado a `TestReleaseDatasetCli`.
-
-**PR #33 (M5.1) — P1**: `_initPromise` ficava permanentemente rejected após falha
-transitória de CORS/WASM. Fix: rejection handler limpa `_initPromise = null` para
-permitir retry na próxima chamada.
-
-**PR #33 (M5.1) — P2**: resultados stale quando duas buscas concorrentes resolviam
-fora de ordem. Fix: `searchSeq` incrementa por chamada; updates de state só aplicados
-se o seq local ainda for o mais recente.
-
-**PR #34 (M2.7)**: Kilo in_progress na chegada desta sessão — skip, próxima sessão pega.
+**Testes**: 3 novos em `TestFetchIaHtml` + 3 novos em `TestCmdParseUpload`. 314 total.
 
 ### 2026-05-22 — M3.4: parse_law aceita HTML além de OCR
 
@@ -730,15 +743,13 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 ## Próximos passos imediatos
 
-**M0–M4.1 concluídos** ✅ | **M3.5, M4.2, M5.1, M2.7 em PRs abertas**
+**M0–M4.1, M3.4, M3.5, M2.7 concluídos** ✅ | **M4.2, M5.1 em PRs abertas**
 
 **PRs abertas agora** (em decantação — não auto-merge):
-- **#29** M4.2: release-dataset CLI. CI verde (pós-fix P2 ValueError). Aguardando CI rerun + review.
-- **#33** M5.1: Frontend foundation. CI verde (pós-fix P1+P2 retry/stale). Aguardando CI rerun + review.
-- **#34** M2.7: Planalto federal HTML pipeline. Kilo in_progress na última sessão.
-- **M3.5** (branch `claude/cool-cerf-qPCfV`): CLI `parse --input-type html` + `fetch_ia_html`. 314 testes passando. PR desta sessão.
+- **#36** M4.2: release-dataset CLI. CI pendente.
+- **#33** M5.1: Frontend foundation. Fixes P1/P2/orphaned-workers pushed. CI pendente.
 
-**M4.3** (próximo após #29 mergear):
+**M4.3** (próximo após #36 mergear):
 - Benchmark DuckDB-WASM real contra §3.4 gatilhos.
 - Avisa se file_mb > 100, row_count > 2M, ou full-text latência > 1s.
 
@@ -747,6 +758,7 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 - Paginação de resultados.
 - Filtro por ente/ano.
 
-**M2.8** (após #34 mergear):
+**M2.8** (próximo após M2.7):
+- Year-scoped URLs Planalto via API Câmara (leis pós-2002).
 - `parse-all --input-type html --tipo lei|lcp|decreto` para iterar range federal.
 - Requer ajuste no padrão de chave (federal usa `lei-NNNNN`, não `coddoc-NNNNN`).

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -155,40 +155,79 @@ def cmd_upload(
 @app.command("scrape")
 def cmd_scrape(
     ente: str = typer.Option("ro", help="Ente federativo"),
-    fonte: str = typer.Option("assembleia", help="Fonte (assembleia, casacivil)"),
+    fonte: str = typer.Option("assembleia", help="Fonte (assembleia, casacivil, planalto)"),
     start_coddoc: int = typer.Option(
-        1, help="ID inicial (coddoc para assembleia; número de lei para casacivil)"
+        1, help="ID inicial (coddoc p/ assembleia; número de lei p/ casacivil/planalto)"
     ),
     end_coddoc: int = typer.Option(10, help="ID final"),
     tipo: str = typer.Option(
-        "lei", help="Tipo de lei para casacivil: lei (ordinária) ou lc (complementar)"
+        "lei", help="Tipo: lei (ordinária), lc (complementar, casacivil), decreto (planalto)"
     ),
 ) -> None:
-    """Scrape leis: discover → robots → wayback → upload_raw para IA."""
-    if tipo != "lei" and fonte != "casacivil":
-        echo(
-            f"--tipo só é válido com --fonte casacivil (recebido: --tipo {tipo} --fonte {fonte})"
-        )
+    """Scrape leis: discover → robots → wayback → upload_raw/upload_raw_html para IA."""
+    _VALID_TIPOS = {"lei", "lc", "lcp", "decreto"}
+
+    if tipo not in _VALID_TIPOS:
+        echo(f"--tipo inválido: {tipo!r}. Valores suportados: {sorted(_VALID_TIPOS)}")
+        raise typer.Exit(1)
+    if tipo == "lc" and fonte != "casacivil":
+        echo(f"--tipo lc só é válido com --fonte casacivil (recebido: --fonte {fonte})")
+        raise typer.Exit(1)
+    if tipo == "lcp" and fonte != "planalto":
+        echo(f"--tipo lcp só é válido com --fonte planalto (recebido: --fonte {fonte})")
+        raise typer.Exit(1)
+    if tipo == "decreto" and fonte != "planalto":
+        echo(f"--tipo decreto só é válido com --fonte planalto (recebido: --fonte {fonte})")
         raise typer.Exit(1)
 
-    echo(f"Scraping {ente}/{fonte} {start_coddoc}–{end_coddoc}")
+    echo(f"Scraping {ente}/{fonte} {start_coddoc}–{end_coddoc} (tipo={tipo})")
 
     try:
-        from leizilla.crawler import LeisCrawler, discover_casacivil_laws
         from leizilla.publisher import InternetArchivePublisher
-        from leizilla.scraper import make_rate_limiter, scrape_one
+        from leizilla.scraper import make_rate_limiter
 
         publisher = InternetArchivePublisher()
         rate_limiter = make_rate_limiter()
 
+        if ente == "federal" and fonte == "planalto":
+            from leizilla.fontes.federal import discover_planalto_laws
+            from leizilla.scraper import scrape_one_html
+
+            laws = discover_planalto_laws(
+                tipo=tipo,
+                start_num=start_coddoc,
+                end_num=end_coddoc,
+            )
+            ok = 0
+            for law in laws:
+                fonte_url = law.get("url_original")
+                if not fonte_url:
+                    echo(f"  Sem URL: {law.get('chave', 'N/A')}")
+                    continue
+                result = scrape_one_html(fonte_url, law, publisher, rate_limiter)
+                if result.get("success"):
+                    echo(f"  OK: {result.get('ia_id', '?')}")
+                    ok += 1
+                else:
+                    echo(
+                        f"  Falha [{result.get('reason', '?')}]: {law.get('chave', 'N/A')}"
+                    )
+            echo(f"Scraping concluído: {ok}/{len(laws)} com sucesso")
+            return
+
+        # Fontes PDF (ro/assembleia, ro/casacivil)
+        from leizilla.scraper import scrape_one
+
         async def run() -> None:
             if ente == "ro" and fonte == "assembleia":
+                from leizilla.crawler import LeisCrawler
                 crawler = LeisCrawler(crawler_type="playwright")
                 laws = await crawler.discover_rondonia_laws(
                     start_coddoc=start_coddoc,
                     end_coddoc=end_coddoc,
                 )
             elif ente == "ro" and fonte == "casacivil":
+                from leizilla.crawler import discover_casacivil_laws
                 laws = discover_casacivil_laws(
                     tipo=tipo,
                     start_num=start_coddoc,

--- a/src/leizilla/fontes/federal.py
+++ b/src/leizilla/fontes/federal.py
@@ -1,40 +1,15 @@
 """Fontes de leis federais (slug: 'federal').
 
-Fontes mapeadas em 2026-05 para futura implementação:
-
+Fontes mapeadas:
 - planalto: Portal da Legislação — Presidência da República / Casa Civil
-  Portal: https://www.planalto.gov.br/ccivil_03/
-  Acesso: leis em formato HTML por tipo/número. PDFs de publicação original
-  via URL padrão (https://www.planalto.gov.br/ccivil_03/leis/LXXXX.htm).
-  Compilados vigentes disponíveis inline — FONTE_CANONICA para federal.
-  Obs: HTML, não PDF — scraping exige extração de texto via LLM a partir
-  do HTML (não OCR). Ajuste no pipeline M3 (parser.fetch_html vs fetch_ocr).
-
-- camara: Portal da Câmara dos Deputados
-  Portal: https://www.camara.leg.br/legislacao/
-  Acesso: API REST pública via https://dadosabertos.camara.leg.br/api/v2/
-  Inclui PDFs de proposições, texto compilado, metadados estruturados.
-  Útil para projetos de lei + texto consolidado.
-
-- senado: Portal do Senado Federal / LegisWeb
-  Portal: https://legis.senado.leg.br/norma/
-  Acesso: API REST via https://legis.senado.leg.br/dadosabertos/
-  Cobre legislação federal com metadados (autoria, situação, ementa).
-
-- dou: Diário Oficial da União — Imprensa Nacional
-  Portal: https://www.in.gov.br/
-  Acesso: API pública (https://queridodiario.ok.org.br/ para histórico).
-  Útil para publicação original e cross-verificação de data.
-
-Notas para implementação:
-- Planalto é o equivalente federal da casacivil RO (compilados vigentes).
-- A API da Câmara é a melhor entrada para metadados estruturados (JSON).
-- HTML no Planalto exige adaptação no pipeline: parse_law deve aceitar HTML
-  além de OCR text. Decisão de M3.4 (future milestone).
-- Camara API tem paginação e rate-limit explícito: 60 req/min.
-- Legislação pré-1988 (anterior à CF) disponível mas com cobertura parcial.
-- robots.txt do Planalto e Câmara: a auditar antes da implementação.
+  HTML compilado vigente. FONTE_CANONICA para federal.
+  Desbloqueado em M3.4 (parser.fetch_html).
+- camara: API REST pública (60 req/min). Útil para metadados estruturados.
+- senado: API REST pública. Cobre legislação federal.
+- dou: Diário Oficial da União. Cross-verificação de publicação original.
 """
+
+from typing import Any, Dict, List
 
 FONTES = ["planalto", "camara", "senado", "dou"]
 FONTE_CANONICA = "planalto"
@@ -50,3 +25,50 @@ APIS = {
     "camara": "https://dadosabertos.camara.leg.br/api/v2/",
     "senado": "https://legis.senado.leg.br/dadosabertos/",
 }
+
+# URL templates por tipo de ato normativo no Planalto
+_PLANALTO_BASE = "https://www.planalto.gov.br/ccivil_03"
+_PLANALTO_URLS: Dict[str, str] = {
+    "lei": f"{_PLANALTO_BASE}/leis/L{{num}}.htm",
+    "lcp": f"{_PLANALTO_BASE}/leis/lcp/Lcp{{num}}.htm",
+    "decreto": f"{_PLANALTO_BASE}/decreto/D{{num}}.htm",
+}
+
+
+def discover_planalto_laws(
+    tipo: str,
+    start_num: int,
+    end_num: int,
+) -> List[Dict[str, Any]]:
+    """Gera candidatos de URL do Planalto para o range de números.
+
+    Análogo a discover_casacivil_laws: retorna candidatos sem verificar
+    existência — scrape_one_html trata 404/timeout via robots+wayback.
+
+    Args:
+        tipo: "lei", "lcp", ou "decreto"
+        start_num: número inicial (inclusive)
+        end_num: número final (inclusive)
+
+    Returns:
+        Lista de lei_data dicts com url_original, ente, fonte, chave, tipo.
+    """
+    template = _PLANALTO_URLS.get(tipo)
+    if template is None:
+        raise ValueError(f"tipo deve ser {list(_PLANALTO_URLS)}, got {tipo!r}")
+
+    laws = []
+    for num in range(start_num, end_num + 1):
+        url = template.format(num=num)
+        chave = f"{tipo}-{num:05d}"
+        laws.append(
+            {
+                "ente": "federal",
+                "fonte": "planalto",
+                "chave": chave,
+                "tipo": tipo,
+                "numero": num,
+                "url_original": url,
+            }
+        )
+    return laws

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -56,6 +56,37 @@ def build_raw_meta(
     }
 
 
+def build_raw_meta_html(
+    html_content: str,
+    lei_data: Dict[str, Any],
+    fetched_from: str,
+    wayback_url: Optional[str] = None,
+    wayback_blocked_robots: bool = False,
+) -> Dict[str, Any]:
+    """Constrói raw_meta.json para item HTML (fontes sem PDF, ex: Planalto)."""
+    ente = str(lei_data.get("ente", "unknown"))
+    fonte = str(lei_data.get("fonte", "planalto"))
+    chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
+    html_bytes = html_content.encode("utf-8")
+    return {
+        "leizilla_meta_version": "0.1",
+        "content_type": "html",
+        "ente": ente,
+        "fonte": fonte,
+        "chave": chave,
+        "fonte_url": lei_data.get("url_original"),
+        "data_captura": datetime.now(tz=timezone.utc).isoformat(),
+        "hash_html": f"sha256:{hashlib.sha256(html_bytes).hexdigest()}",
+        "user_agent": _USER_AGENT,
+        "ia_id_bundle": _bundle_identifier(ente, fonte),
+        "provenance_wayback": {
+            "fetched_from": fetched_from,
+            "wayback_url": wayback_url,
+            "wayback_blocked_robots": wayback_blocked_robots,
+        },
+    }
+
+
 class InternetArchivePublisher:
     """Upload para IA e geração de datasets Parquet."""
 
@@ -120,6 +151,66 @@ class InternetArchivePublisher:
                     "ia_id": ia_id,
                     "ia_url": f"https://archive.org/details/{ia_id}",
                 }
+            except subprocess.CalledProcessError as e:
+                return {"success": False, "error": e.stderr, "ia_id": ia_id}
+
+    def upload_raw_html(
+        self,
+        html_content: str,
+        lei_data: Dict[str, Any],
+        fetched_from: str = "source-fallback",
+        wayback_url: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Upload raw HTML + raw_meta.json sidecar para IA.
+
+        Identifier: leizilla-raw-{ente}-{fonte}-{chave} (SCHEMA.md §1.2).
+        Análogo a upload_raw mas para fontes que servem HTML (ex: Planalto).
+        IA não faz OCR em HTML — Etapa 2 usa fetch_html direto da fonte_url.
+        """
+        if not self.access_key or not self.secret_key:
+            return {"success": False, "error": "IA credentials not configured"}
+
+        ente = str(lei_data.get("ente", "unknown"))
+        fonte = str(lei_data.get("fonte", "planalto"))
+        chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
+        ia_id = _raw_identifier(ente, fonte, chave)
+
+        raw_meta = build_raw_meta_html(html_content, lei_data, fetched_from, wayback_url)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            html_dst = Path(tmp) / f"{ia_id}.html"
+            html_dst.write_text(html_content, encoding="utf-8")
+            meta_path = Path(tmp) / "raw_meta.json"
+            meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
+
+            try:
+                subprocess.run(
+                    [
+                        "ia",
+                        "upload",
+                        ia_id,
+                        str(html_dst),
+                        str(meta_path),
+                        "--metadata",
+                        f"title:{lei_data.get('titulo', 'Lei')}",
+                        "--metadata",
+                        "mediatype:texts",
+                        "--metadata",
+                        f"subject:leis;leizilla;{ente}",
+                        "--metadata",
+                        "creator:leizilla-crawler",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                return {
+                    "success": True,
+                    "ia_id": ia_id,
+                    "ia_url": f"https://archive.org/details/{ia_id}",
+                }
+            except FileNotFoundError:
+                return {"success": False, "error": "ia CLI não encontrado — instale 'internetarchive'", "ia_id": ia_id}
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
 

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 from leizilla import robots, wayback
+from leizilla.parser import fetch_html
 from leizilla.publisher import InternetArchivePublisher
 
 _RATE_LIMIT_S = 1.0
@@ -83,6 +84,60 @@ def scrape_one(
         return {"success": False, "reason": "upload-failed", "error": str(exc)}
     finally:
         tmp_path.unlink(missing_ok=True)
+
+
+def scrape_one_html(
+    fonte_url: str,
+    lei_data: dict,
+    publisher: InternetArchivePublisher,
+    rate_limiter: Optional[Callable[[str], None]] = None,
+) -> dict:
+    """Scrape de uma página HTML: robots → wayback save → fetch → upload_raw_html.
+
+    Para fontes sem PDF (ex: Planalto federal) que servem HTML compilado vigente.
+    Retorna dict com 'success' + ('ia_id', 'ia_url') ou ('reason') em falha.
+    Robots bloqueado é permanente — caller NÃO deve re-tentar a mesma URL.
+    """
+    if not robots.is_allowed(fonte_url):
+        return {"success": False, "reason": "robots-blocked", "url": fonte_url}
+
+    try:
+        wayback.save_page(fonte_url)
+    except Exception:
+        pass
+
+    # Tenta primeiro Wayback (snapshot recente)
+    wb_url = wayback.check_available(fonte_url)
+    fetched_from: str
+    html_content: Optional[str]
+
+    if wb_url:
+        html_content = fetch_html(wb_url)
+        fetched_from = "wayback"
+    else:
+        html_content = None
+        wb_url = None
+
+    if html_content is None:
+        # Fallback direto com rate-limit por host (princípio #10)
+        if rate_limiter is not None:
+            rate_limiter(fonte_url)
+        html_content = fetch_html(fonte_url)
+        fetched_from = "source-fallback"
+        wb_url = None
+
+    if html_content is None:
+        return {"success": False, "reason": "fetch-failed", "url": fonte_url}
+
+    try:
+        return publisher.upload_raw_html(
+            html_content,
+            lei_data,
+            fetched_from=fetched_from,
+            wayback_url=wb_url,
+        )
+    except Exception as exc:
+        return {"success": False, "reason": "upload-failed", "error": str(exc)}
 
 
 def make_rate_limiter(min_interval: float = _RATE_LIMIT_S) -> Callable[[str], None]:

--- a/tests/test_planalto_pipeline.py
+++ b/tests/test_planalto_pipeline.py
@@ -1,0 +1,305 @@
+"""Testes para M2.7: Planalto federal HTML pipeline.
+
+Cobre: discover_planalto_laws, build_raw_meta_html, upload_raw_html, scrape_one_html.
+HTTP e IA CLI 100% mockados — sem rede.
+"""
+
+import subprocess
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from leizilla.fontes.federal import discover_planalto_laws
+from leizilla.publisher import InternetArchivePublisher, build_raw_meta_html
+
+# ---------------------------------------------------------------------------
+# discover_planalto_laws
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverPlanaltoLaws:
+    def test_generates_correct_lei_urls(self) -> None:
+        laws = discover_planalto_laws("lei", 9503, 9505)
+        assert len(laws) == 3
+        assert laws[0]["url_original"] == "https://www.planalto.gov.br/ccivil_03/leis/L9503.htm"
+        assert laws[1]["url_original"] == "https://www.planalto.gov.br/ccivil_03/leis/L9504.htm"
+        assert laws[2]["url_original"] == "https://www.planalto.gov.br/ccivil_03/leis/L9505.htm"
+
+    def test_generates_correct_lcp_urls(self) -> None:
+        laws = discover_planalto_laws("lcp", 87, 88)
+        assert laws[0]["url_original"] == "https://www.planalto.gov.br/ccivil_03/leis/lcp/Lcp87.htm"
+        assert laws[1]["url_original"] == "https://www.planalto.gov.br/ccivil_03/leis/lcp/Lcp88.htm"
+
+    def test_generates_correct_decreto_urls(self) -> None:
+        laws = discover_planalto_laws("decreto", 99, 101)
+        assert laws[0]["url_original"] == "https://www.planalto.gov.br/ccivil_03/decreto/D99.htm"
+
+    def test_sets_correct_metadata(self) -> None:
+        laws = discover_planalto_laws("lei", 9503, 9503)
+        law = laws[0]
+        assert law["ente"] == "federal"
+        assert law["fonte"] == "planalto"
+        assert law["chave"] == "lei-09503"
+        assert law["tipo"] == "lei"
+        assert law["numero"] == 9503
+
+    def test_empty_range(self) -> None:
+        laws = discover_planalto_laws("lei", 5, 4)
+        assert laws == []
+
+    def test_invalid_tipo_raises(self) -> None:
+        with pytest.raises(ValueError, match="tipo deve ser"):
+            discover_planalto_laws("portaria", 1, 5)
+
+    def test_single_item_range(self) -> None:
+        laws = discover_planalto_laws("lei", 1, 1)
+        assert len(laws) == 1
+        assert laws[0]["chave"] == "lei-00001"
+
+
+# ---------------------------------------------------------------------------
+# build_raw_meta_html
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRawMetaHtml:
+    def _lei_data(self) -> Dict[str, Any]:
+        return {
+            "ente": "federal",
+            "fonte": "planalto",
+            "chave": "lei-09503",
+            "url_original": "https://www.planalto.gov.br/ccivil_03/leis/L9503.htm",
+        }
+
+    def test_content_type_is_html(self) -> None:
+        meta = build_raw_meta_html("<html/>", self._lei_data(), "wayback")
+        assert meta["content_type"] == "html"
+
+    def test_hash_html_present(self) -> None:
+        meta = build_raw_meta_html("<html>test</html>", self._lei_data(), "wayback")
+        assert meta["hash_html"].startswith("sha256:")
+        assert len(meta["hash_html"]) == 71  # "sha256:" + 64 hex chars
+
+    def test_hash_depends_on_content(self) -> None:
+        meta1 = build_raw_meta_html("<html>a</html>", self._lei_data(), "wayback")
+        meta2 = build_raw_meta_html("<html>b</html>", self._lei_data(), "wayback")
+        assert meta1["hash_html"] != meta2["hash_html"]
+
+    def test_provenance_wayback_field(self) -> None:
+        meta = build_raw_meta_html("<html/>", self._lei_data(), "wayback", wayback_url="https://web.archive.org/web/snap/url")
+        assert meta["provenance_wayback"]["fetched_from"] == "wayback"
+        assert meta["provenance_wayback"]["wayback_url"] == "https://web.archive.org/web/snap/url"
+
+    def test_meta_version(self) -> None:
+        meta = build_raw_meta_html("<html/>", self._lei_data(), "source-fallback")
+        assert meta["leizilla_meta_version"] == "0.1"
+
+
+# ---------------------------------------------------------------------------
+# upload_raw_html
+# ---------------------------------------------------------------------------
+
+
+def _publisher() -> InternetArchivePublisher:
+    pub = InternetArchivePublisher()
+    pub.access_key = "test-key"
+    pub.secret_key = "test-secret"
+    return pub
+
+
+def _lei_data_html() -> Dict[str, Any]:
+    return {
+        "ente": "federal",
+        "fonte": "planalto",
+        "chave": "lei-09503",
+        "url_original": "https://www.planalto.gov.br/ccivil_03/leis/L9503.htm",
+        "titulo": "Lei 9503",
+    }
+
+
+class TestUploadRawHtml:
+    def test_success_returns_ia_id(self, tmp_path: Any) -> None:
+        pub = _publisher()
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            result = pub.upload_raw_html("<html>lei</html>", _lei_data_html())
+        assert result["success"] is True
+        assert result["ia_id"] == "leizilla-raw-federal-planalto-lei-09503"
+        assert "archive.org/details" in result["ia_url"]
+
+    def test_no_credentials_returns_error(self) -> None:
+        pub = InternetArchivePublisher()
+        pub.access_key = ""
+        pub.secret_key = ""
+        result = pub.upload_raw_html("<html/>", _lei_data_html())
+        assert result["success"] is False
+        assert "credentials" in result["error"]
+
+    def test_subprocess_failure_returns_error(self) -> None:
+        pub = _publisher()
+        err = subprocess.CalledProcessError(1, "ia", stderr="quota exceeded")
+        with patch("subprocess.run", side_effect=err):
+            result = pub.upload_raw_html("<html/>", _lei_data_html())
+        assert result["success"] is False
+        assert "quota exceeded" in result["error"]
+
+    def test_missing_ia_cli_returns_error(self) -> None:
+        pub = _publisher()
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = pub.upload_raw_html("<html/>", _lei_data_html())
+        assert result["success"] is False
+        assert "ia CLI" in result["error"]
+
+    def test_ia_called_with_html_extension(self) -> None:
+        pub = _publisher()
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            pub.upload_raw_html("<html>lei</html>", _lei_data_html())
+        call_args = mock_run.call_args_list[0][0][0]
+        html_files = [a for a in call_args if isinstance(a, str) and a.endswith(".html")]
+        assert len(html_files) == 1
+
+    def test_mediatype_is_texts(self) -> None:
+        pub = _publisher()
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            pub.upload_raw_html("<html/>", _lei_data_html())
+        call_args = mock_run.call_args_list[0][0][0]
+        assert "mediatype:texts" in call_args
+
+
+# ---------------------------------------------------------------------------
+# scrape_one_html
+# ---------------------------------------------------------------------------
+
+
+class TestScrapeOneHtml:
+    def _url(self) -> str:
+        return "https://www.planalto.gov.br/ccivil_03/leis/L9503.htm"
+
+    def test_robots_blocked_returns_failure(self) -> None:
+        from leizilla.scraper import scrape_one_html
+        pub = _publisher()
+        with patch("leizilla.robots.is_allowed", return_value=False):
+            result = scrape_one_html(self._url(), _lei_data_html(), pub)
+        assert result["success"] is False
+        assert result["reason"] == "robots-blocked"
+
+    def test_fetch_failed_returns_failure(self) -> None:
+        from leizilla.scraper import scrape_one_html
+        pub = _publisher()
+        with patch("leizilla.robots.is_allowed", return_value=True), \
+             patch("leizilla.wayback.save_page"), \
+             patch("leizilla.wayback.check_available", return_value=None), \
+             patch("leizilla.scraper.fetch_html", return_value=None):
+            result = scrape_one_html(self._url(), _lei_data_html(), pub)
+        assert result["success"] is False
+        assert result["reason"] == "fetch-failed"
+
+    def test_wayback_primary_success(self) -> None:
+        from leizilla.scraper import scrape_one_html
+        pub = _publisher()
+        wb_url = "https://web.archive.org/web/snap/url"
+        mock_run = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("leizilla.robots.is_allowed", return_value=True), \
+             patch("leizilla.wayback.save_page"), \
+             patch("leizilla.wayback.check_available", return_value=wb_url), \
+             patch("leizilla.scraper.fetch_html", return_value="<html>lei</html>"), \
+             patch("subprocess.run", return_value=mock_run):
+            result = scrape_one_html(self._url(), _lei_data_html(), pub)
+        assert result["success"] is True
+
+    def test_fallback_when_wayback_unavailable(self) -> None:
+        from leizilla.scraper import scrape_one_html
+        pub = _publisher()
+        mock_run = MagicMock(returncode=0, stdout="", stderr="")
+        calls: list = []
+
+        def fake_fetch(url: str, **_: Any) -> str:
+            calls.append(url)
+            return "<html>lei</html>"
+
+        with patch("leizilla.robots.is_allowed", return_value=True), \
+             patch("leizilla.wayback.save_page"), \
+             patch("leizilla.wayback.check_available", return_value=None), \
+             patch("leizilla.scraper.fetch_html", side_effect=fake_fetch), \
+             patch("subprocess.run", return_value=mock_run) as _mock:
+            result = scrape_one_html(self._url(), _lei_data_html(), pub)
+        assert result["success"] is True, result
+        assert self._url() in calls
+
+    def test_rate_limiter_called_on_fallback(self) -> None:
+        from leizilla.scraper import scrape_one_html
+        pub = _publisher()
+        mock_run = MagicMock(returncode=0, stdout="", stderr="")
+        rate_mock = MagicMock()
+        with patch("leizilla.robots.is_allowed", return_value=True), \
+             patch("leizilla.wayback.save_page"), \
+             patch("leizilla.wayback.check_available", return_value=None), \
+             patch("leizilla.scraper.fetch_html", return_value="<html/>"), \
+             patch("subprocess.run", return_value=mock_run):
+            scrape_one_html(self._url(), _lei_data_html(), pub, rate_limiter=rate_mock)
+        rate_mock.assert_called_once_with(self._url())
+
+    def test_rate_limiter_not_called_when_wayback_succeeds(self) -> None:
+        from leizilla.scraper import scrape_one_html
+        pub = _publisher()
+        mock_run = MagicMock(returncode=0, stdout="", stderr="")
+        rate_mock = MagicMock()
+        wb_url = "https://web.archive.org/web/snap/url"
+        with patch("leizilla.robots.is_allowed", return_value=True), \
+             patch("leizilla.wayback.save_page"), \
+             patch("leizilla.wayback.check_available", return_value=wb_url), \
+             patch("leizilla.scraper.fetch_html", return_value="<html/>"), \
+             patch("subprocess.run", return_value=mock_run):
+            scrape_one_html(self._url(), _lei_data_html(), pub, rate_limiter=rate_mock)
+        rate_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI --tipo validation
+# ---------------------------------------------------------------------------
+
+
+class TestCmdScrapeTipoValidation:
+    def _invoke(self, *args: str) -> "typer.testing.Result":  # type: ignore[name-defined]
+        from typer.testing import CliRunner
+        from leizilla.cli import app
+        runner = CliRunner()
+        return runner.invoke(app, ["scrape"] + list(args))
+
+    def test_invalid_tipo_rejected_immediately(self) -> None:
+        result = self._invoke("--tipo", "leii", "--fonte", "casacivil")
+        assert result.exit_code != 0
+        assert "leii" in result.output
+
+    def test_invalid_tipo_rejected_with_planalto(self) -> None:
+        result = self._invoke("--tipo", "poney", "--fonte", "planalto")
+        assert result.exit_code != 0
+        assert "poney" in result.output
+
+    def test_lc_blocked_for_planalto(self) -> None:
+        result = self._invoke("--tipo", "lc", "--fonte", "planalto")
+        assert result.exit_code != 0
+        assert "casacivil" in result.output
+
+    def test_lcp_blocked_for_casacivil(self) -> None:
+        result = self._invoke("--tipo", "lcp", "--fonte", "casacivil")
+        assert result.exit_code != 0
+        assert "planalto" in result.output
+
+    def test_decreto_blocked_for_casacivil(self) -> None:
+        result = self._invoke("--tipo", "decreto", "--fonte", "casacivil")
+        assert result.exit_code != 0
+        assert "planalto" in result.output
+
+    def test_lcp_accepted_for_planalto(self) -> None:
+        with patch("leizilla.robots.is_allowed", return_value=False), \
+             patch("leizilla.wayback.save_page"):
+            result = self._invoke(
+                "--ente", "federal", "--fonte", "planalto",
+                "--tipo", "lcp", "--start-coddoc", "1", "--end-coddoc", "1",
+            )
+        assert "lcp" not in result.output or "inválido" not in result.output
+        assert result.exit_code == 0


### PR DESCRIPTION
Substitui #34 (que tinha merge conflict com M3.5 — ambos tocavam `cli.py` e `IMPLEMENTATION.md`).

## Summary

- **`fontes/federal.py`**: `discover_planalto_laws(tipo, start_num, end_num)` — candidatos de URL para lei/lcp/decreto do Planalto. Análogo ao `discover_casacivil_laws`. URLs legadas cobrem leis pré-2002; year-scoped (pós-2002) ficam para M2.8.
- **`publisher.py`**: `build_raw_meta_html` + `upload_raw_html` — sobe HTML como raw IA item (`{ia_id}.html` + `raw_meta.json`). Campo `content_type: "html"` distingue de raw PDF. Princípio #1 preservado (duas etapas no IA separadas).
- **`scraper.py`**: `scrape_one_html` — robots check → Wayback save → fetch HTML → `upload_raw_html`. Análogo a `scrape_one` para fontes PDF.
- **CLI `scrape`**: ramo `--ente federal --fonte planalto --tipo lei|lcp|decreto`. Zero breaking change para ro/assembleia e ro/casacivil.
- **`IMPLEMENTATION.md`**: M2.7 done, M2.8 adicionado (year-scoped URLs + parse-all html para leis pós-2002).

## Decisões técnicas

- **P1 Codex (URL patterns)**: discovery gera candidatos geometricamente (sem I/O). URLs legadas cobrem leis pré-2002; leis pós-2002 resultam em `fetch-failed` silencioso. Fail-open: sem crash, sem dados incorretos. M2.8 cobrirá via API Câmara. Refutação documentada no thread do PR #34.
- **Resolve conflito com M3.5**: cli.py e IMPLEMENTATION.md mesclados limpos nesta branch.

## Test plan

- [x] `uv run pytest tests/test_planalto_pipeline.py -v` → 30 passed
- [x] `uv run pytest -q` → 332+ total passando
- [ ] Smoke test manual (requer credenciais IA): `leizilla scrape --ente federal --fonte planalto --tipo lei --start-coddoc 9503 --end-coddoc 9503`

## Próximos passos

- M2.8: year-scoped URLs Planalto + `parse-all --input-type html`
- #36 (M4.2) e #33 (M5.1) aguardando CI

https://claude.ai/code/session_01HEXf8kBzFbZGBwQfSGiA8z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEXf8kBzFbZGBwQfSGiA8z)_