### PR TITLE
feat(M7.2): parse-all --skip-existing — pula raw_ids já publicados em IA

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -33,9 +33,10 @@
 | **M5.1** — Frontend Astro+Svelte+DuckDB-WASM (foundation) | 🟢 done | #33 | `web/` Astro4+Svelte5+Pico2+DuckDB-WASM1.32. Merged. |
 | **M5.2** — TanStack Query + paginação + filtros | 🟢 done | #43 | `LeiSearchUI.svelte` + filtros ente/ano + paginação. TanStack Query via bridge Svelte4 stores. Debounce cleanup + LIMIT/OFFSET safety. Merged. |
 | **M6.1** — `parse-all --output-dir` + workflow parse-release | 🟢 done | #40 | `--output-dir` em `parse-all` + `parse-release.yml` (parse→consolidate→release). 2 novos testes. Merged. |
-| **M6.2** — Deploy-web workflow | ⚪ todo | — | `deploy-web.yml` — incluído em #33 (M5.1). Ativo após M5.1 merge. |
+| **M6.2** — Deploy-web workflow | 🟢 done | #33 | `deploy-web.yml` incluído em M5.1. Ativo após merge de main. |
 | **M6.3** — Planalto year-scoped URLs (pós-2002) | 🟢 done | #41 | `planalto_year_scoped_url` + `_camara_year_lookup` (Câmara API, lru_cache, circuit breaker, 429 sem abrir circuit). 47 novos testes. Fix SCHEMA.md. Merged. |
-| **M7** — Claude Code routines | ⚪ todo | — | Depende de M6. |
+| **M7.1** — Claude Code routine infra | 🟡 in-progress | #44 | `docs/routines/maintenance-prompt.md` + `claude-routine.yml` (seg+qui 10h UTC). Aguardando CI verde. |
+| **M7.2** — `parse-all --skip-existing` | 🟡 in-progress | — | `list_parsed_raw_ids(ente, fonte)` + `--skip-existing/--no-skip-existing`. 9 novos testes. Esta sessão. |
 
 Legenda: ⚪ todo · 🟡 in-progress · 🟢 done · 🔴 blocked
 
@@ -90,6 +91,32 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-23 — M7.2: parse-all --skip-existing via consulta IA
+
+Problema: rotina automática rodando `parse-all --ente ro --fonte assembleia --start 1 --end 5000`
+re-parseia todos os 5000 itens a cada execução, gastando ~$100 em LLM desnecessariamente.
+
+**Abordagem escolhida — fetch de parsed_meta.json por item**:
+`list_parsed_raw_ids(ente, fonte)` faz (1) uma IA scrape query para listar todos os parsed items do ente,
+(2) faz N fetches de `parsed_meta.json` (um por item) para extrair `ia_id_raw`, (3) filtra pelo prefixo
+`leizilla-raw-{ente}-{fonte}-`. Retorna `set[str]` de raw_ids já processados. Fail-open: erro de rede →
+empty set (nunca pula item por falha de conectividade).
+
+**Por que não IA metadata search**: IA permite campos customizados em `--metadata key:value` mas
+indexação é assíncrona e o suporte a buscas por campos arbitrários não é garantido. A alternativa
+confiável seria adicionar `raw-id` ao campo `subject`, mas isso requer modificar `upload_parsed` E
+re-fazer uploads de items existentes para backward compat. Para o MVP, N fetches HTTP de ~1KB cada
+é mais confiável e mais simples.
+
+**Trade-off de latência**: Para RO com ~5k leis e ~100 já parseadas, lista seria 101 requests (1 search
++ 100 fetches). Tempo estimado: 100-200s (sem threading). Aceitável para rotina semanal/quinzenal.
+Se virar gargalo → M7.3 otimiza com metadata IA ou cache local (armazenado em `data/parsed_cache.json`).
+
+**`--skip-existing` não muda saída padrão**: sem a flag, comportamento idêntico ao anterior.
+Com a flag, adiciona linha "N pulados (já publicados)" no sumário.
+
+9 novos testes (5 unitários `TestListParsedRawIds`, 4 de integração `TestCmdParseAllSkipExisting`).
 
 ### 2026-05-22 — M6.1: parse-all --output-dir + parse-release workflow
 
@@ -881,8 +908,12 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 ## Próximos passos imediatos
 
-**M0–M4.3, M2.7, M2.8, M5.1, M5.2, M6.1, M6.3 concluídos** ✅
+**M0–M4.3, M2.7, M2.8, M5.1, M5.2, M6.1, M6.2, M6.3 concluídos** ✅
 
-**Nenhuma PR aberta** — todos os milestones desta sessão mergeados.
+**PRs abertas**:
+- #44 — M7.1 routine infra (CI running, aguardando merge)
+- Esta sessão — M7.2 `parse-all --skip-existing` (PR aberta, aguardando CI)
 
-**Próximo milestone**: M6.2 deploy-web workflow (`deploy-web.yml`) — ativa o frontend no GitHub Pages após M5.1 merge (já feito). Ou M7 (Claude Code routines).
+**Próximos milestones**:
+- M7.3: `parse-all --skip-existing` com metadata IA indexada (otimização — reduz N fetches de parsed_meta.json para 1 search query; decisão em M7.2 se latência for problema)
+- M5.3: benchmark DuckDB-WASM real + FTS (bloqueado por dataset com dados reais)

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -619,6 +619,11 @@ def cmd_parse_all(
         "--output-dir",
         help="Salvar XMLs parseados em {output_dir}/{ia_id_parsed}.xml (além do upload IA)",
     ),
+    skip_existing: bool = typer.Option(
+        False,
+        "--skip-existing/--no-skip-existing",
+        help="Consultar IA e pular raw_ids que já têm parsed item publicado",
+    ),
 ) -> None:
     """Batch parse: range de números → OCR/HTML → LLM → (upload para IA).
 
@@ -636,7 +641,13 @@ def cmd_parse_all(
             output_dir.mkdir(parents=True, exist_ok=True)
 
         from leizilla.parser import fetch_ia_html, fetch_ocr, parse_law
-        from leizilla.publisher import InternetArchivePublisher
+        from leizilla.publisher import InternetArchivePublisher, list_parsed_raw_ids
+
+        already_parsed: set[str] = set()
+        if skip_existing:
+            echo(f"Verificando items já parseados em IA para {ente}/{fonte}...")
+            already_parsed = list_parsed_raw_ids(ente, fonte)
+            echo(f"  {len(already_parsed)} raw_ids já publicados — serão pulados")
 
         pub = InternetArchivePublisher() if upload else None
         coddoc_range = range(start_coddoc, end_coddoc + 1)
@@ -647,6 +658,7 @@ def cmd_parse_all(
         parsed_fail = 0
         uploaded_ok = 0
         upload_fail = 0
+        skipped_ok = 0
 
         for num in coddoc_range:
             if ente == "federal" and fonte == "planalto":
@@ -654,6 +666,12 @@ def cmd_parse_all(
             else:
                 chave = f"coddoc-{num:05d}"
             raw_id = f"leizilla-raw-{ente}-{fonte}-{chave}"
+
+            if skip_existing and raw_id in already_parsed:
+                echo(f"[{num}] {raw_id} — já publicado, skip")
+                skipped_ok += 1
+                continue
+
             echo(f"[{num}] {raw_id}")
 
             try:
@@ -711,6 +729,7 @@ def cmd_parse_all(
 
         echo(
             f"\nBatch concluído: {parsed_ok} parseados, {parsed_fail} falhos"
+            + (f", {skipped_ok} pulados (já publicados)" if skip_existing else "")
             + (f", {uploaded_ok} uploaded" if upload else "")
             + (f", {upload_fail} erros de upload" if upload and upload_fail else "")
         )

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -153,6 +153,8 @@ def list_parsed_raw_ids(ente: str, fonte: str) -> Set[str]:
     each item's parsed_meta.json to extract ia_id_raw.  Only IDs from the
     given fonte are returned.
 
+    Follows IA scrape API cursor for full pagination — never truncates at
+    one page even for large collections (e.g. federal).
     Fail-open: returns empty set on any network error so parse-all never
     silently skips items due to connectivity issues.
     """
@@ -162,19 +164,27 @@ def list_parsed_raw_ids(ente: str, fonte: str) -> Set[str]:
         f"AND NOT identifier:leizilla-bundle-{ente}-* "
         f"AND NOT identifier:leizilla-dataset-{ente}-*"
     )
-    search_url = (
+    base_url = (
         f"{_IA_SCRAPE_URL}?q={urllib.parse.quote(q)}&count=10000&fields=identifier"
     )
 
-    try:
-        req = urllib.request.Request(
-            search_url, headers={"User-Agent": _USER_AGENT}
-        )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.loads(resp.read())
-        parsed_ids = [item["identifier"] for item in data.get("items", [])]
-    except Exception:
-        return set()
+    parsed_ids: list[str] = []
+    cursor: Optional[str] = None
+
+    while True:
+        url = base_url
+        if cursor:
+            url += f"&cursor={urllib.parse.quote(cursor)}"
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = json.loads(resp.read())
+            parsed_ids.extend(item["identifier"] for item in data.get("items", []))
+            cursor = data.get("cursor")
+            if not cursor:
+                break
+        except Exception:
+            return set()
 
     raw_ids: Set[str] = set()
     prefix = f"leizilla-raw-{ente}-{fonte}-"

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -6,9 +6,11 @@ import re
 import shutil
 import subprocess
 import tempfile
+import urllib.parse
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 from leizilla import config
 from leizilla import storage as storage_module
@@ -137,6 +139,61 @@ def build_dataset_meta(
     if effective_git_sha:
         meta["git_sha"] = effective_git_sha
     return meta
+
+
+_IA_SCRAPE_URL = "https://archive.org/services/search/v1/scrape"
+_IA_DOWNLOAD_URL = "https://archive.org/download"
+
+
+def list_parsed_raw_ids(ente: str, fonte: str) -> Set[str]:
+    """Return raw item IDs that have already been parsed and uploaded to IA.
+
+    Queries IA for all parsed items of the ente (identifiers matching
+    leizilla-{ente}-* excluding raw/bundle/dataset variants), then fetches
+    each item's parsed_meta.json to extract ia_id_raw.  Only IDs from the
+    given fonte are returned.
+
+    Fail-open: returns empty set on any network error so parse-all never
+    silently skips items due to connectivity issues.
+    """
+    q = (
+        f"identifier:leizilla-{ente}-* "
+        f"AND NOT identifier:leizilla-raw-{ente}-* "
+        f"AND NOT identifier:leizilla-bundle-{ente}-* "
+        f"AND NOT identifier:leizilla-dataset-{ente}-*"
+    )
+    search_url = (
+        f"{_IA_SCRAPE_URL}?q={urllib.parse.quote(q)}&count=10000&fields=identifier"
+    )
+
+    try:
+        req = urllib.request.Request(
+            search_url, headers={"User-Agent": _USER_AGENT}
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+        parsed_ids = [item["identifier"] for item in data.get("items", [])]
+    except Exception:
+        return set()
+
+    raw_ids: Set[str] = set()
+    prefix = f"leizilla-raw-{ente}-{fonte}-"
+
+    for ia_id_parsed in parsed_ids:
+        meta_url = f"{_IA_DOWNLOAD_URL}/{ia_id_parsed}/parsed_meta.json"
+        try:
+            req = urllib.request.Request(
+                meta_url, headers={"User-Agent": _USER_AGENT}
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                meta = json.loads(resp.read())
+            raw_id = str(meta.get("ia_id_raw", ""))
+            if raw_id.startswith(prefix):
+                raw_ids.add(raw_id)
+        except Exception:
+            continue
+
+    return raw_ids
 
 
 class InternetArchivePublisher:

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -624,6 +624,104 @@ class TestCmdParseAll:
         assert not any(out.glob("*.xml"))
 
 
+class TestCmdParseAllSkipExisting:
+    """Testes para --skip-existing em parse-all."""
+
+    def test_skip_existing_skips_already_parsed_items(self):
+        """Items cujo raw_id está em already_parsed são pulados sem fetch/parse."""
+        raw_id = "leizilla-raw-ro-assembleia-coddoc-00001"
+        with (
+            patch(
+                "leizilla.publisher.list_parsed_raw_ids",
+                return_value={raw_id},
+            ),
+            patch("leizilla.parser.fetch_ocr") as mock_ocr,
+            patch("leizilla.parser.parse_law") as mock_parse,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "parse-all",
+                    "--start-coddoc", "1",
+                    "--end-coddoc", "1",
+                    "--skip-existing",
+                    "--no-upload",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "já publicado, skip" in result.output
+        mock_ocr.assert_not_called()
+        mock_parse.assert_not_called()
+
+    def test_skip_existing_reports_skipped_count_in_summary(self):
+        raw_ids = {
+            "leizilla-raw-ro-assembleia-coddoc-00001",
+            "leizilla-raw-ro-assembleia-coddoc-00002",
+        }
+        with (
+            patch("leizilla.publisher.list_parsed_raw_ids", return_value=raw_ids),
+            patch("leizilla.parser.fetch_ocr", return_value=None),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "parse-all",
+                    "--start-coddoc", "1",
+                    "--end-coddoc", "2",
+                    "--skip-existing",
+                    "--no-upload",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "2 pulados (já publicados)" in result.output
+
+    def test_no_skip_existing_processes_all_items(self):
+        """Sem --skip-existing, list_parsed_raw_ids não é chamado."""
+        with (
+            patch("leizilla.publisher.list_parsed_raw_ids") as mock_list,
+            patch("leizilla.parser.fetch_ocr", return_value=None),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "parse-all",
+                    "--start-coddoc", "1",
+                    "--end-coddoc", "2",
+                    "--no-skip-existing",
+                    "--no-upload",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_list.assert_not_called()
+
+    def test_skip_existing_network_error_falls_through(self):
+        """Falha de rede em list_parsed_raw_ids → empty set → nenhum skip."""
+        with (
+            patch(
+                "leizilla.publisher.list_parsed_raw_ids",
+                return_value=set(),
+            ),
+            patch("leizilla.parser.fetch_ocr", return_value="ocr"),
+            patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT),
+            patch("leizilla.cli._xsd_gate", return_value=True),
+            patch(
+                "leizilla.publisher.InternetArchivePublisher.upload_parsed",
+                return_value=_UPLOAD_OK,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "parse-all",
+                    "--start-coddoc", "1",
+                    "--end-coddoc", "1",
+                    "--skip-existing",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "1 parseados" in result.output
+
+
 class TestCmdParseXsdGateBlocking:
     def test_parse_upload_blocked_when_xsd_fails(self):
         with (

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -11,6 +11,7 @@ from leizilla.publisher import (
     _raw_identifier,
     _bundle_identifier,
     build_raw_meta,
+    list_parsed_raw_ids,
     InternetArchivePublisher,
 )
 
@@ -212,3 +213,106 @@ class TestUploadParsed:
             )
         assert result["success"] is False
         assert "upload failed" in result["error"]
+
+
+class TestListParsedRawIds:
+    """Testes para list_parsed_raw_ids — consulta IA sem credenciais."""
+
+    def _make_urlopen(self, responses: list):
+        """Retorna mock para urllib.request.urlopen que serve respostas sequenciais."""
+        calls = iter(responses)
+
+        class _FakeResponse:
+            def __init__(self, data: bytes):
+                self._data = data
+
+            def read(self):
+                return self._data
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResponse(next(calls))
+
+        return fake_urlopen
+
+    def test_returns_empty_set_on_search_network_error(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("network")):
+            result = list_parsed_raw_ids("ro", "assembleia")
+        assert result == set()
+
+    def test_returns_empty_set_when_no_parsed_items(self):
+        scrape_resp = json.dumps({"items": []}).encode()
+        urlopen = self._make_urlopen([scrape_resp])
+        with patch("urllib.request.urlopen", side_effect=urlopen):
+            result = list_parsed_raw_ids("ro", "assembleia")
+        assert result == set()
+
+    def test_returns_raw_ids_matching_fonte(self):
+        scrape_resp = json.dumps(
+            {"items": [{"identifier": "leizilla-ro-lei-00001-2000"}]}
+        ).encode()
+        meta_resp = json.dumps(
+            {"ia_id_raw": "leizilla-raw-ro-assembleia-coddoc-00001"}
+        ).encode()
+        urlopen = self._make_urlopen([scrape_resp, meta_resp])
+        with patch("urllib.request.urlopen", side_effect=urlopen):
+            result = list_parsed_raw_ids("ro", "assembleia")
+        assert result == {"leizilla-raw-ro-assembleia-coddoc-00001"}
+
+    def test_filters_out_different_fonte(self):
+        scrape_resp = json.dumps(
+            {"items": [{"identifier": "leizilla-ro-lei-00001-2000"}]}
+        ).encode()
+        # raw_id belongs to casacivil, not assembleia
+        meta_resp = json.dumps(
+            {"ia_id_raw": "leizilla-raw-ro-casacivil-coddoc-00001"}
+        ).encode()
+        urlopen = self._make_urlopen([scrape_resp, meta_resp])
+        with patch("urllib.request.urlopen", side_effect=urlopen):
+            result = list_parsed_raw_ids("ro", "assembleia")
+        assert result == set()
+
+    def test_skips_items_whose_meta_fetch_fails(self):
+        scrape_resp = json.dumps(
+            {
+                "items": [
+                    {"identifier": "leizilla-ro-lei-00001-2000"},
+                    {"identifier": "leizilla-ro-lei-00002-2001"},
+                ]
+            }
+        ).encode()
+        meta_ok = json.dumps(
+            {"ia_id_raw": "leizilla-raw-ro-assembleia-coddoc-00002"}
+        ).encode()
+
+        call_count = {"n": 0}
+
+        def urlopen_with_first_meta_fail(req, timeout=None):
+            class _R:
+                def __init__(self, data):
+                    self._data = data
+
+                def read(self):
+                    return self._data
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *a):
+                    pass
+
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _R(scrape_resp)
+            if call_count["n"] == 2:
+                raise OSError("meta fetch failed")
+            return _R(meta_ok)
+
+        with patch("urllib.request.urlopen", side_effect=urlopen_with_first_meta_fail):
+            result = list_parsed_raw_ids("ro", "assembleia")
+        assert result == {"leizilla-raw-ro-assembleia-coddoc-00002"}

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -316,3 +316,64 @@ class TestListParsedRawIds:
         with patch("urllib.request.urlopen", side_effect=urlopen_with_first_meta_fail):
             result = list_parsed_raw_ids("ro", "assembleia")
         assert result == {"leizilla-raw-ro-assembleia-coddoc-00002"}
+
+    def test_follows_cursor_for_pagination(self):
+        """IA scrape API retorna cursor → segunda requisição busca próxima página."""
+        page1 = json.dumps(
+            {
+                "items": [{"identifier": "leizilla-ro-lei-00001-2000"}],
+                "cursor": "abc123",
+            }
+        ).encode()
+        page2 = json.dumps(
+            {"items": [{"identifier": "leizilla-ro-lei-00002-2001"}]}
+        ).encode()
+        meta1 = json.dumps(
+            {"ia_id_raw": "leizilla-raw-ro-assembleia-coddoc-00001"}
+        ).encode()
+        meta2 = json.dumps(
+            {"ia_id_raw": "leizilla-raw-ro-assembleia-coddoc-00002"}
+        ).encode()
+        urlopen = self._make_urlopen([page1, page2, meta1, meta2])
+        with patch("urllib.request.urlopen", side_effect=urlopen) as mock_open:
+            result = list_parsed_raw_ids("ro", "assembleia")
+        assert result == {
+            "leizilla-raw-ro-assembleia-coddoc-00001",
+            "leizilla-raw-ro-assembleia-coddoc-00002",
+        }
+        # Verifica que o cursor foi passado na segunda chamada de scrape
+        second_call_url = mock_open.call_args_list[1][0][0].full_url
+        assert "cursor=abc123" in second_call_url
+
+    def test_returns_empty_set_on_second_page_error(self):
+        """Erro na 2ª página do cursor → fail-open retorna set() (não resultado parcial)."""
+        page1 = json.dumps(
+            {
+                "items": [{"identifier": "leizilla-ro-lei-00001-2000"}],
+                "cursor": "abc123",
+            }
+        ).encode()
+        call_count = {"n": 0}
+
+        def urlopen_fail_on_second(req, timeout=None):
+            class _R:
+                def __init__(self, data):
+                    self._data = data
+
+                def read(self):
+                    return self._data
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *a):
+                    pass
+
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _R(page1)
+            raise OSError("second page network error")
+
+        with patch("urllib.request.urlopen", side_effect=urlopen_fail_on_second):
+            result = list_parsed_raw_ids("ro", "assembleia")
+        assert result == set()


### PR DESCRIPTION
## Summary

- **`publisher.list_parsed_raw_ids(ente, fonte) → set[str]`**: consulta IA scrape API para listar todos os parsed items do ente, depois fetcha cada `parsed_meta.json` para extrair `ia_id_raw`, filtrando pelo prefixo `leizilla-raw-{ente}-{fonte}-`. Fail-open: erro de rede → empty set.
- **`parse-all --skip-existing/--no-skip-existing`** (default `False`): chama `list_parsed_raw_ids` antes do loop; itens no set são pulados com log "já publicado, skip". Sumário inclui "N pulados (já publicados)".
- **`IMPLEMENTATION.md`** atualizado: M6.2 → done, M7.1 → in-progress (#44), M7.2 → in-progress (esta PR). Entrada no log de decisões com design rationale.

## Trade-offs aceitos

- **N fetches de `parsed_meta.json`** em vez de IA metadata search: mais confiável (sem dependência de indexação assíncrona do IA), mais simples (sem modificar `upload_parsed`). Para RO com ~100 itens já parseados: ~101 requests HTTP de ~1KB = ~100-200s. Aceitável para rotina semanal. Se virar gargalo → M7.3 otimiza com `subject:raw-{raw_id}` em metadata IA.
- **Fail-open**: erro de rede em `list_parsed_raw_ids` retorna empty set — nunca silencia itens por falha de conectividade. Pior caso: re-parseia itens já feitos (gasto de LLM), não silencia itens novos.
- **Backward compatible**: sem `--skip-existing`, comportamento idêntico ao anterior.

## Test plan

- [x] `uv run pytest` — 407 passed, 13 skipped
- [x] `TestListParsedRawIds` (5 testes): empty set em erro de rede, filtragem por fonte, skip de meta fetch que falha
- [x] `TestCmdParseAllSkipExisting` (4 testes): skip com log, sumário com contagem, `list_parsed_raw_ids` não chamado sem flag, fallback via empty set
- [x] Lint limpo (erro `F821` em `test_planalto_pipeline.py` é pré-existente, não introduzido)

## Próximos passos pendentes

- M7.1 (#44): workflow `claude-routine.yml` — aguardando CI verde para merge
- M7.3 (deferido): otimizar `list_parsed_raw_ids` com metadata IA indexada — só se latência virar problema real
- M5.3: benchmark DuckDB-WASM real + FTS

https://claude.ai/code/session_01CHo5y39GyDDYGDksgwbf1d

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHo5y39GyDDYGDksgwbf1d)_