### PR TITLE
feat: enhance Internet Archive upload metadata and allow age limit bypass in Wayback Machine

### DIFF
--- a/src/leizilla/config.py
+++ b/src/leizilla/config.py
@@ -12,6 +12,7 @@ DUCKDB_PATH = Path(os.getenv("DUCKDB_PATH", str(DATA_DIR / "leizilla.duckdb")))
 
 IA_ACCESS_KEY: Optional[str] = os.getenv("IA_ACCESS_KEY")
 IA_SECRET_KEY: Optional[str] = os.getenv("IA_SECRET_KEY")
+IA_COLLECTION: Optional[str] = os.getenv("IA_COLLECTION")
 ANTHROPIC_API_KEY: Optional[str] = os.getenv("ANTHROPIC_API_KEY")
 
 CRAWLER_DELAY = int(os.getenv("CRAWLER_DELAY", "2000"))

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -158,6 +158,7 @@ class InternetArchivePublisher:
     def __init__(self) -> None:
         self.access_key = config.IA_ACCESS_KEY
         self.secret_key = config.IA_SECRET_KEY
+        self.collection = config.IA_COLLECTION
 
     def upload_raw(
         self,
@@ -190,23 +191,51 @@ class InternetArchivePublisher:
             meta_path = Path(tmp) / "raw_meta.json"
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
 
+            desc_text = f"Documento original (PDF) da legislação do ente federativo {ente.upper()}, fonte {fonte}, chave {chave}, capturado pelo projeto Leizilla."
+            try:
+                from leizilla.entes import get_ente
+
+                ente_obj = get_ente(ente)
+                if ente_obj.tipo == "federal":
+                    coverage = "Brazil"
+                else:
+                    coverage = f"{ente_obj.nome}, Brazil"
+            except Exception:
+                coverage = "Brazil"
+
+            ia_args = [
+                "ia",
+                "upload",
+                ia_id,
+                str(pdf_dst),
+                str(meta_path),
+                "--metadata",
+                f"title:{lei_data.get('titulo', 'Lei')}",
+                "--metadata",
+                "mediatype:texts",
+                "--metadata",
+                f"subject:leis;leizilla;{ente};{fonte}",
+                "--metadata",
+                "creator:leizilla-crawler",
+                "--metadata",
+                "language:por",
+                "--metadata",
+                f"description:{desc_text}",
+                "--metadata",
+                f"coverage:{coverage}",
+            ]
+
+            ano = lei_data.get("ano")
+            if ano:
+                ia_args.extend(["--metadata", f"date:{ano}"])
+
+            collection = getattr(self, "collection", None)
+            if collection:
+                ia_args.extend(["--metadata", f"collection:{collection}"])
+
             try:
                 subprocess.run(
-                    [
-                        "ia",
-                        "upload",
-                        ia_id,
-                        str(pdf_dst),
-                        str(meta_path),
-                        "--metadata",
-                        f"title:{lei_data.get('titulo', 'Lei')}",
-                        "--metadata",
-                        "mediatype:texts",
-                        "--metadata",
-                        f"subject:leis;leizilla;{ente}",
-                        "--metadata",
-                        "creator:leizilla-crawler",
-                    ],
+                    ia_args,
                     capture_output=True,
                     text=True,
                     check=True,
@@ -250,23 +279,51 @@ class InternetArchivePublisher:
             meta_path = Path(tmp) / "raw_meta.json"
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
 
+            desc_text = f"Documento original (HTML) da legislação do ente federativo {ente.upper()}, fonte {fonte}, chave {chave}, capturado pelo projeto Leizilla."
+            try:
+                from leizilla.entes import get_ente
+
+                ente_obj = get_ente(ente)
+                if ente_obj.tipo == "federal":
+                    coverage = "Brazil"
+                else:
+                    coverage = f"{ente_obj.nome}, Brazil"
+            except Exception:
+                coverage = "Brazil"
+
+            ia_args = [
+                "ia",
+                "upload",
+                ia_id,
+                str(html_dst),
+                str(meta_path),
+                "--metadata",
+                f"title:{lei_data.get('titulo', 'Lei')}",
+                "--metadata",
+                "mediatype:texts",
+                "--metadata",
+                f"subject:leis;leizilla;{ente};{fonte}",
+                "--metadata",
+                "creator:leizilla-crawler",
+                "--metadata",
+                "language:por",
+                "--metadata",
+                f"description:{desc_text}",
+                "--metadata",
+                f"coverage:{coverage}",
+            ]
+
+            ano = lei_data.get("ano")
+            if ano:
+                ia_args.extend(["--metadata", f"date:{ano}"])
+
+            collection = getattr(self, "collection", None)
+            if collection:
+                ia_args.extend(["--metadata", f"collection:{collection}"])
+
             try:
                 subprocess.run(
-                    [
-                        "ia",
-                        "upload",
-                        ia_id,
-                        str(html_dst),
-                        str(meta_path),
-                        "--metadata",
-                        f"title:{lei_data.get('titulo', 'Lei')}",
-                        "--metadata",
-                        "mediatype:texts",
-                        "--metadata",
-                        f"subject:leis;leizilla;{ente}",
-                        "--metadata",
-                        "creator:leizilla-crawler",
-                    ],
+                    ia_args,
                     capture_output=True,
                     text=True,
                     check=True,
@@ -311,23 +368,55 @@ class InternetArchivePublisher:
                 json.dumps(parsed_meta, indent=2, ensure_ascii=False), encoding="utf-8"
             )
 
+            urn_match = re.search(r'urn-lex="([^"]+)"', xml_content)
+            urn = urn_match.group(1) if urn_match else "unknown"
+            desc_text = f"Representação estruturada (XML) da legislação do ente federativo {ente.upper()}, identificador {ia_id_parsed}, URN {urn}, processada pelo parser do projeto Leizilla."
+
+            try:
+                from leizilla.entes import get_ente
+
+                ente_obj = get_ente(ente)
+                if ente_obj.tipo == "federal":
+                    coverage = "Brazil"
+                else:
+                    coverage = f"{ente_obj.nome}, Brazil"
+            except Exception:
+                coverage = "Brazil"
+
+            ia_args = [
+                "ia",
+                "upload",
+                ia_id_parsed,
+                str(xml_path),
+                str(meta_path),
+                "--metadata",
+                f"title:{titulo}",
+                "--metadata",
+                "mediatype:texts",
+                "--metadata",
+                f"subject:leis;leizilla;{ente};{tipo}",
+                "--metadata",
+                "creator:leizilla-parser",
+                "--metadata",
+                "language:por",
+                "--metadata",
+                f"description:{desc_text}",
+                "--metadata",
+                f"coverage:{coverage}",
+            ]
+
+            parts = ia_id_parsed.split("-")
+            ano = parts[-1] if parts and parts[-1].isdigit() else None
+            if ano:
+                ia_args.extend(["--metadata", f"date:{ano}"])
+
+            collection = getattr(self, "collection", None)
+            if collection:
+                ia_args.extend(["--metadata", f"collection:{collection}"])
+
             try:
                 subprocess.run(
-                    [
-                        "ia",
-                        "upload",
-                        ia_id_parsed,
-                        str(xml_path),
-                        str(meta_path),
-                        "--metadata",
-                        f"title:{titulo}",
-                        "--metadata",
-                        "mediatype:texts",
-                        "--metadata",
-                        f"subject:leis;leizilla;{ente};{tipo}",
-                        "--metadata",
-                        "creator:leizilla-parser",
-                    ],
+                    ia_args,
                     capture_output=True,
                     text=True,
                     check=True,
@@ -380,23 +469,47 @@ class InternetArchivePublisher:
                 json.dumps(dataset_meta, indent=2, ensure_ascii=False), encoding="utf-8"
             )
 
+            desc_text = f"Dataset consolidado (Parquet) da legislação do ente federativo {ente.upper()}, versão {version}, gerado pelo projeto Leizilla."
+            try:
+                from leizilla.entes import get_ente
+
+                ente_obj = get_ente(ente)
+                if ente_obj.tipo == "federal":
+                    coverage = "Brazil"
+                else:
+                    coverage = f"{ente_obj.nome}, Brazil"
+            except Exception:
+                coverage = "Brazil"
+
+            ia_args = [
+                "ia",
+                "upload",
+                ia_id,
+                str(parquet_dst),
+                str(meta_path),
+                "--metadata",
+                f"title:Leizilla Dataset {ente.upper()} v{version}",
+                "--metadata",
+                "mediatype:data",
+                "--metadata",
+                f"subject:leis;leizilla;{ente};parquet;versoes",
+                "--metadata",
+                "creator:leizilla-etl",
+                "--metadata",
+                "language:por",
+                "--metadata",
+                f"description:{desc_text}",
+                "--metadata",
+                f"coverage:{coverage}",
+            ]
+
+            collection = getattr(self, "collection", None)
+            if collection:
+                ia_args.extend(["--metadata", f"collection:{collection}"])
+
             try:
                 subprocess.run(
-                    [
-                        "ia",
-                        "upload",
-                        ia_id,
-                        str(parquet_dst),
-                        str(meta_path),
-                        "--metadata",
-                        f"title:Leizilla Dataset {ente.upper()} v{version}",
-                        "--metadata",
-                        "mediatype:data",
-                        "--metadata",
-                        f"subject:leis;leizilla;{ente};parquet;versoes",
-                        "--metadata",
-                        "creator:leizilla-etl",
-                    ],
+                    ia_args,
                     capture_output=True,
                     text=True,
                     check=True,

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -160,6 +160,16 @@ class InternetArchivePublisher:
         self.secret_key = config.IA_SECRET_KEY
         self.collection = config.IA_COLLECTION
 
+    def _ia_env(self) -> Dict[str, str]:
+        import os
+
+        env = os.environ.copy()
+        if self.access_key:
+            env["IA_ACCESS_KEY_ID"] = self.access_key
+        if self.secret_key:
+            env["IA_SECRET_ACCESS_KEY"] = self.secret_key
+        return env
+
     def upload_raw(
         self,
         pdf_path: Path,
@@ -236,6 +246,7 @@ class InternetArchivePublisher:
             try:
                 subprocess.run(
                     ia_args,
+                    env=self._ia_env(),
                     capture_output=True,
                     text=True,
                     check=True,
@@ -324,6 +335,7 @@ class InternetArchivePublisher:
             try:
                 subprocess.run(
                     ia_args,
+                    env=self._ia_env(),
                     capture_output=True,
                     text=True,
                     check=True,
@@ -417,6 +429,7 @@ class InternetArchivePublisher:
             try:
                 subprocess.run(
                     ia_args,
+                    env=self._ia_env(),
                     capture_output=True,
                     text=True,
                     check=True,
@@ -510,6 +523,7 @@ class InternetArchivePublisher:
             try:
                 subprocess.run(
                     ia_args,
+                    env=self._ia_env(),
                     capture_output=True,
                     text=True,
                     check=True,

--- a/src/leizilla/wayback.py
+++ b/src/leizilla/wayback.py
@@ -18,9 +18,11 @@ _USER_AGENT = (
 _MAX_AGE_SECONDS = 24 * 3600
 
 
-def check_available(url: str, max_age_seconds: int = _MAX_AGE_SECONDS) -> Optional[str]:
-    """Retorna URL do snapshot Wayback mais recente se fresco (< max_age_seconds).
+def check_available(url: str, max_age_seconds: Optional[int] = None) -> Optional[str]:
+    """Retorna URL do snapshot Wayback mais recente.
 
+    Se max_age_seconds for informado, filtra para garantir que o snapshot
+    seja fresco (< max_age_seconds).
     None se não existe snapshot, se expirou, ou se a API falhar (fail-open).
     """
     try:
@@ -44,9 +46,11 @@ def check_available(url: str, max_age_seconds: int = _MAX_AGE_SECONDS) -> Option
         snapshot_dt = datetime.strptime(timestamp_str, "%Y%m%d%H%M%S").replace(
             tzinfo=timezone.utc
         )
-        age = (datetime.now(tz=timezone.utc) - snapshot_dt).total_seconds()
-        if age <= max_age_seconds:
-            return str(snapshot.get("url", ""))
+        if max_age_seconds is not None:
+            age = (datetime.now(tz=timezone.utc) - snapshot_dt).total_seconds()
+            if age > max_age_seconds:
+                return None
+        return str(snapshot.get("url", ""))
     except ValueError:
         pass
     return None

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import json
+import os
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -166,7 +168,9 @@ class TestUploadParsed:
         def capture_run(cmd, **kwargs):
             for arg in cmd:
                 if arg.endswith("law.xml"):
-                    captured_files.append(Path(arg).read_text())
+                    real_path = os.path.realpath(arg)
+                    assert real_path.startswith(os.path.realpath(tempfile.gettempdir()))
+                    captured_files.append(Path(real_path).read_text())
             return MagicMock(returncode=0)
 
         with patch("subprocess.run", side_effect=capture_run):
@@ -182,7 +186,9 @@ class TestUploadParsed:
         def capture_run(cmd, **kwargs):
             for arg in cmd:
                 if arg.endswith("parsed_meta.json"):
-                    captured_metas.append(json.loads(Path(arg).read_text()))
+                    real_path = os.path.realpath(arg)
+                    assert real_path.startswith(os.path.realpath(tempfile.gettempdir()))
+                    captured_metas.append(json.loads(Path(real_path).read_text()))
             return MagicMock(returncode=0)
 
         with patch("subprocess.run", side_effect=capture_run):
@@ -212,3 +218,130 @@ class TestUploadParsed:
             )
         assert result["success"] is False
         assert "upload failed" in result["error"]
+
+    def test_metadata_fields_are_passed(self):
+        pub = self._publisher()
+        pub.collection = "test-collection"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            pub.upload_parsed("leizilla-ro-lei-00042-1990", _XML_CONTENT, _PARSED_META)
+
+        call_args = mock_run.call_args[0][0]
+        metadata_pairs = {}
+        for i in range(len(call_args) - 1):
+            if call_args[i] == "--metadata":
+                k, v = call_args[i + 1].split(":", 1)
+                metadata_pairs[k] = v
+
+        assert metadata_pairs["language"] == "por"
+        assert "Rondônia, Brazil" in metadata_pairs["coverage"]
+        assert metadata_pairs["date"] == "1990"
+        assert metadata_pairs["collection"] == "test-collection"
+        assert "URN" in metadata_pairs["description"]
+
+
+class TestUploadRaw:
+    def _publisher(self) -> InternetArchivePublisher:
+        pub = InternetArchivePublisher()
+        pub.access_key = "test-key"
+        pub.secret_key = "test-secret"
+        pub.collection = "test-collection"
+        return pub
+
+    def test_upload_raw_metadata(self, tmp_path):
+        pub = self._publisher()
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_bytes(b"pdf data")
+
+        lei_data = {
+            "ente": "ro",
+            "fonte": "casacivil",
+            "chave": "coddoc-00042",
+            "titulo": "Lei 42/1990",
+            "ano": "1990",
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            pub.upload_raw(pdf_path, lei_data, b"pdf data")
+
+        call_args = mock_run.call_args[0][0]
+        metadata_pairs = {}
+        for i in range(len(call_args) - 1):
+            if call_args[i] == "--metadata":
+                k, v = call_args[i + 1].split(":", 1)
+                metadata_pairs[k] = v
+
+        assert metadata_pairs["language"] == "por"
+        assert "Rondônia, Brazil" in metadata_pairs["coverage"]
+        assert metadata_pairs["date"] == "1990"
+        assert metadata_pairs["collection"] == "test-collection"
+        assert "Documento original (PDF)" in metadata_pairs["description"]
+
+
+class TestUploadRawHtml:
+    def _publisher(self) -> InternetArchivePublisher:
+        pub = InternetArchivePublisher()
+        pub.access_key = "test-key"
+        pub.secret_key = "test-secret"
+        pub.collection = "test-collection"
+        return pub
+
+    def test_upload_raw_html_metadata(self):
+        pub = self._publisher()
+        lei_data = {
+            "ente": "federal",
+            "fonte": "planalto",
+            "chave": "lei-14133-2021",
+            "titulo": "Lei 14133/2021",
+            "ano": 2021,
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            pub.upload_raw_html("<html></html>", lei_data)
+
+        call_args = mock_run.call_args[0][0]
+        metadata_pairs = {}
+        for i in range(len(call_args) - 1):
+            if call_args[i] == "--metadata":
+                k, v = call_args[i + 1].split(":", 1)
+                metadata_pairs[k] = v
+
+        assert metadata_pairs["language"] == "por"
+        assert metadata_pairs["coverage"] == "Brazil"
+        assert metadata_pairs["date"] == "2021"
+        assert metadata_pairs["collection"] == "test-collection"
+        assert "Documento original (HTML)" in metadata_pairs["description"]
+
+
+class TestUploadDataset:
+    def _publisher(self) -> InternetArchivePublisher:
+        pub = InternetArchivePublisher()
+        pub.access_key = "test-key"
+        pub.secret_key = "test-secret"
+        pub.collection = "test-collection"
+        return pub
+
+    def test_upload_dataset_metadata(self, tmp_path):
+        pub = self._publisher()
+        parquet_path = tmp_path / "versoes.parquet"
+        parquet_path.write_bytes(b"parquet data")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            pub.upload_dataset(
+                parquet_path, "ro", version=1, row_count=10, git_sha="fake-git-sha"
+            )
+
+        call_args = mock_run.call_args[0][0]
+        metadata_pairs = {}
+        for i in range(len(call_args) - 1):
+            if call_args[i] == "--metadata":
+                k, v = call_args[i + 1].split(":", 1)
+                metadata_pairs[k] = v
+
+        assert metadata_pairs["language"] == "por"
+        assert "Rondônia, Brazil" in metadata_pairs["coverage"]
+        assert metadata_pairs["collection"] == "test-collection"
+        assert "Dataset consolidado" in metadata_pairs["description"]

--- a/tests/test_wayback.py
+++ b/tests/test_wayback.py
@@ -48,8 +48,24 @@ class TestCheckAvailable:
             }
         }
         with patch("urllib.request.urlopen", return_value=_mock_urlopen(data)):
-            result = wayback.check_available("https://example.gov.br")
+            result = wayback.check_available(
+                "https://example.gov.br", max_age_seconds=24 * 3600
+            )
         assert result is None
+
+    def test_returns_old_snapshot_when_no_max_age_limit(self):
+        data = {
+            "archived_snapshots": {
+                "closest": {
+                    "status": "200",
+                    "timestamp": _ts(25),  # 25h atrás
+                    "url": "https://web.archive.org/web/old/https://example.gov.br",
+                }
+            }
+        }
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(data)):
+            result = wayback.check_available("https://example.gov.br")
+        assert result == "https://web.archive.org/web/old/https://example.gov.br"
 
     def test_returns_none_when_no_snapshot(self):
         data = {"archived_snapshots": {}}


### PR DESCRIPTION
This PR adds enhanced metadata fields (language, coverage, date, description, and collection) for the Internet Archive upload methods (raw, raw HTML, parsed, and dataset). It also makes the maximum age limit optional in the Wayback Machine check to allow reusing old snapshots of static PDFs.