### PR TITLE
feat(M7.3): metadata IA enriquecida — language + coverage + description

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -33,9 +33,11 @@
 | **M5.1** — Frontend Astro+Svelte+DuckDB-WASM (foundation) | 🟢 done | #33 | `web/` Astro4+Svelte5+Pico2+DuckDB-WASM1.32. Merged. |
 | **M5.2** — TanStack Query + paginação + filtros | 🟢 done | #43 | `LeiSearchUI.svelte` + filtros ente/ano + paginação. TanStack Query via bridge Svelte4 stores. Debounce cleanup + LIMIT/OFFSET safety. Merged. |
 | **M6.1** — `parse-all --output-dir` + workflow parse-release | 🟢 done | #40 | `--output-dir` em `parse-all` + `parse-release.yml` (parse→consolidate→release). 2 novos testes. Merged. |
-| **M6.2** — Deploy-web workflow | ⚪ todo | — | `deploy-web.yml` — incluído em #33 (M5.1). Ativo após M5.1 merge. |
+| **M6.2** — Deploy-web workflow | 🟢 done | #33 | `deploy-web.yml` — incluído em M5.1 (#33). Ativo. |
 | **M6.3** — Planalto year-scoped URLs (pós-2002) | 🟢 done | #41 | `planalto_year_scoped_url` + `_camara_year_lookup` (Câmara API, lru_cache, circuit breaker, 429 sem abrir circuit). 47 novos testes. Fix SCHEMA.md. Merged. |
-| **M7** — Claude Code routines | ⚪ todo | — | Depende de M6. |
+| **M7.1** — Claude Code routines: infra de automação | 🟢 done | #44 | `docs/routines/maintenance-prompt.md` + `claude-routine.yml` (schedule: seg+qui 10h UTC). Merged. |
+| **M7.2** — `parse-all --skip-existing` | 🟡 in-progress | #46 | `list_parsed_raw_ids` + cursor paginação + 2 novos testes. Aguardando CI. |
+| **M7.3** — Metadata IA enriquecida (language + coverage + description) | 🟡 in-progress | — | `_entity_coverage` helper + 4 upload methods enriquecidos. Esta sessão. |
 
 Legenda: ⚪ todo · 🟡 in-progress · 🟢 done · 🔴 blocked
 
@@ -881,8 +883,11 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 ## Próximos passos imediatos
 
-**M0–M4.3, M2.7, M2.8, M5.1, M5.2, M6.1, M6.3 concluídos** ✅
+**M0–M7.1 concluídos** ✅
 
-**Nenhuma PR aberta** — todos os milestones desta sessão mergeados.
+**PRs abertas**:
+- **#44** (M7.1): aguardando Kilo CI rerun após merge-conflict fix.
+- **#46** (M7.2): `parse-all --skip-existing` + fix paginação cursor. Aguardando CI.
+- **Esta sessão** (M7.3): metadata IA enriquecida — `language:pt`, `coverage`, `description` em todos os uploads.
 
-**Próximo milestone**: M6.2 deploy-web workflow (`deploy-web.yml`) — ativa o frontend no GitHub Pages após M5.1 merge (já feito). Ou M7 (Claude Code routines).
+**Próximo após M7.3**: M5.3 — benchmark DuckDB-WASM real com dataset publicado; índice FTS se latência > threshold.

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -18,6 +18,16 @@ _DATASET_IDENTIFIER_RE = r"^leizilla-dataset-(?P<ente>[a-z][a-z0-9-]*)-v(?P<vers
 _USER_AGENT = "leizilla-crawler/0.1"
 
 
+def _entity_coverage(ente: str) -> str:
+    """Geographic coverage string for IA metadata, derived from ente slug."""
+    try:
+        from leizilla.entes import get_ente
+        e = get_ente(ente)
+        return "Brazil" if e.tipo == "federal" else f"{e.nome}, Brazil"
+    except Exception:
+        return "Brazil"
+
+
 def _raw_identifier(ente: str, fonte: str, chave: str) -> str:
     """Constrói IA identifier para raw item conforme SCHEMA.md §1.2."""
     return f"leizilla-raw-{ente}-{fonte}-{chave}"
@@ -177,6 +187,12 @@ class InternetArchivePublisher:
             meta_path = Path(tmp) / "raw_meta.json"
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
 
+            coverage = _entity_coverage(ente)
+            desc = (
+                f"Documento original (PDF) da legislação do ente federativo "
+                f"{ente.upper()}, fonte {fonte}, chave {chave}, "
+                f"identificador {ia_id}, capturado pelo projeto Leizilla."
+            )
             try:
                 subprocess.run(
                     [
@@ -185,14 +201,13 @@ class InternetArchivePublisher:
                         ia_id,
                         str(pdf_dst),
                         str(meta_path),
-                        "--metadata",
-                        f"title:{lei_data.get('titulo', 'Lei')}",
-                        "--metadata",
-                        "mediatype:texts",
-                        "--metadata",
-                        f"subject:leis;leizilla;{ente}",
-                        "--metadata",
-                        "creator:leizilla-crawler",
+                        "--metadata", f"title:{lei_data.get('titulo', 'Lei')}",
+                        "--metadata", "mediatype:texts",
+                        "--metadata", f"subject:leis;leizilla;{ente};{fonte}",
+                        "--metadata", "creator:leizilla-crawler",
+                        "--metadata", "language:pt",
+                        "--metadata", f"coverage:{coverage}",
+                        "--metadata", f"description:{desc}",
                     ],
                     capture_output=True,
                     text=True,
@@ -235,6 +250,12 @@ class InternetArchivePublisher:
             meta_path = Path(tmp) / "raw_meta.json"
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
 
+            coverage = _entity_coverage(ente)
+            desc = (
+                f"Documento original (HTML) da legislação do ente federativo "
+                f"{ente.upper()}, fonte {fonte}, chave {chave}, "
+                f"identificador {ia_id}, capturado pelo projeto Leizilla."
+            )
             try:
                 subprocess.run(
                     [
@@ -243,14 +264,13 @@ class InternetArchivePublisher:
                         ia_id,
                         str(html_dst),
                         str(meta_path),
-                        "--metadata",
-                        f"title:{lei_data.get('titulo', 'Lei')}",
-                        "--metadata",
-                        "mediatype:texts",
-                        "--metadata",
-                        f"subject:leis;leizilla;{ente}",
-                        "--metadata",
-                        "creator:leizilla-crawler",
+                        "--metadata", f"title:{lei_data.get('titulo', 'Lei')}",
+                        "--metadata", "mediatype:texts",
+                        "--metadata", f"subject:leis;leizilla;{ente};{fonte}",
+                        "--metadata", "creator:leizilla-crawler",
+                        "--metadata", "language:pt",
+                        "--metadata", f"coverage:{coverage}",
+                        "--metadata", f"description:{desc}",
                     ],
                     capture_output=True,
                     text=True,
@@ -292,6 +312,12 @@ class InternetArchivePublisher:
                 json.dumps(parsed_meta, indent=2, ensure_ascii=False), encoding="utf-8"
             )
 
+            coverage = _entity_coverage(ente)
+            desc = (
+                f"Texto estruturado (Leizilla XML) da legislação do ente "
+                f"{ente.upper()}, tipo {tipo}, identificador {ia_id_parsed}, "
+                f"processado pelo projeto Leizilla."
+            )
             try:
                 subprocess.run(
                     [
@@ -300,14 +326,13 @@ class InternetArchivePublisher:
                         ia_id_parsed,
                         str(xml_path),
                         str(meta_path),
-                        "--metadata",
-                        f"title:{titulo}",
-                        "--metadata",
-                        "mediatype:texts",
-                        "--metadata",
-                        f"subject:leis;leizilla;{ente};{tipo}",
-                        "--metadata",
-                        "creator:leizilla-parser",
+                        "--metadata", f"title:{titulo}",
+                        "--metadata", "mediatype:texts",
+                        "--metadata", f"subject:leis;leizilla;{ente};{tipo}",
+                        "--metadata", "creator:leizilla-parser",
+                        "--metadata", "language:pt",
+                        "--metadata", f"coverage:{coverage}",
+                        "--metadata", f"description:{desc}",
                     ],
                     capture_output=True,
                     text=True,
@@ -357,6 +382,12 @@ class InternetArchivePublisher:
                 json.dumps(dataset_meta, indent=2, ensure_ascii=False), encoding="utf-8"
             )
 
+            coverage = _entity_coverage(ente)
+            desc = (
+                f"Dataset Parquet (tabela versoes) das leis do ente {ente.upper()}, "
+                f"versão v{version}, gerado pelo projeto Leizilla. "
+                f"Contém {effective_row_count} linhas."
+            )
             try:
                 subprocess.run(
                     [
@@ -366,6 +397,9 @@ class InternetArchivePublisher:
                         "--metadata", "mediatype:data",
                         "--metadata", f"subject:leis;leizilla;{ente};parquet;versoes",
                         "--metadata", "creator:leizilla-etl",
+                        "--metadata", "language:pt",
+                        "--metadata", f"coverage:{coverage}",
+                        "--metadata", f"description:{desc}",
                     ],
                     capture_output=True,
                     text=True,


### PR DESCRIPTION
## Summary

- **`_entity_coverage(ente)`**: helper que deriva cobertura geográfica do catálogo de entes (`ro` → `"Rondônia, Brazil"`, `federal` → `"Brazil"`). Fail-open: retorna `"Brazil"` se ente desconhecido.
- **4 métodos de upload enriquecidos** (`upload_raw`, `upload_raw_html`, `upload_parsed`, `upload_dataset`): adicionados `language:pt`, `coverage:{ente}`, `description:{texto}` aos metadados IA. Itens agora aparecem pesquisáveis por idioma e localização geográfica no archive.org.
- **IMPLEMENTATION.md** atualizado: M6.2 → done, M7.1 → done (#44), M7.2 → in-progress (#46), M7.3 → esta PR.

## Trade-offs aceitos

- **`_entity_coverage` acoplado a `leizilla.entes`**: fail-open garante que entes futuros não quebram o upload — retorna `"Brazil"` genérico. Sem necessidade de manter lista separada.
- **Sem mudança de interface**: parâmetros dos métodos inalterados. Callers existentes (scraper, CLI) não precisam de atualização.
- **Sem campo `date`**: o ano da lei não é uniformemente disponível em todos os contextos de upload. `date` seria impreciso; omitido por ora (pode ser adicionado quando o parsedmeta tiver estrutura `ano` confiável em todos os paths).
- **`description` inclui `ia_id`**: facilita auditoria e vinculação de itens no archive.org sem depender de metadados estruturados.

## Test plan

- [x] `uv run pytest` — 398 passed, 13 skipped (todos os testes existentes passam)
- [x] `_entity_coverage` coberta indiretamente pelos testes de upload (subprocess mockado)
- [ ] Verificar metadados reais em item IA após primeiro upload com credenciais

## Contexto: PR #47 rejeitada

Esta PR implementa a parte útil de #47 (metadata enriquecida) sem a mudança arquitetural indesejada (litellm) e sem alterar o default de `max_age_seconds` no wayback (que removeria a guarda de 24h para todos os callers). Diagnóstico completo em #47 e #45.

https://claude.ai/code/session_01Gp1HLZM6n4G1GYUMraLwF4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp1HLZM6n4G1GYUMraLwF4)_