### PR TITLE
feat(M8.2): error-threshold + GitHub Step Summary em parse-all

### DIFF
--- a/.github/workflows/check-credentials.yml
+++ b/.github/workflows/check-credentials.yml
@@ -32,13 +32,19 @@ jobs:
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          # Testa autenticação IA via S3 check_auth — sem upload, sem side effects
-          if [ -z "$IA_ACCESS_KEY" ] || [ -z "$IA_SECRET_KEY" ]; then
-            echo "> ⚠️ IA_ACCESS_KEY ou IA_SECRET_KEY ausentes — teste de autenticação pulado." >> "$GITHUB_STEP_SUMMARY"
-            echo "Configure os secrets em Settings → Secrets → Actions antes de rodar o pipeline."
+          # Falha se qualquer secret obrigatório estiver ausente
+          MISSING=""
+          [ -z "$IA_ACCESS_KEY" ]     && MISSING="$MISSING IA_ACCESS_KEY"
+          [ -z "$IA_SECRET_KEY" ]     && MISSING="$MISSING IA_SECRET_KEY"
+          [ -z "$ANTHROPIC_API_KEY" ] && MISSING="$MISSING ANTHROPIC_API_KEY"
+
+          if [ -n "$MISSING" ]; then
+            echo "> ❌ Secrets ausentes:$MISSING" >> "$GITHUB_STEP_SUMMARY"
+            echo "Configure em Settings → Secrets → Actions antes de rodar o pipeline."
             exit 1
           fi
 
+          # Testa autenticação IA via S3 check_auth — sem upload, sem side effects
           echo "### Teste de autenticação Internet Archive"
           AUTH=$(curl -sf --max-time 15 \
             -H "authorization: LOW ${IA_ACCESS_KEY}:${IA_SECRET_KEY}" \
@@ -54,6 +60,6 @@ jobs:
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             echo "$AUTH" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
-            echo "Verifique se IA_ACCESS_KEY e IA_SECRET_KEY estão corretos (obtidos em archive.org/account/s3.php)." >> "$GITHUB_STEP_SUMMARY"
+            echo "Verifique IA_ACCESS_KEY e IA_SECRET_KEY em archive.org/account/s3.php" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi

--- a/.github/workflows/check-credentials.yml
+++ b/.github/workflows/check-credentials.yml
@@ -1,0 +1,59 @@
+name: Check Pipeline Credentials
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check-credentials:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verificar presença e autenticar no IA
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          echo "## 🔑 Status das credenciais do pipeline" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Secret | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+
+          [ -n "$IA_ACCESS_KEY" ] \
+            && echo "| IA_ACCESS_KEY     | ✅ configurado |" >> "$GITHUB_STEP_SUMMARY" \
+            || echo "| IA_ACCESS_KEY     | ❌ **não configurado** |" >> "$GITHUB_STEP_SUMMARY"
+
+          [ -n "$IA_SECRET_KEY" ] \
+            && echo "| IA_SECRET_KEY     | ✅ configurado |" >> "$GITHUB_STEP_SUMMARY" \
+            || echo "| IA_SECRET_KEY     | ❌ **não configurado** |" >> "$GITHUB_STEP_SUMMARY"
+
+          [ -n "$ANTHROPIC_API_KEY" ] \
+            && echo "| ANTHROPIC_API_KEY | ✅ configurado |" >> "$GITHUB_STEP_SUMMARY" \
+            || echo "| ANTHROPIC_API_KEY | ❌ **não configurado** |" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Testa autenticação IA via S3 check_auth — sem upload, sem side effects
+          if [ -z "$IA_ACCESS_KEY" ] || [ -z "$IA_SECRET_KEY" ]; then
+            echo "> ⚠️ IA_ACCESS_KEY ou IA_SECRET_KEY ausentes — teste de autenticação pulado." >> "$GITHUB_STEP_SUMMARY"
+            echo "Configure os secrets em Settings → Secrets → Actions antes de rodar o pipeline."
+            exit 1
+          fi
+
+          echo "### Teste de autenticação Internet Archive"
+          AUTH=$(curl -sf --max-time 15 \
+            -H "authorization: LOW ${IA_ACCESS_KEY}:${IA_SECRET_KEY}" \
+            "https://s3.us.archive.org/?check_auth=1" 2>&1) || true
+
+          echo "Resposta IA: $AUTH"
+
+          if echo "$AUTH" | grep -q '"authorized":true'; then
+            echo "### ✅ Internet Archive autenticado com sucesso" >> "$GITHUB_STEP_SUMMARY"
+            echo "As credenciais IA estão válidas. O pipeline pode fazer uploads." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### ❌ Falha de autenticação no Internet Archive" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$AUTH" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "Verifique se IA_ACCESS_KEY e IA_SECRET_KEY estão corretos (obtidos em archive.org/account/s3.php)." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/.github/workflows/parse-release.yml
+++ b/.github/workflows/parse-release.yml
@@ -64,6 +64,7 @@ jobs:
             --input-type "${{ inputs.input_type || 'ocr' }}" \
             --limit "${{ inputs.limit || '50' }}" \
             --output-dir /tmp/leizilla-xmls \
+            --error-threshold 20 \
             $UPLOAD_FLAG
 
       - name: Consolidate XMLs → Parquet

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -37,7 +37,10 @@
 | **M6.3** — Planalto year-scoped URLs (pós-2002) | 🟢 done | #41 | `planalto_year_scoped_url` + `_camara_year_lookup` (Câmara API, lru_cache, circuit breaker, 429 sem abrir circuit). 47 novos testes. Fix SCHEMA.md. Merged. |
 | **M7.1** — Claude Code routines: infra de automação | 🟢 done | #44 | `docs/routines/maintenance-prompt.md` + `claude-routine.yml` (schedule: seg+qui 10h UTC). Prompt canônico versionado no repo; workflow dispara sessões automáticas. |
 | **M7.2** — Incremental tracking (check IA antes de parsear) | 🟢 done | #46 | `parse-all --skip-existing` via `list_parsed_raw_ids` com paginação cursor. 9 novos testes. Merged. |
-| **M7.3** — Metadata IA enriquecida | 🟡 in-progress | #48 | `_entity_coverage` helper + `language:pt`, `coverage:{ente}`, `description` nos 4 métodos de upload. Aguardando merge. |
+| **M7.3** — Metadata IA enriquecida | 🟢 done | #48 | `_entity_coverage` helper + `language:pt`, `coverage:{ente}`, `description` nos 4 métodos de upload. Merged. |
+| **M8.1** — `leizilla stats` via IA | 🟡 in-progress | #49 | `count_ia_items(prefix)` + `cmd_stats --ente --ia`: mostra raw/parsed/dataset counts do IA. 9 novos testes. Aguardando merge. |
+| **M5.3** — Benchmark DuckDB-WASM real + FTS | 🔴 blocked | — | Aguarda dataset publicado (~100k+ rows RO). ILIKE columnar é suficiente para ~300k rows estimados. |
+| **M8.2** — Observabilidade do pipeline (error rate) | 🟡 in-progress | esta sessão | `--error-threshold` em `parse-all` + GitHub Step Summary. Workflow `parse-release.yml` com `--error-threshold 20`. 5 novos testes. |
 
 Legenda: ⚪ todo · 🟡 in-progress · 🟢 done · 🔴 blocked
 
@@ -92,6 +95,32 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-23 — M8.2: observabilidade do pipeline — error-threshold + GitHub Step Summary
+
+**Problema**: `parse-release.yml` pode completar com sucesso mesmo quando 80% das leis falharam
+no LLM (confiança baixa, OCR ruim, etc.). Sem um gate, um batch ruim sobe para o IA sem
+visibilidade. M8.1 adicionou contagens via IA API; M8.2 fecha o ciclo do lado do pipeline.
+
+**`--error-threshold FLOAT`** em `parse-all`: se a taxa de falhas de parse exceder o percentual,
+emite aviso e termina com exit 1. Default `0.0` (desabilitado) — retrocompatível. Workflow
+`parse-release.yml` agora usa `--error-threshold 20` (20% de falhas indica problema real).
+
+**Distinção com `upload_fail`**: o exit 1 de upload_fail (já existente) captura falhas de rede/IA.
+O exit 1 de error_threshold captura degradação de qualidade do LLM/OCR. São condições independentes;
+o threshold é verificado antes do upload_fail para que o Step Summary seja sempre escrito.
+
+**GitHub Step Summary (`$GITHUB_STEP_SUMMARY`)**: quando rodando em CI, `_write_step_summary`
+escreve Markdown com stats (parseados, falhos, taxa, uploaded) no arquivo apontado pela env var.
+Fail-open: se a variável não está definida ou o arquivo não é gravável, segue sem erro.
+Aparece na UI do workflow run do GitHub — visibilidade sem criar issues ou comentários.
+
+**Threshold de 20%**: conservador para MVP. Com ~50 leis por batch (--limit 50), 20% = 10 falhas.
+Falhas de OCR ruim tendem a ser estruturais (todas as leis de uma fonte), não aleatórias.
+Se 10/50 falharem, algo está errado. Revisitar com dados reais quando pipeline for rodado.
+
+5 novos testes em `TestCmdParseAllErrorThreshold`: threshold disabled, abaixo do limite,
+acima do limite (exit 1 + aviso), step summary escrito, step summary com threshold no conteúdo.
 
 ### 2026-05-23 — M7.2: parse-all --skip-existing via consulta IA
 
@@ -929,8 +958,14 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 ## Próximos passos imediatos
 
-**M0–M7.2 concluídos** ✅
+**M0–M7.3 + M8.2 concluídos** ✅
 
-**PR aberta**: #48 (M7.3) — metadata IA enriquecida (`language`, `coverage`, `description`) nos 4 métodos de upload. CI verde, aguardando merge.
+**PRs abertas**:
+- #49 (M8.1) — `leizilla stats --ente --ia` + `count_ia_items`. CI verde, aguardando merge.
+- Esta sessão (M8.2) — `--error-threshold` + GitHub Step Summary em `parse-all`. Aguardando CI e merge.
 
-**Próximo após M7.3**: M5.3 — benchmark DuckDB-WASM real com dataset publicado; índice FTS se latência > threshold.
+**M5.3 bloqueado**: aguarda dataset publicado em IA (requer scraping completo + credenciais IA_ACCESS_KEY em CI).
+
+**Ação manual necessária**: configurar `IA_ACCESS_KEY`, `IA_SECRET_KEY`, `ANTHROPIC_API_KEY` nos GitHub Actions secrets para ativar workflows de scraping e parsing.
+
+**Após desbloqueio M5.3**: benchmark DuckDB-WASM real com dataset publicado; índice FTS se search > 1s in-browser.

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -1,6 +1,7 @@
 """Leizilla CLI — interface de linha de comando."""
 
 import asyncio
+import os
 import re
 import subprocess
 import tempfile
@@ -495,6 +496,43 @@ def _xsd_gate(xml_content: str, warn_prefix: str = "") -> bool:
             tmp_path.unlink(missing_ok=True)
 
 
+def _write_step_summary(
+    parsed_ok: int,
+    parsed_fail: int,
+    uploaded_ok: int,
+    upload_fail: int,
+    skipped_ok: int,
+    error_threshold: float,
+) -> None:
+    """Escreve resumo Markdown no GitHub Step Summary se rodando em CI."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    total = parsed_ok + parsed_fail
+    rate = (parsed_fail / total * 100.0) if total > 0 else 0.0
+    over = error_threshold > 0 and total > 0 and rate > error_threshold
+    status = "❌" if over or upload_fail > 0 else "✅"
+    lines = [
+        f"## {status} Leizilla parse-all",
+        "",
+        "| Métrica | Valor |",
+        "|---|---|",
+        f"| Parseados OK | {parsed_ok} |",
+        f"| Falhas de parse | {parsed_fail} |",
+        f"| Taxa de falhas | {rate:.1f}% |",
+        f"| Uploaded | {uploaded_ok} |",
+        f"| Erros de upload | {upload_fail} |",
+        f"| Pulados (já publicados) | {skipped_ok} |",
+    ]
+    if error_threshold > 0:
+        lines.append(f"| Limite de falhas configurado | {error_threshold:.0f}% |")
+    try:
+        with open(summary_path, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except OSError:
+        pass  # fail-open: CI summary não é crítico
+
+
 @app.command("parse")
 def cmd_parse(
     raw_id: str = typer.Option(..., help="IA raw item ID (leizilla-raw-...)"),
@@ -624,6 +662,11 @@ def cmd_parse_all(
         "--skip-existing/--no-skip-existing",
         help="Consultar IA e pular raw_ids que já têm parsed item publicado",
     ),
+    error_threshold: float = typer.Option(
+        0.0,
+        "--error-threshold",
+        help="Taxa máx de falhas de parse tolerada, em %% (0 = desabilitado). Causa exit 1 se excedida.",
+    ),
 ) -> None:
     """Batch parse: range de números → OCR/HTML → LLM → (upload para IA).
 
@@ -733,6 +776,19 @@ def cmd_parse_all(
             + (f", {uploaded_ok} uploaded" if upload else "")
             + (f", {upload_fail} erros de upload" if upload and upload_fail else "")
         )
+        _write_step_summary(
+            parsed_ok, parsed_fail, uploaded_ok, upload_fail, skipped_ok, error_threshold
+        )
+        if error_threshold > 0:
+            total = parsed_ok + parsed_fail
+            if total > 0:
+                rate = (parsed_fail / total) * 100.0
+                if rate > error_threshold:
+                    echo(
+                        f"\n⚠ Taxa de falhas {rate:.1f}% excede limite"
+                        f" {error_threshold:.0f}% — verifique qualidade do OCR/fonte"
+                    )
+                    raise typer.Exit(1)
         if upload_fail > 0:
             raise typer.Exit(1)
     except typer.Exit:

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -744,3 +744,113 @@ class TestCmdParseXsdGateBlocking:
         assert result.exit_code == 1
         assert "XSD inválido" in result.output
         mock_upload.assert_not_called()
+
+
+class TestCmdParseAllErrorThreshold:
+    """Testes para --error-threshold e GitHub Step Summary em parse-all."""
+
+    def test_threshold_disabled_by_default_allows_all_failures(self):
+        """Threshold=0 (default): 100% de falhas não dispara exit 1."""
+        with (
+            patch("leizilla.parser.fetch_ocr", return_value="ocr"),
+            patch("leizilla.parser.parse_law", return_value=None),
+        ):
+            result = runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "3", "--no-upload"],
+            )
+        assert result.exit_code == 0
+        assert "3 falhos" in result.output
+
+    def test_threshold_not_exceeded_exits_zero(self):
+        """1 success, 1 fail = 50%; threshold=60% → exit 0, sem aviso."""
+        with (
+            patch("leizilla.parser.fetch_ocr", return_value="ocr"),
+            patch("leizilla.parser.parse_law", side_effect=[_PARSE_RESULT, None]),
+            patch("leizilla.cli._xsd_gate", return_value=True),
+            patch(
+                "leizilla.publisher.InternetArchivePublisher.upload_parsed",
+                return_value=_UPLOAD_OK,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "parse-all",
+                    "--start-coddoc", "1",
+                    "--end-coddoc", "2",
+                    "--error-threshold", "60",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "⚠" not in result.output
+
+    def test_threshold_exceeded_exits_one_with_warning(self):
+        """2 success, 3 fail = 60%; threshold=50% → exit 1 + mensagem de aviso."""
+        parse_results = [_PARSE_RESULT, _PARSE_RESULT, None, None, None]
+        with (
+            patch("leizilla.parser.fetch_ocr", return_value="ocr"),
+            patch("leizilla.parser.parse_law", side_effect=parse_results),
+            patch("leizilla.cli._xsd_gate", return_value=True),
+            patch(
+                "leizilla.publisher.InternetArchivePublisher.upload_parsed",
+                return_value=_UPLOAD_OK,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "parse-all",
+                    "--start-coddoc", "1",
+                    "--end-coddoc", "5",
+                    "--error-threshold", "50",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "⚠ Taxa de falhas" in result.output
+        assert "excede limite" in result.output
+
+    def test_step_summary_written_in_ci(self, tmp_path, monkeypatch):
+        """GITHUB_STEP_SUMMARY definido → arquivo Markdown escrito com stats."""
+        summary_file = tmp_path / "step_summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        with (
+            patch("leizilla.parser.fetch_ocr", return_value="ocr"),
+            patch("leizilla.parser.parse_law", return_value=_PARSE_RESULT),
+            patch("leizilla.cli._xsd_gate", return_value=True),
+            patch(
+                "leizilla.publisher.InternetArchivePublisher.upload_parsed",
+                return_value=_UPLOAD_OK,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["parse-all", "--start-coddoc", "1", "--end-coddoc", "2"],
+            )
+        assert result.exit_code == 0
+        assert summary_file.exists()
+        content = summary_file.read_text()
+        assert "Leizilla parse-all" in content
+        assert "Parseados OK" in content
+        assert "Taxa de falhas" in content
+
+    def test_step_summary_includes_threshold_when_set(self, tmp_path, monkeypatch):
+        """--error-threshold N aparece no step summary."""
+        summary_file = tmp_path / "step_summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+        with (
+            patch("leizilla.parser.fetch_ocr", return_value="ocr"),
+            patch("leizilla.parser.parse_law", return_value=None),
+        ):
+            runner.invoke(
+                app,
+                [
+                    "parse-all",
+                    "--start-coddoc", "1",
+                    "--end-coddoc", "2",
+                    "--no-upload",
+                    "--error-threshold", "30",
+                ],
+            )
+        content = summary_file.read_text()
+        assert "30%" in content


### PR DESCRIPTION
## Summary

- **`--error-threshold FLOAT`** em `parse-all`: taxa máxima de falhas de parse tolerada (%). Quando excedida, emite aviso e termina com exit 1. Default `0.0` (desabilitado) — retrocompatível com todos os callers existentes.
- **`_write_step_summary`**: ao fim de cada batch, escreve Markdown com stats (parseados, falhos, taxa, uploaded) no arquivo `$GITHUB_STEP_SUMMARY` quando rodando em CI. Fail-open (OSError ignorado, env var ausente = skip). Aparece na UI do workflow run — visibilidade sem criar issues/comentários.
- **`parse-release.yml`** atualizado: `--error-threshold 20` (20% de falhas = ~10 de 50 leis = degradação estrutural de OCR/LLM).
- **IMPLEMENTATION.md**: M7.3 marcado done, M8.1 in-progress (#49), M5.3 blocked, M8.2 in-progress; decisão log com raciocínio do threshold de 20%.

## Trade-offs aceitos

- **Threshold de 20% é arbitrário** para o MVP — sem dados reais de produção ainda. Baseado em heurística: falhas de OCR ruim tendem a ser estruturais (muitas leis da mesma fonte), não aleatórias. 10/50 falhando indica problema real.
- **Step Summary sempre escrito** (mesmo em sucesso): pequena verbosidade extra nos logs de CI em troca de visibilidade consistente.
- **`_write_step_summary` acoplado a `cli.py`**: evita dependência nova. Se virar mais complexo, extrai para `leizilla.observability`.

## Test plan

- [x] `uv run pytest` — 414 passed, 13 skipped
- [x] `TestCmdParseAllErrorThreshold` (5 testes): threshold disabled, abaixo do limite, excedido (exit 1 + aviso), step summary escrito, step summary inclui threshold
- [x] Regressão: todos os 33 testes pré-existentes de `TestCmdParseAll` passam

## Próximos passos pendentes

- Merge de #49 (M8.1) — CI verde, falso positivo do Kilo refutado inline
- M5.3 desbloqueado quando `IA_ACCESS_KEY`, `IA_SECRET_KEY`, `ANTHROPIC_API_KEY` forem configurados em GitHub Actions secrets

https://claude.ai/code/session_01G1hDojqEnb1G11bq7Nrgj3

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1hDojqEnb1G11bq7Nrgj3)_