### PR TITLE
Enable credential checks on claude/* branch pushes [superseded by #53]

### DIFF
--- a/.github/workflows/check-credentials.yml
+++ b/.github/workflows/check-credentials.yml
@@ -2,6 +2,9 @@ name: Check Pipeline Credentials
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "claude/**"
 
 jobs:
   check-credentials:


### PR DESCRIPTION
## Summary

Extends the Check Pipeline Credentials workflow to automatically run on pushes to branches matching the `claude/**` pattern, in addition to manual workflow dispatch triggers.

## Changes

- Added `push` trigger with branch filter for `claude/**` pattern to the workflow configuration
- This ensures credential validation runs automatically when pushing changes to Claude-related feature branches

## Implementation Details

The workflow now triggers in two scenarios:
1. Manual execution via `workflow_dispatch` (existing behavior)
2. Automatic execution on any push to branches matching `claude/**` (new behavior)

This aligns with the project's development workflow where Claude Code assistant work is organized under the `claude/` branch namespace.

https://claude.ai/code/session_01G1hDojqEnb1G11bq7Nrgj3