### PR TITLE
fix(M9.2): check-credentials informacional em PRs/pushes — só bloqueia em workflow_dispatch

### DIFF
--- a/.github/workflows/check-credentials.yml
+++ b/.github/workflows/check-credentials.yml
@@ -2,6 +2,11 @@ name: Check Pipeline Credentials
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+  push:
+    branches:
+      - "claude/**"
 
 jobs:
   check-credentials:
@@ -32,7 +37,6 @@ jobs:
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          # Falha se qualquer secret obrigatório estiver ausente
           MISSING=""
           [ -z "$IA_ACCESS_KEY" ]     && MISSING="$MISSING IA_ACCESS_KEY"
           [ -z "$IA_SECRET_KEY" ]     && MISSING="$MISSING IA_SECRET_KEY"
@@ -41,6 +45,11 @@ jobs:
           if [ -n "$MISSING" ]; then
             echo "> ❌ Secrets ausentes:$MISSING" >> "$GITHUB_STEP_SUMMARY"
             echo "Configure em Settings → Secrets → Actions antes de rodar o pipeline."
+            # Em PRs e pushes automáticos: só informa, não bloqueia desenvolvimento.
+            # Em workflow_dispatch (pre-flight manual): falha explicitamente.
+            if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+              exit 0
+            fi
             exit 1
           fi
 
@@ -61,5 +70,8 @@ jobs:
             echo "$AUTH" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             echo "Verifique IA_ACCESS_KEY e IA_SECRET_KEY em archive.org/account/s3.php" >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+              exit 0
+            fi
             exit 1
           fi


### PR DESCRIPTION
## Summary

- **Problema**: PRs #51 e #52 adicionaram triggers automáticos (`pull_request` / `push: claude/**`) ao `check-credentials.yml`, mas os secrets não estão configurados em CI. Resultado: CI vermelho permanente em todas as PRs de claude/* — bloqueando todos os merges.
- **Causa raiz**: `check-credentials` foi desenhado para ser um gate bloqueador (pré-voo manual antes de rodar o pipeline). Auto-triggers são informativos — não deveriam bloquear desenvolvimento.
- **Fix**: detecta `${{ github.event_name }}`. Em `workflow_dispatch`: comportamento existente (exit 1 se secrets ausentes). Em `pull_request` / `push`: exit 0 sempre — só reporta status no Step Summary.
- **Triggers incluídos**: `pull_request: branches: [main]` e `push: branches: claude/**` já incorporados aqui (combinando a intenção boa de #51 e #52).

## Trade-offs aceitos

- Secrets ausentes em PRs mostram ❌ no Step Summary mas não marcam o commit como failing — esse é o comportamento correto para um repo em desenvolvimento onde credentials são ação manual pendente de franklinbaldo.
- PR #52 fica superseded por este commit (a mudança que ela fazia é um subconjunto do fix, e com o exit condicional correto).
- PR #51 precisará de rebase trivial: conflito em `check-credentials.yml`, mantém esta versão.

## Test plan

- [x] Lógica `if github.event_name != workflow_dispatch: exit 0` verificada no diff
- [x] `workflow_dispatch` continua com exit 1 quando secrets ausentes (comportamento inalterado)
- [ ] Após merge: PRs #51 e #52 devem ter `check-credentials: ✅ success` no próximo push

## Decisão (decision log)

Esta PR é M9.2 no projeto. A intenção de auto-trigger em check-credentials é correta (visibilidade antecipada do status de credentials), mas credenciais são configuração manual que depende de ação de franklinbaldo. Fazer o check falhar em todo push seria mais ruído que sinal até as credentials serem configuradas. A separação `informativo vs. bloqueador` por tipo de trigger é o padrão correto.

## Próximos passos

- franklinbaldo configura `IA_ACCESS_KEY`, `IA_SECRET_KEY`, `ANTHROPIC_API_KEY` em Settings → Secrets → Actions
- Após credenciais: `workflow_dispatch` no check-credentials confirma autenticação
- M5.3 desbloqueado quando primeiro batch real de scraping/parsing completar

https://claude.ai/code/session_011viC1Acu5hMoV93JRmB9aP

---
_Generated by [Claude Code](https://claude.ai/code/session_011viC1Acu5hMoV93JRmB9aP)_