### PR TITLE
feat(M10.1): fetch-all-parsed CLI + Parquet cumulativo em parse-release

### DIFF
--- a/.github/workflows/parse-release.yml
+++ b/.github/workflows/parse-release.yml
@@ -120,6 +120,12 @@ jobs:
 
       # ── ETL + RELEASE ──────────────────────────────────────────────────────
 
+      - name: Fetch all parsed XMLs from IA (cumulative Parquet)
+        run: |
+          uv run leizilla fetch-all-parsed \
+            --ente "${{ inputs.ente || 'ro' }}" \
+            --output-dir /tmp/leizilla-xmls
+
       - name: Consolidate XMLs → Parquet
         run: |
           XML_COUNT=$(find /tmp/leizilla-xmls -name '*.xml' | wc -l)

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -44,7 +44,8 @@
 | **M9.2** — check-credentials informacional | 🟢 done | #53 | `exit 0` em `pull_request`/`push`; só bloqueia em `workflow_dispatch`. Triggers `claude/**` e `pull_request: main`. Merged. |
 | **M9.3** — `scrape --skip-existing` | 🟢 done | #54 | `list_raw_ids(ente, fonte)` + flag `--skip-existing/--no-skip-existing` em `cmd_scrape`. Evita re-scraping de itens já no IA. 10 novos testes. Merged. |
 | **M9.4** — parse-release multi-fonte + skip-existing | 🟢 done | #55 | Três steps scheduled (assembleia + casacivil-lei + casacivil-lc); fix `--limit` (conta post-skip) + casacivil chave discriminant. Merged. |
-| **M9.5** — `rondonia_crawler.yml` idempotente + ranges reais | 🟡 in-progress | #57 | Schedule/dispatch split; `--skip-existing` por default; ranges 5000/6000/1300 (alinhados com parse-release). Inputs renomeados por fonte. |
+| **M9.5** — `rondonia_crawler.yml` idempotente + ranges reais | 🟢 done | #57 | Schedule/dispatch split; `--skip-existing` por default; ranges 5000/6000/1300 (alinhados com parse-release). Inputs renomeados por fonte. Merged. |
+| **M10.1** — `fetch-all-parsed` + Parquet cumulativo | 🟡 in-progress | esta sessão | `list_parsed_ia_ids` + `fetch_parsed_xml` + CLI `fetch-all-parsed`; `parse-release.yml` baixa todos os XMLs do IA antes do consolidate. 12 testes. |
 | **M5.3** — Benchmark DuckDB-WASM real + FTS | 🔴 blocked | — | Aguarda dataset publicado (~100k+ rows RO). ILIKE no DuckDB columnar é suficiente para ~300k rows estimados; FTS só se benchmark in-browser medir > 1s. |
 
 Legenda: ⚪ todo · 🟡 in-progress · 🟢 done · 🔴 blocked
@@ -100,6 +101,37 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-05-23 — M10.1: fetch-all-parsed + Parquet cumulativo
+
+**Problema**: cada `parse-release.yml` run publica um Parquet com ≤150 leis (apenas os itens
+parsed naquele run). O dataset não acumula — a cada semana substitui o anterior com uma fatia
+pequena, nunca chegando a um Parquet browsable com todo o acervo do ente.
+
+**`list_parsed_ia_ids(ente)`** adicionado a `publisher.py`: variante simplificada de
+`list_parsed_raw_ids` — mesmo query IA scrape API (filtra raw/bundle/dataset), mas retorna
+`list[str]` dos próprios identifiers parsed (sem fetch de `parsed_meta.json` por item).
+Fail-open: erro de rede → lista vazia (não bloqueia pipeline).
+
+**`fetch_parsed_xml(ia_id, output_path)`**: HTTP GET de `archive.org/download/{ia_id}/law.xml`
+com timeout 30s. Salva bytes em `output_path`. Retorna `bool` (True = sucesso). Fail-open por item.
+
+**`cmd_fetch_all_parsed --ente --output-dir`**: lista todos os IDs, skip se arquivo já existe
+(idempotente), baixa em sequência, reporta `Baixados: N, Erros: M`. Exit 0 sempre (falhas
+individuais não abortam pipeline — IA pode ter itens cujo upload está em andamento).
+
+**Integração em `parse-release.yml`**: step `Fetch all parsed XMLs from IA` adicionado entre
+os steps de parse e o `Consolidate`. Output dir `/tmp/leizilla-xmls` é compartilhado com o
+parse-all step — novos XMLs gerados pelo parse ficam no dir, fetch-all-parsed adiciona os
+históricos. Consolidate processa todos. Resultado: Parquet full-histórico acumulado.
+
+**Trade-off de latência**: N requests HTTP (um por item parsed + N/10000 requests de paginação).
+Para 500 items: ~501 requests × 1-2s = ~10min extra. Aceitável para run semanal noturno.
+Otimização futura: cache local de IDs já baixados para pular confirmados (desnecessário agora).
+
+12 testes em `tests/test_fetch_all_parsed.py`: 4 × `TestListParsedIaIds` (basic, paginate,
+network_error, empty) + 3 × `TestFetchParsedXml` (success, error, url) + 5 × `TestCmdFetchAllParsed`
+(basic, skip_existing_files, count_errors, no_items, create_dir).
 
 ### 2026-05-23 — M9.5: rondonia_crawler.yml idempotente + ranges reais
 
@@ -1077,14 +1109,12 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 
 **M0–M9.3 concluídos** ✅
 
-**M9.4 (#55) mergeada** ✅ — parse-release multi-fonte + fix --limit + casacivil discriminant.
+**M9.4 (#55) + M9.5 (#57) mergeadas** ✅ — pipelines idempotentes, ranges reais, P1 bugs corrigidos.
 
-**PR aberta desta sessão**: #57 (M9.5) — `rondonia_crawler.yml` idempotente: schedule/dispatch split + ranges reais (5000/6000/1300) + `--skip-existing`. Aguardando CI e decantação.
+**PR aberta desta sessão**: M10.1 — `fetch-all-parsed` CLI + `parse-release.yml` com Parquet cumulativo. Aguardando CI e decantação.
 
 **M5.3 bloqueado**: aguarda dataset publicado em IA (requer scraping completo + credenciais em CI). Revisitar após primeiro batch real.
 
 **Ação manual necessária**: configurar `IA_ACCESS_KEY`, `IA_SECRET_KEY`, `ANTHROPIC_API_KEY` nos GitHub Actions secrets para ativar o pipeline.
 
 **Após desbloqueio M5.3**: benchmark DuckDB-WASM real; FTS se search > 1s in-browser.
-
-**M10.1 (futuro)**: `fetch-all-parsed` — baixar todos os XMLs existentes do IA antes do consolidate para Parquet full-histórico acumulado.

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -836,6 +836,47 @@ def cmd_parse_all(
         raise typer.Exit(1)
 
 
+@app.command("fetch-all-parsed")
+def cmd_fetch_all_parsed(
+    ente: str = typer.Option("ro", help="Ente federativo"),
+    output_dir: Path = typer.Option(
+        ..., "--output-dir", help="Diretório de saída para os XMLs baixados"
+    ),
+) -> None:
+    """Baixar todos os XMLs parseados do IA para o diretório local.
+
+    Complementa parse-all: baixa os XMLs de todos os itens parsed existentes
+    no IA para que consolidate possa gerar um Parquet full-histórico acumulado
+    (não apenas os itens parsed na execução corrente).
+    """
+    from leizilla.publisher import fetch_parsed_xml, list_parsed_ia_ids
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    echo(f"Listando itens parsed de '{ente}' no IA...")
+    ia_ids = list_parsed_ia_ids(ente)
+
+    if not ia_ids:
+        echo("Nenhum item parsed encontrado (ou erro de conectividade com IA).")
+        return
+
+    echo(f"Encontrados {len(ia_ids)} itens. Baixando XMLs...")
+    ok = 0
+    fail = 0
+    for ia_id in ia_ids:
+        dest = output_dir / f"{ia_id}.xml"
+        if dest.exists():
+            ok += 1
+            continue
+        if fetch_parsed_xml(ia_id, dest):
+            ok += 1
+        else:
+            echo(f"  [ERRO] {ia_id} — law.xml não disponível, pulando")
+            fail += 1
+
+    echo(f"Baixados: {ok}, Erros: {fail}")
+
+
 @app.command("pipeline")
 def cmd_pipeline(
     ente: str = typer.Option("ro", help="Ente federativo"),

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -862,11 +862,12 @@ def cmd_fetch_all_parsed(
 
     echo(f"Encontrados {len(ia_ids)} itens. Baixando XMLs...")
     ok = 0
+    skipped = 0
     fail = 0
     for ia_id in ia_ids:
         dest = output_dir / f"{ia_id}.xml"
         if dest.exists():
-            ok += 1
+            skipped += 1
             continue
         if fetch_parsed_xml(ia_id, dest):
             ok += 1
@@ -874,7 +875,7 @@ def cmd_fetch_all_parsed(
             echo(f"  [ERRO] {ia_id} — law.xml não disponível, pulando")
             fail += 1
 
-    echo(f"Baixados: {ok}, Erros: {fail}")
+    echo(f"Baixados: {ok}, Pulados (já existiam): {skipped}, Erros: {fail}")
 
 
 @app.command("pipeline")

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -281,6 +281,63 @@ def list_parsed_raw_ids(ente: str, fonte: str) -> Set[str]:
     return raw_ids
 
 
+def list_parsed_ia_ids(ente: str) -> list[str]:
+    """Return all parsed IA item identifiers for this ente.
+
+    Queries the IA scrape API for leizilla-{ente}-* items, excluding raw,
+    bundle, and dataset variants. Returns the parsed item identifiers themselves
+    (unlike list_parsed_raw_ids which returns the raw IDs they were derived from).
+
+    Paginates via cursor. Fail-open: returns empty list on any network error.
+    """
+    q = (
+        f"identifier:leizilla-{ente}-* "
+        f"AND NOT identifier:leizilla-raw-{ente}-* "
+        f"AND NOT identifier:leizilla-bundle-{ente}-* "
+        f"AND NOT identifier:leizilla-dataset-{ente}-*"
+    )
+    base_url = (
+        f"{_IA_SCRAPE_URL}?q={urllib.parse.quote(q)}&count=10000&fields=identifier"
+    )
+
+    ids: list[str] = []
+    cursor: Optional[str] = None
+
+    while True:
+        url = base_url
+        if cursor:
+            url += f"&cursor={urllib.parse.quote(cursor)}"
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = json.loads(resp.read())
+            ids.extend(item["identifier"] for item in data.get("items", []))
+            cursor = data.get("cursor")
+            if not cursor:
+                break
+        except Exception:
+            return []
+
+    return ids
+
+
+def fetch_parsed_xml(ia_id: str, output_path: Path) -> bool:
+    """Download law.xml from an IA parsed item and save to output_path.
+
+    URL: archive.org/download/{ia_id}/law.xml
+    Returns True on success, False on any network or I/O error (fail-open).
+    """
+    url = f"{_IA_DOWNLOAD_URL}/{ia_id}/law.xml"
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            xml_bytes = resp.read()
+        output_path.write_bytes(xml_bytes)
+        return True
+    except Exception:
+        return False
+
+
 class InternetArchivePublisher:
     """Upload para IA e geração de datasets Parquet."""
 

--- a/tests/test_fetch_all_parsed.py
+++ b/tests/test_fetch_all_parsed.py
@@ -1,0 +1,193 @@
+"""Tests for M10.1: fetch-all-parsed — list_parsed_ia_ids + fetch_parsed_xml + CLI."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from leizilla.cli import app
+from leizilla.publisher import fetch_parsed_xml, list_parsed_ia_ids
+
+runner = CliRunner()
+
+
+def _scrape_response(identifiers: list[str], cursor: str | None = None) -> bytes:
+    data: dict = {"items": [{"identifier": id_} for id_ in identifiers]}
+    if cursor:
+        data["cursor"] = cursor
+    return json.dumps(data).encode()
+
+
+class TestListParsedIaIds:
+    def test_basic_returns_parsed_ids(self):
+        response = _scrape_response(["leizilla-ro-lei-00001-2001", "leizilla-ro-lei-00002-2002"])
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            ids = list_parsed_ia_ids("ro")
+
+        assert ids == ["leizilla-ro-lei-00001-2001", "leizilla-ro-lei-00002-2002"]
+
+    def test_paginates_via_cursor(self):
+        page1 = _scrape_response(["leizilla-ro-lei-00001-2001"], cursor="abc123")
+        page2 = _scrape_response(["leizilla-ro-lei-00002-2002"])
+
+        call_count = 0
+
+        def urlopen_side(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = page1 if call_count == 1 else page2
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=urlopen_side):
+            ids = list_parsed_ia_ids("ro")
+
+        assert ids == ["leizilla-ro-lei-00001-2001", "leizilla-ro-lei-00002-2002"]
+        assert call_count == 2
+
+    def test_network_error_returns_empty_list(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("network down")):
+            ids = list_parsed_ia_ids("ro")
+        assert ids == []
+
+    def test_empty_collection(self):
+        response = _scrape_response([])
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            ids = list_parsed_ia_ids("ro")
+
+        assert ids == []
+
+
+class TestFetchParsedXml:
+    def test_success_writes_file(self, tmp_path: Path):
+        xml_content = b"<lei><header urn='urn:lex:br;rondonia:estadual:lei:2001-01-01;1'/></lei>"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = xml_content
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        dest = tmp_path / "leizilla-ro-lei-00001-2001.xml"
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = fetch_parsed_xml("leizilla-ro-lei-00001-2001", dest)
+
+        assert result is True
+        assert dest.read_bytes() == xml_content
+
+    def test_network_error_returns_false(self, tmp_path: Path):
+        dest = tmp_path / "leizilla-ro-lei-00001-2001.xml"
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            result = fetch_parsed_xml("leizilla-ro-lei-00001-2001", dest)
+
+        assert result is False
+        assert not dest.exists()
+
+    def test_uses_correct_url(self, tmp_path: Path):
+        captured_url = []
+
+        def urlopen_side(req, timeout=None):
+            captured_url.append(req.full_url)
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b"<lei/>"
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        dest = tmp_path / "leizilla-ro-lei-00042-2003.xml"
+        with patch("urllib.request.urlopen", side_effect=urlopen_side):
+            fetch_parsed_xml("leizilla-ro-lei-00042-2003", dest)
+
+        assert captured_url[0] == "https://archive.org/download/leizilla-ro-lei-00042-2003/law.xml"
+
+
+class TestCmdFetchAllParsed:
+    def test_downloads_xmls_to_output_dir(self, tmp_path: Path):
+        ids = ["leizilla-ro-lei-00001-2001", "leizilla-ro-lei-00002-2002"]
+
+        with (
+            patch("leizilla.publisher.list_parsed_ia_ids", return_value=ids),
+            patch("leizilla.publisher.fetch_parsed_xml", return_value=True) as mock_fetch,
+        ):
+            result = runner.invoke(
+                app,
+                ["fetch-all-parsed", "--ente", "ro", "--output-dir", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0
+        assert "Encontrados 2 itens" in result.output
+        assert "Baixados: 2, Erros: 0" in result.output
+        assert mock_fetch.call_count == 2
+
+    def test_skips_already_existing_files(self, tmp_path: Path):
+        ids = ["leizilla-ro-lei-00001-2001"]
+        existing = tmp_path / "leizilla-ro-lei-00001-2001.xml"
+        existing.write_text("<lei/>")
+
+        with (
+            patch("leizilla.publisher.list_parsed_ia_ids", return_value=ids),
+            patch("leizilla.publisher.fetch_parsed_xml", return_value=True) as mock_fetch,
+        ):
+            result = runner.invoke(
+                app,
+                ["fetch-all-parsed", "--ente", "ro", "--output-dir", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0
+        assert "Baixados: 1, Erros: 0" in result.output
+        mock_fetch.assert_not_called()
+
+    def test_counts_errors_per_item(self, tmp_path: Path):
+        ids = ["leizilla-ro-lei-00001-2001", "leizilla-ro-lei-00002-2002"]
+
+        def fetch_side(ia_id: str, path: Path) -> bool:
+            return ia_id != "leizilla-ro-lei-00001-2001"
+
+        with (
+            patch("leizilla.publisher.list_parsed_ia_ids", return_value=ids),
+            patch("leizilla.publisher.fetch_parsed_xml", side_effect=fetch_side),
+        ):
+            result = runner.invoke(
+                app,
+                ["fetch-all-parsed", "--ente", "ro", "--output-dir", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0
+        assert "Baixados: 1, Erros: 1" in result.output
+
+    def test_no_items_found_exits_cleanly(self, tmp_path: Path):
+        with patch("leizilla.publisher.list_parsed_ia_ids", return_value=[]):
+            result = runner.invoke(
+                app,
+                ["fetch-all-parsed", "--ente", "ro", "--output-dir", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0
+        assert "Nenhum item parsed encontrado" in result.output
+
+    def test_creates_output_dir_if_missing(self, tmp_path: Path):
+        new_dir = tmp_path / "subdir" / "xmls"
+        assert not new_dir.exists()
+
+        with (
+            patch("leizilla.publisher.list_parsed_ia_ids", return_value=[]),
+        ):
+            result = runner.invoke(
+                app,
+                ["fetch-all-parsed", "--ente", "ro", "--output-dir", str(new_dir)],
+            )
+
+        assert result.exit_code == 0
+        assert new_dir.exists()

--- a/tests/test_fetch_all_parsed.py
+++ b/tests/test_fetch_all_parsed.py
@@ -128,7 +128,7 @@ class TestCmdFetchAllParsed:
 
         assert result.exit_code == 0
         assert "Encontrados 2 itens" in result.output
-        assert "Baixados: 2, Erros: 0" in result.output
+        assert "Baixados: 2, Pulados (já existiam): 0, Erros: 0" in result.output
         assert mock_fetch.call_count == 2
 
     def test_skips_already_existing_files(self, tmp_path: Path):
@@ -146,7 +146,7 @@ class TestCmdFetchAllParsed:
             )
 
         assert result.exit_code == 0
-        assert "Baixados: 1, Erros: 0" in result.output
+        assert "Baixados: 0, Pulados (já existiam): 1, Erros: 0" in result.output
         mock_fetch.assert_not_called()
 
     def test_counts_errors_per_item(self, tmp_path: Path):
@@ -165,7 +165,7 @@ class TestCmdFetchAllParsed:
             )
 
         assert result.exit_code == 0
-        assert "Baixados: 1, Erros: 1" in result.output
+        assert "Baixados: 1, Pulados (já existiam): 0, Erros: 1" in result.output
 
     def test_no_items_found_exits_cleanly(self, tmp_path: Path):
         with patch("leizilla.publisher.list_parsed_ia_ids", return_value=[]):


### PR DESCRIPTION
## Summary

- **Problema raiz**: `parse-release.yml` publicava um Parquet com ≤150 leis por run (apenas os itens parsed naquele batch). Dataset não acumulava — substituía o anterior com uma fatia pequena, nunca chegando a um Parquet navegável com o acervo completo do ente.
- **`list_parsed_ia_ids(ente)`** em `publisher.py`: scrape API com filtro `NOT raw/bundle/dataset`; retorna `list[str]` de IDs parsed. Fail-open: erro de rede → lista vazia (não bloqueia pipeline).
- **`fetch_parsed_xml(ia_id, output_path)`** em `publisher.py`: GET `archive.org/download/{ia_id}/law.xml`, salva bytes, retorna `bool`. Fail-open por item.
- **CLI `leizilla fetch-all-parsed --ente --output-dir`**: lista todos os IDs, skip se arquivo já existe (idempotente), baixa sequencialmente, reporta `Baixados: N, Erros: M`. Exit 0 sempre.
- **`parse-release.yml`**: step `Fetch all parsed XMLs from IA` adicionado entre os steps de parse e o `Consolidate`. Output dir `/tmp/leizilla-xmls` é compartilhado → consolidate processa novos + históricos → Parquet full-histórico acumulado.

## Trade-offs aceitos

- Sem paralelismo no download: ~N requests × 1-2s por run, aceito para pipeline semanal. Paralelismo (asyncio) seria ganho marginal com complexidade real.
- Exit 0 mesmo com erros individuais: itens com upload em andamento no IA podem falhar temporariamente. Re-run na semana seguinte recupera. Exit 1 só faz sentido se 100% dos downloads falharem (indicação de problema de conectividade) — mas isso já está coberto pelo step de consolidate (sem XMLs = exit 0 com aviso, configurado anteriormente).
- Skip de arquivos existentes inclui os gerados pelo parse-all no mesmo run: idempotente + evita download redundante para itens recém-uploadados.

## Test plan

- [x] `uv run pytest tests/test_fetch_all_parsed.py -v` — 12 passed
- [x] `uv run pytest -q` — 448 passed, 13 skipped, 0 failures
- [x] `leizilla fetch-all-parsed --help` — comando presente e parâmetros corretos
- [ ] Após credenciais configuradas: verificar que parse-release com fetch-all-parsed inclui histórico no Parquet

## Próximos passos

- M5.3 (benchmark DuckDB-WASM real) — desbloqueado quando primeiro batch RO for publicado com o Parquet acumulado desta PR
- Ação manual necessária: configurar `IA_ACCESS_KEY`, `IA_SECRET_KEY`, `ANTHROPIC_API_KEY` nos GitHub Actions secrets

https://claude.ai/code/session_012Fqfp2sqPrzrcuFMx3B7P8

---
_Generated by [Claude Code](https://claude.ai/code/session_012Fqfp2sqPrzrcuFMx3B7P8)_