### PR TITLE
feat: implement OCR text retrieval pipeline

### DIFF
--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -147,6 +147,68 @@ def cmd_bundle_raw(
         raise typer.Exit(1)
 
 
+@app.command("fetch-ocr")
+def cmd_fetch_ocr(
+    ente: Optional[str] = typer.Option(None, help="Filtrar por ente federativo"),
+    limit: int = typer.Option(100, help="Limite de leis a processar"),
+) -> None:
+    """Busca os textos de OCR no Internet Archive e popula a base local."""
+    echo("Buscando textos de OCR pendentes...")
+    try:
+        from leizilla.storage import DuckDBStorage
+        from leizilla.ocr import fetch_and_clean_ocr, normalize_text
+
+        db = DuckDBStorage()
+        pending = db.get_leis_pending_ocr(ente=ente, limit=limit)
+
+        if not pending:
+            echo("Nenhuma lei sem OCR encontrada no banco.")
+            return
+
+        echo(f"Encontradas {len(pending)} leis sem OCR. Iniciando busca...")
+        success = 0
+        failed = 0
+
+        for lei in pending:
+            lei_id = lei["id"]
+            url_pdf_ia = lei.get("url_pdf_ia") or ""
+
+            # Determina o ia_id
+            ia_id = None
+            if url_pdf_ia:
+                match = re.search(
+                    r"archive\.org/(?:details|download)/([^/]+)", url_pdf_ia
+                )
+                if match:
+                    ia_id = match.group(1)
+
+            if not ia_id:
+                ia_id = f"leizilla-raw-{lei_id}"
+
+            echo(f"Buscando OCR para {lei_id} (IA ID: {ia_id})...")
+            text = fetch_and_clean_ocr(ia_id)
+
+            if text:
+                norm = normalize_text(text)
+                db.update_lei(
+                    lei_id,
+                    {
+                        "texto_completo": text,
+                        "texto_normalizado": norm,
+                    },
+                )
+                echo(f"  Sucesso: {len(text)} caracteres salvos.")
+                success += 1
+            else:
+                echo("  Não foi possível obter o OCR do Internet Archive.")
+                failed += 1
+
+        echo(f"Busca de OCR concluída: {success} com sucesso, {failed} falhas.")
+    except Exception as e:
+        echo(f"Erro ao buscar OCR: {e}")
+        raise typer.Exit(1)
+
+
 @app.command("download")
 def cmd_download(
     ente: str = typer.Option("ro", help="Ente federativo"),

--- a/src/leizilla/ocr.py
+++ b/src/leizilla/ocr.py
@@ -1,0 +1,42 @@
+"""Módulo para download e normalização do texto de OCR do Internet Archive."""
+
+import re
+import unicodedata
+from typing import Optional
+from leizilla.parser import fetch_ocr
+
+
+def clean_ocr_text(text: str) -> str:
+    """Limpa ruídos óbvios e formatações indesejadas do OCR bruto."""
+    if not text:
+        return ""
+    # Remove caracteres de controle estranhos, mantendo quebras de linha comuns
+    cleaned = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\xff]", "", text)
+    return cleaned.strip()
+
+
+def normalize_text(text: str) -> str:
+    """Normaliza texto para a coluna texto_normalizado (busca rápida).
+
+    Remove acentos, converte para minúsculo, remove pontuação e excesso de espaços.
+    """
+    if not text:
+        return ""
+    # Remove acentos e diacríticos
+    normalized = unicodedata.normalize("NFKD", text)
+    normalized = "".join([c for c in normalized if not unicodedata.combining(c)])
+    # Minúsculo
+    normalized = normalized.lower()
+    # Substituir quebras de linha e múltiplos espaços por um espaço simples
+    normalized = re.sub(r"\s+", " ", normalized)
+    # Remover caracteres especiais mantendo apenas letras, números e espaços simples
+    normalized = re.sub(r"[^a-z0-9\s]", "", normalized)
+    return normalized.strip()
+
+
+def fetch_and_clean_ocr(ia_id: str) -> Optional[str]:
+    """Busca o texto de OCR do IA e limpa ruídos iniciais."""
+    raw_text = fetch_ocr(ia_id)
+    if raw_text is None:
+        return None
+    return clean_ocr_text(raw_text)

--- a/src/leizilla/ocr.py
+++ b/src/leizilla/ocr.py
@@ -10,8 +10,8 @@ def clean_ocr_text(text: str) -> str:
     """Limpa ruídos óbvios e formatações indesejadas do OCR bruto."""
     if not text:
         return ""
-    # Remove caracteres de controle estranhos, mantendo quebras de linha comuns
-    cleaned = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\xff]", "", text)
+    # Remove control chars (excludes \t \n \r) and DEL; preserves Latin-1 chars like ç ã é
+    cleaned = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
     return cleaned.strip()
 
 

--- a/src/leizilla/storage.py
+++ b/src/leizilla/storage.py
@@ -142,6 +142,23 @@ class DuckDBStorage:
             return dict(zip(columns, result))
         return None
 
+    def get_leis_pending_ocr(
+        self, ente: Optional[str] = None, limit: int = 100
+    ) -> List[Dict[str, Any]]:
+        conn = self.connect()
+        query = (
+            "SELECT * FROM leis WHERE (texto_completo IS NULL OR texto_completo = '')"
+        )
+        params = []
+        if ente:
+            query += " AND ente = ?"
+            params.append(ente)
+        query += " LIMIT ?"
+        params.append(limit)
+        results = conn.execute(query, params).fetchall()
+        columns = [desc[0] for desc in conn.description]
+        return [dict(zip(columns, row)) for row in results]
+
     def update_lei(self, lei_id: str, updates: Dict[str, Any]) -> None:
         conn = self.connect()
         updates["updated_at"] = datetime.now()

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -12,6 +12,9 @@ def test_clean_ocr_text():
     assert clean_ocr_text("Hello\x00 World\r\n") == "Hello World"
     assert clean_ocr_text("") == ""
     assert clean_ocr_text(None) == ""
+    # Portuguese characters (Latin-1 range \x80-\xff) must be preserved
+    assert clean_ocr_text("ação legislação ônibus") == "ação legislação ônibus"
+    assert clean_ocr_text("Art. 5º — são garantidos") == "Art. 5º — são garantidos"
 
 
 def test_normalize_text():

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,83 @@
+"""Testes unitários para o módulo leizilla.ocr e o comando cmd_fetch_ocr."""
+
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+from leizilla.cli import app
+from leizilla.ocr import clean_ocr_text, normalize_text, fetch_and_clean_ocr
+
+runner = CliRunner()
+
+
+def test_clean_ocr_text():
+    assert clean_ocr_text("Hello\x00 World\r\n") == "Hello World"
+    assert clean_ocr_text("") == ""
+    assert clean_ocr_text(None) == ""
+
+
+def test_normalize_text():
+    # Test accents
+    assert normalize_text("Constituição") == "constituicao"
+    # Test lowercase and punctuation
+    assert normalize_text("Lei Nº 12.345, de 2026!") == "lei no 12345 de 2026"
+    # Test spaces and newlines
+    assert (
+        normalize_text("lei   ordinaria\n\ncomplementar")
+        == "lei ordinaria complementar"
+    )
+    # Empty
+    assert normalize_text("") == ""
+    assert normalize_text(None) == ""
+
+
+@patch("leizilla.ocr.fetch_ocr")
+def test_fetch_and_clean_ocr(mock_fetch):
+    mock_fetch.return_value = "raw \x00text"
+    assert fetch_and_clean_ocr("ia-item-123") == "raw text"
+    mock_fetch.assert_called_once_with("ia-item-123")
+
+    mock_fetch.return_value = None
+    assert fetch_and_clean_ocr("ia-item-123") is None
+
+
+def test_cli_fetch_ocr_no_laws():
+    with patch("leizilla.storage.DuckDBStorage") as mock_db_class:
+        mock_db = MagicMock()
+        mock_db.get_leis_pending_ocr.return_value = []
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(app, ["fetch-ocr"])
+    assert result.exit_code == 0
+    assert "Nenhuma lei sem OCR encontrada no banco" in result.output
+
+
+def test_cli_fetch_ocr_success():
+    laws = [
+        {
+            "id": "ro-casacivil-lei-05120",
+            "url_pdf_ia": "https://archive.org/details/leizilla-raw-ro-casacivil-lei-05120",
+            "ente": "ro",
+        }
+    ]
+
+    with (
+        patch("leizilla.storage.DuckDBStorage") as mock_db_class,
+        patch(
+            "leizilla.ocr.fetch_and_clean_ocr", return_value="lei constituicao"
+        ) as mock_ocr_fetch,
+    ):
+        mock_db = MagicMock()
+        mock_db.get_leis_pending_ocr.return_value = laws
+        mock_db_class.return_value = mock_db
+
+        result = runner.invoke(app, ["fetch-ocr"])
+
+    assert result.exit_code == 0
+    assert "Busca de OCR concluída: 1 com sucesso, 0 falhas" in result.output
+    mock_ocr_fetch.assert_called_once_with("leizilla-raw-ro-casacivil-lei-05120")
+    mock_db.update_lei.assert_called_once_with(
+        "ro-casacivil-lei-05120",
+        {
+            "texto_completo": "lei constituicao",
+            "texto_normalizado": "lei constituicao",
+        },
+    )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -170,3 +170,22 @@ def test_get_downloaded_resources(temp_db):
     downloaded = temp_db.get_downloaded_resources("ro", "casacivil")
     assert len(downloaded) == 1
     assert downloaded[0]["url"] == res_data["url"]
+
+
+def test_get_leis_pending_ocr(temp_db):
+    lei_data = {
+        "id": "ro-casacivil-lei-05120",
+        "titulo": "Lei 5120",
+        "ente": "ro",
+        "texto_completo": None,
+    }
+    temp_db.insert_lei(lei_data)
+
+    pending = temp_db.get_leis_pending_ocr("ro")
+    assert len(pending) == 1
+    assert pending[0]["id"] == "ro-casacivil-lei-05120"
+
+    # Set texto_completo
+    temp_db.update_lei("ro-casacivil-lei-05120", {"texto_completo": "conteudo da lei"})
+    pending = temp_db.get_leis_pending_ocr("ro")
+    assert len(pending) == 0


### PR DESCRIPTION
This PR implements the OCR text retrieval pipeline, exposing a new 'leizilla fetch-ocr' command and adding clean/normalize methods for legal text extraction.