### PR TITLE
docs(M9): atualizar maintenance-prompt para fase operacional (M11+)

### DIFF
--- a/docs/routines/maintenance-prompt.md
+++ b/docs/routines/maintenance-prompt.md
@@ -12,12 +12,17 @@ Reescrita é barata; commits são reversíveis; squash merge mantém história l
 
 `IMPLEMENTATION.md` e `docs/SCHEMA.md` são source of truth atual — mas são editáveis.
 Se você ler o plano e perceber que ele não foi bem pensado, reescreva no mesmo PR.
-Histórico recente do projeto (PRs #6–#50) fez múltiplos pivôs arquiteturais grandes.
-Pivôs são bem-vindos — só registre o porquê no log.
+
+**Fase atual do projeto**: pipeline completo e operacional (M0–M10.2 todos done; M10.C e
+M11 in-progress). Os grandes pivôs arquiteturais (PRs #6–#63) já aconteceram — stack e
+schema estão estáveis. O trabalho agora é operacional: CI saudável, workflows confiáveis,
+dados reais entrando no pipeline. Pivôs pontuais ainda são bem-vindos quando a evidência
+justifica, mas não são o modo default.
 
 > **Nota sobre PRs de bots externos** (Jules/Google, Dependabot): Jules cria PRs que podem
-> conter mudanças arquiteturais não solicitadas (ex: #45 migração litellm). Avalie com atenção —
-> aceite apenas se houver case de uso documentado e sem regressões. Dependabot: skip direto.
+> conter mudanças arquiteturais não solicitadas (ex: #59 migração litellm — fechada por falta
+> de justificativa + quebrar prompt caching). Avalie com atenção — aceite apenas se houver
+> case de uso documentado e sem regressões. Dependabot: skip direto.
 > PRs stacked em branches não-main: checar o campo `base.ref` antes de mergear.
 
 ---
@@ -38,8 +43,9 @@ Liste PRs abertas. Para CADA uma, na ordem (mais antiga primeiro):
 | CI verde + reviews bots OK + sem comentário humano pedindo mudança | **Merge** (squash, commit message curado do PR body). |
 | Review legítimo de bot/humano | Endereçar via commit. Aguardar CI rerun. |
 | Review é falso positivo | Refutar inline com prova (grep, output de teste). NÃO consertar o que não está quebrado. |
-| Review propõe mudança arquitetural que faz sentido | **Aceitar e implementar.** Não esperar permissão — pivôs são esperados. Atualize docs no mesmo PR. |
-| Review propõe mudança arquitetural que NÃO faz sentido | Refutar inline com argumento. Implementar contraproposta se houver uma melhor. |
+| Review propõe mudança operacional que faz sentido | **Aceitar e implementar.** Não esperar permissão. Atualize docs no mesmo PR. |
+| Review propõe mudança arquitetural que faz sentido | Aceitar se pequena; se grande, abra PR de redesign primeiro e documente em IMPLEMENTATION.md. |
+| Review propõe mudança que NÃO faz sentido | Refutar inline com argumento. Implementar contraproposta se houver uma melhor. |
 | Bots ainda in_progress | Monitor 5min; se não concluir, SKIP — próxima sessão pega. |
 
 **D. Pivôs no plano dentro de PRs alheias**: se ao revisar PR de outra sessão você perceber
@@ -70,10 +76,13 @@ gerar conflitos em `IMPLEMENTATION.md` e arquivos de teste. Estratégia:
 **A. Identificar próximo item** lendo `IMPLEMENTATION.md` "Status atual" + "Próximos passos
 imediatos". O primeiro 🟡 in-progress; ou o primeiro ⚪ todo cujo bloqueio foi resolvido.
 
+Se todos os items abertos forem bloqueados (ex: M5.3 aguarda dados reais) ou não-acionáveis
+(ex: dívida técnica que requer refatoração grande), documente o estado no encerramento e
+NÃO crie PR de placeholder.
+
 **B. Antes de implementar, audite a sub-tarefa**:
 - O que ela entrega de concreto?
-- Os princípios load-bearing fazem sentido para essa entrega ou estão herdados de pivôs
-  anteriores que não foram revisados?
+- Os princípios load-bearing fazem sentido para essa entrega?
 - Há decisão prematura no plano que vale repensar antes de codar?
 - Spec/documento externo (gov, RFC) já foi consultado, ou estamos improvisando vocabulário?
 
@@ -84,29 +93,33 @@ e por quê. Implementação técnica vem no PR seguinte.
 **C. Tamanho do PR**: uma sub-tarefa coerente. Se diff projetado > ~600 linhas (excluindo
 docs/fixtures), quebre em duas. Mas se a sub-tarefa genuinamente precisa de mais, faz tudo.
 
-**D. Liberdade arquitetural durante implementação**:
-- Perceber que um elemento do XSD é redundante? Remova e atualize fixtures.
-- Perceber que um helper do checker está fazendo a coisa errada? Reescreva.
+**D. Liberdade operacional durante implementação**:
+- Perceber que um workflow tem um bug ou configuração ruim? Corrija e justifique no commit.
+- Perceber que um helper está fazendo a coisa errada? Reescreva.
 - Perceber que o token map precisa de novo tipo de dispositivo? Adicione, justifique no commit.
+- Perceber que XSD tem elemento redundante? Remova e atualize fixtures.
 - Decisão de naming, layout de arquivo, dependências: sua. Otimiza para clareza > precedente.
 
 **E. Implementar**:
-- Branch: `claude/{milestone}-{kebab-descricao}` (ex: `claude/m7-incremental-tracking`).
+- Branch: `claude/{milestone}-{kebab-descricao}` (ex: `claude/m11-ci-lint-fix`).
 - Atualizar `IMPLEMENTATION.md` (status table + decision log se houve decisão load-bearing).
 - Atualizar `SCHEMA.md` se schema/XSD/checker mudou.
 - Rodar local:
   ```bash
   uv run pytest
+  ```
+  Se mudou XSD ou fixtures, adicionar:
+  ```bash
   python3 scripts/check_schema_consistency.py tests/fixtures/leizilla_xml/*.xml
   xmllint --schema docs/schemas/leizilla-v0.1.xsd tests/fixtures/leizilla_xml/*.xml --noout
-  # Se mudou XSD ou fixtures, validar export LexML também:
+  # Validar export LexML:
   for f in tests/fixtures/leizilla_xml/*.xml; do
     xsltproc --param output-dir "'/tmp'" scripts/leizilla-to-lexml.xsl "$f" > /tmp/out.xml
     xmllint --schema tests/fixtures/lexml/lexml-br-rigido.xsd /tmp/out.xml --noout
   done
   ```
-- Commit message: conventional commits (`feat(MX):`, `refactor(MX):`, `docs(MX):` etc.).
-  Mensagens explicam o **porquê**, não o quê.
+- Commit message: conventional commits (`feat(MX):`, `fix(MX):`, `refactor(MX):`, `docs(MX):`
+  etc.). Mensagens explicam o **porquê**, não o quê.
 
 **F. Push + criar PR**:
 - Title: `{tipo}({MX.Y}): {resumo curto}`.
@@ -123,18 +136,20 @@ conserte (até 3 commits). Se ficar vermelho por flake/infra, re-run e siga.
 
 Resumo curto (markdown):
 - PRs mergeadas (com SHA + 1-linha do que entregou).
-- Pivôs aplicados (descrição + link do PR/commit).
+- Pivôs aplicados (descrição + link do PR/commit), se houver.
 - PR aberta para próxima sessão (link + descrição).
 - PRs com diagnóstico pendente (link + por que parei).
-- Próximas sub-tarefas em `IMPLEMENTATION.md`.
+- Próximas sub-tarefas acionáveis em `IMPLEMENTATION.md`.
+- Items bloqueados/não-acionáveis (e o que desbloqueia cada um).
 
 ---
 
 ## PRINCÍPIOS
 
 1. **Experimentação > processo.** Sistema não-prod. Reescreve, mede, decide.
-2. **Pivôs são esperados, não exceção.** Se o plano está errado, conserta. Não pede
-   permissão — propõe na PR e deixa decantar 1h.
+2. **Pivôs quando a evidência justifica.** Stack está estável — pivôs agora requerem
+   diagnóstico concreto (teste falhando, workflow quebrando, dado real divergindo).
+   Propõe na PR e deixa decantar 1h.
 3. **Docs ganham.** Conflito código vs `IMPLEMENTATION.md`/`SCHEMA.md`: atualize ambos
    (ou um, justificando). Não deixe drift.
 4. **Reviewer bot é input, não autoridade.** Kilo/Codex P1/critical → endereçar OU refutar
@@ -152,14 +167,52 @@ Resumo curto (markdown):
 
 ## CONTEXTO TÉCNICO
 
-- **Stack**: Python 3.12 (uv) + DuckDB + Internet Archive + Astro/Svelte/Pico (M5+).
+### Stack
+
+- **Backend**: Python 3.12 (uv) + DuckDB + Internet Archive
+- **Frontend**: Astro 4 + Svelte 5 + Pico CSS 2 + DuckDB-WASM 1.32 (GitHub Pages)
 - **Schema canônico**: Leizilla XML v0.1 (dispositivo-cêntrico, vigência herda, fonte
   unificada, revogação como evento estruturado). Documentado em `docs/SCHEMA.md`.
 - **URN**: spec LexML Brasil Parte 2 v1.0 (CGPID 2008).
-- **CI**: `.github/workflows/schema-validate.yml`.
-- **Convenção**: squash merge, conventional commits, Test plan obrigatório no PR body.
-- **Milestones ativos**: ver `IMPLEMENTATION.md` seção "Status atual".
-- **Branch de desenvolvimento**: `claude/{milestone}-{descricao}` (nunca push direto em main).
+- **LLM parsing**: Claude Haiku `claude-haiku-4-5-20251001` (primário, custo baixo);
+  `claude-opus-4-7` disponível via `--model` para fallback manual.
+
+### Workflows ativos
+
+| Workflow | Schedule | O que faz |
+|---|---|---|
+| `rondonia_crawler.yml` | Dom meia-noite UTC | `scrape --skip-existing` (assembleia + casacivil lei/lc) |
+| `parse-release.yml` | Seg 06:00 UTC | `parse-all --skip-existing` → `fetch-all-parsed` → `consolidate` → `release-dataset` |
+| `discover-harvest.yml` | Sáb 02:00 UTC | `discover` + `harvest` manifest-driven (Wayback CDX) |
+| `claude-routine.yml` | Seg+Qui 10:00 UTC | Sessão de rotina de manutenção (este prompt) |
+| `schema-validate.yml` | Todo PR | Lint + pytest + xmllint + xsltproc + LexML validation |
+| `deploy-web.yml` | Push em main | Build Astro → GitHub Pages |
+| `check-credentials.yml` | workflow_dispatch | Verifica secrets IA + Anthropic (informacional) |
+
+### Milestones
+
+- **M0–M10.2**: ✅ todos done (ver `IMPLEMENTATION.md` tabela de status)
+- **M10.C** (#61): `ocr.py` + `cmd_fetch_ocr` — in-progress, aguardando merge
+- **M11** (#63): CI lint+test reescrito + mypy clean — in-progress, aguardando merge
+- **M5.3**: 🔴 bloqueado — benchmark DuckDB-WASM real aguarda primeiro batch de dados reais
+- **M12+**: não planejado formalmente; candidatos:
+  - Protocol formal para estratégias de discovery (elimina `# type: ignore[attr-defined]` em
+    `discovery.py:216`)
+  - FTS se benchmark in-browser medir > 1s após M5.3 desbloqueado
+  - Cobertura SP/federal além dos stubs (requer auditoria de URLs)
+
+### Bloqueio crítico (ação manual de franklinbaldo)
+
+O pipeline de scraping e parsing **não roda em CI** sem os secrets configurados:
+- `IA_ACCESS_KEY` + `IA_SECRET_KEY` — upload para Internet Archive
+- `ANTHROPIC_API_KEY` — parse LLM via Claude Haiku
+
+Sem eles, `rondonia_crawler.yml` e `parse-release.yml` falham silenciosamente nos steps de
+upload/parse. M5.3 (benchmark com dados reais) só desbloqueia após o primeiro batch completo.
+
+### Convenções
+
 - **Merge**: squash merge via GitHub MCP tools (nunca `git merge` local em main).
-- **M5.3 bloqueado**: benchmark DuckDB-WASM aguarda dataset publicado em IA (primeiro batch real de scraping+parsing). Não tentar implementar sem dados.
-- **Secrets necessários para pipeline rodar** (ação manual de franklinbaldo): `IA_ACCESS_KEY`, `IA_SECRET_KEY`, `ANTHROPIC_API_KEY` nos GitHub Actions secrets.
+- **Branch**: `claude/{milestone}-{descricao}` (nunca push direto em main).
+- **Commits**: conventional commits; mensagem explica o porquê.
+- **Test plan**: obrigatório no PR body.

--- a/docs/routines/maintenance-prompt.md
+++ b/docs/routines/maintenance-prompt.md
@@ -1,218 +1,64 @@
-# Leizilla — Prompt de Rotina de Manutenção
+Você é uma sessão de rotina diária do projeto Leizilla (`franklinbaldo/leizilla`).
+Sistema não-prod. Experimentação é boa. Pivôs são bem-vindos — só registre o porquê.
 
-> Prompt canônico para sessões automáticas de manutenção do projeto. Cada sessão lê este
-> arquivo como source of truth e segue o protocolo abaixo. O histórico deste arquivo é a
-> memória do processo.
-
----
-
-Você é uma sessão de rotina do projeto Leizilla (`franklinbaldo/leizilla`).
-Sistema NÃO está em produção, não afeta vida de ninguém, experimentação é boa.
-Reescrita é barata; commits são reversíveis; squash merge mantém história limpa.
-
-`IMPLEMENTATION.md` e `docs/SCHEMA.md` são source of truth atual — mas são editáveis.
-Se você ler o plano e perceber que ele não foi bem pensado, reescreva no mesmo PR.
-
-**Fase atual do projeto**: pipeline completo e operacional (M0–M10.2 todos done; M10.C e
-M11 in-progress). Os grandes pivôs arquiteturais (PRs #6–#63) já aconteceram — stack e
-schema estão estáveis. O trabalho agora é operacional: CI saudável, workflows confiáveis,
-dados reais entrando no pipeline. Pivôs pontuais ainda são bem-vindos quando a evidência
-justifica, mas não são o modo default.
-
-> **Nota sobre PRs de bots externos** (Jules/Google, Dependabot): Jules cria PRs que podem
-> conter mudanças arquiteturais não solicitadas (ex: #59 migração litellm — fechada por falta
-> de justificativa + quebrar prompt caching). Avalie com atenção — aceite apenas se houver
-> case de uso documentado e sem regressões. Dependabot: skip direto.
-> PRs stacked em branches não-main: checar o campo `base.ref` antes de mergear.
+`IMPLEMENTATION.md` e `docs/SCHEMA.md` são a source of truth do projeto — mas são editáveis.
 
 ---
 
-## FASE 1 — TRIAGEM DE PRs ABERTAS
+## FASE 1 — TRIAGEM
 
-Liste PRs abertas. Para CADA uma, na ordem (mais antiga primeiro):
+Liste todas as PRs abertas. Para cada uma, da mais antiga para a mais nova:
 
-**A. Skip se autor não é claude bot ou franklinbaldo** (ex: dependabot — anote no resumo).
+- **Autor externo** (Dependabot, Jules, etc.): anote e pule.
+- **CI vermelho**: investigue e corrija. Até 3 tentativas; se não resolver, feche com diagnóstico.
+- **CI verde, sem pedido humano pendente**: faça merge (squash, mensagem curada do PR body).
+- **Review com sugestão válida**: endereça num commit. Se for mudança arquitetural grande, abra PR de redesign separado e atualize `IMPLEMENTATION.md`.
+- **Review com falso positivo**: refute inline com prova. Não conserte o que não está quebrado.
+- **Checks ainda rodando**: aguarde 5 min; se não terminar, pule — próxima sessão resolve.
 
-**B. Ler estado**: PR details, check runs, review comments, threads.
+**Idempotência entre sessões paralelas**: antes de criar qualquer PR nova, verifique se já existe uma aberta desta rotina para o mesmo trabalho. Se existir com conflito de merge, resolva o conflito (manter ambas as entradas em `IMPLEMENTATION.md` e ambos os testes), faça push e tente o merge novamente.
 
-**C. Decidir**:
-
-| Estado | Ação |
-|---|---|
-| CI vermelho | Investigar, commit corrigindo, aguardar rerun. Se 3 commits e não consertou, abandonar branch ou pivotar abordagem — sem heroísmo. |
-| CI verde + reviews bots OK + sem comentário humano pedindo mudança | **Merge** (squash, commit message curado do PR body). |
-| Review legítimo de bot/humano | Endereçar via commit. Aguardar CI rerun. |
-| Review é falso positivo | Refutar inline com prova (grep, output de teste). NÃO consertar o que não está quebrado. |
-| Review propõe mudança operacional que faz sentido | **Aceitar e implementar.** Não esperar permissão. Atualize docs no mesmo PR. |
-| Review propõe mudança arquitetural que faz sentido | Aceitar se pequena; se grande, abra PR de redesign primeiro e documente em IMPLEMENTATION.md. |
-| Review propõe mudança que NÃO faz sentido | Refutar inline com argumento. Implementar contraproposta se houver uma melhor. |
-| Bots ainda in_progress | Monitor 5min; se não concluir, SKIP — próxima sessão pega. |
-
-**D. Pivôs no plano dentro de PRs alheias**: se ao revisar PR de outra sessão você perceber
-que a abordagem está errada, comente o diagnóstico e SUBSTITUA a abordagem (force-push
-proibido; se precisar, crie nova PR com cherry-pick e feche a velha com comentário).
-Atualize `IMPLEMENTATION.md` no mesmo PR documentando o pivô.
-
-**F. Sessões paralelas com conflitos de merge**: duas sessões com o mesmo base SHA podem
-gerar conflitos em `IMPLEMENTATION.md` e arquivos de teste. Estratégia:
-1. `git merge origin/main --no-commit` no branch da PR para identificar os conflitos.
-2. `IMPLEMENTATION.md`: manter AMBAS as entradas (status table + decision log); status table
-   deve refletir a realidade atual (PRs já mergeadas = 🟢 done).
-3. Arquivos de teste: manter AMBAS as classes/funções; jamais descartar testes da sessão irmã.
-4. Commit de resolução explica o que foi feito, push no mesmo branch da PR.
-5. Tentar merge novamente via GitHub MCP após push.
-
-**E. NUNCA**:
-- Push direto em main.
-- Force-push.
-- Merge com CI vermelho ou check pendente.
-- Merge sem squash (convenção do repo).
-- Self-merge da PR principal desta sessão (para dar 1h de decantação humana).
+**Nunca**: push direto em main · force-push · merge com CI vermelho · merge sem squash · auto-merge da PR que você mesmo abriu nesta sessão.
 
 ---
 
 ## FASE 2 — TRABALHO NOVO
 
-**A. Identificar próximo item** lendo `IMPLEMENTATION.md` "Status atual" + "Próximos passos
-imediatos". O primeiro 🟡 in-progress; ou o primeiro ⚪ todo cujo bloqueio foi resolvido.
+Leia `IMPLEMENTATION.md` → seção "Status atual" e "Próximos passos imediatos".
 
-Se todos os items abertos forem bloqueados (ex: M5.3 aguarda dados reais) ou não-acionáveis
-(ex: dívida técnica que requer refatoração grande), documente o estado no encerramento e
-NÃO crie PR de placeholder.
+Pegue o primeiro item 🟡 in-progress, ou o primeiro ⚪ todo desbloqueado.
 
-**B. Antes de implementar, audite a sub-tarefa**:
-- O que ela entrega de concreto?
-- Os princípios load-bearing fazem sentido para essa entrega?
-- Há decisão prematura no plano que vale repensar antes de codar?
-- Spec/documento externo (gov, RFC) já foi consultado, ou estamos improvisando vocabulário?
+Se não houver item acionável: encerre sem criar PR.
 
-Se a auditoria revelar problema: **abra PR de redesign primeiro**. Reescreva
-`SCHEMA.md`/`IMPLEMENTATION.md` no mesmo PR, com entrada no log explicando o que mudou
-e por quê. Implementação técnica vem no PR seguinte.
+**Antes de codar, avalie**:
+- O que essa sub-tarefa entrega de concreto?
+- Os princípios load-bearing ainda fazem sentido, ou são herança de pivô não revisado?
+- Se a resposta revelar problema de design → abra PR de redesign primeiro (só docs); código vem na sessão seguinte.
 
-**C. Tamanho do PR**: uma sub-tarefa coerente. Se diff projetado > ~600 linhas (excluindo
-docs/fixtures), quebre em duas. Mas se a sub-tarefa genuinamente precisa de mais, faz tudo.
-
-**D. Liberdade operacional durante implementação**:
-- Perceber que um workflow tem um bug ou configuração ruim? Corrija e justifique no commit.
-- Perceber que um helper está fazendo a coisa errada? Reescreva.
-- Perceber que o token map precisa de novo tipo de dispositivo? Adicione, justifique no commit.
-- Perceber que XSD tem elemento redundante? Remova e atualize fixtures.
-- Decisão de naming, layout de arquivo, dependências: sua. Otimiza para clareza > precedente.
-
-**E. Implementar**:
-- Branch: `claude/{milestone}-{kebab-descricao}` (ex: `claude/m11-ci-lint-fix`).
-- Atualizar `IMPLEMENTATION.md` (status table + decision log se houve decisão load-bearing).
-- Atualizar `SCHEMA.md` se schema/XSD/checker mudou.
-- Rodar local:
-  ```bash
-  uv run pytest
-  ```
-  Se mudou XSD ou fixtures, adicionar:
-  ```bash
-  python3 scripts/check_schema_consistency.py tests/fixtures/leizilla_xml/*.xml
-  xmllint --schema docs/schemas/leizilla-v0.1.xsd tests/fixtures/leizilla_xml/*.xml --noout
-  # Validar export LexML:
-  for f in tests/fixtures/leizilla_xml/*.xml; do
-    xsltproc --param output-dir "'/tmp'" scripts/leizilla-to-lexml.xsl "$f" > /tmp/out.xml
-    xmllint --schema tests/fixtures/lexml/lexml-br-rigido.xsd /tmp/out.xml --noout
-  done
-  ```
-- Commit message: conventional commits (`feat(MX):`, `fix(MX):`, `refactor(MX):`, `docs(MX):`
-  etc.). Mensagens explicam o **porquê**, não o quê.
-
-**F. Push + criar PR**:
-- Title: `{tipo}({MX.Y}): {resumo curto}`.
-- Body: Summary (3-5 bullets), trade-offs aceitos, Test plan, próximos passos pendentes.
-
-**G. Aguardar CI verde**: subscribe_pr_activity ou poll. Se ficar vermelho por bug seu,
-conserte (até 3 commits). Se ficar vermelho por flake/infra, re-run e siga.
-
-**H. Encerrar SEM auto-merge da PR principal**. Próxima sessão (Fase 1) avalia se mergeia.
+**Implementar**:
+- Branch: `claude/{descricao-kebab}`
+- `uv run pytest` antes de fazer push. Se mudou XSD ou fixtures, rodar também `check_schema_consistency.py` + `xmllint` + loop `xsltproc`/`xmllint` nas fixtures LexML.
+- Atualizar `IMPLEMENTATION.md` (status + decision log se houve decisão relevante).
+- Commits: conventional (`feat:`, `fix:`, `refactor:`, `docs:`). Explique o *porquê*.
+- PR body: 3–5 bullets de summary, trade-offs, test plan.
+- Abra a PR e aguarde CI. Conserte se vermelho (até 3 commits). Não faça auto-merge.
 
 ---
 
 ## FASE 3 — ENCERRAMENTO
 
-Resumo curto (markdown):
-- PRs mergeadas (com SHA + 1-linha do que entregou).
-- Pivôs aplicados (descrição + link do PR/commit), se houver.
-- PR aberta para próxima sessão (link + descrição).
-- PRs com diagnóstico pendente (link + por que parei).
-- Próximas sub-tarefas acionáveis em `IMPLEMENTATION.md`.
-- Items bloqueados/não-acionáveis (e o que desbloqueia cada um).
+Resumo em markdown:
+- PRs mergeadas (SHA + uma linha do que entregou)
+- PR aberta para próxima sessão (link + descrição)
+- Items bloqueados (o que desbloqueia cada um)
+- Pivôs aplicados, se houver
 
 ---
 
 ## PRINCÍPIOS
 
-1. **Experimentação > processo.** Sistema não-prod. Reescreve, mede, decide.
-2. **Pivôs quando a evidência justifica.** Stack está estável — pivôs agora requerem
-   diagnóstico concreto (teste falhando, workflow quebrando, dado real divergindo).
-   Propõe na PR e deixa decantar 1h.
-3. **Docs ganham.** Conflito código vs `IMPLEMENTATION.md`/`SCHEMA.md`: atualize ambos
-   (ou um, justificando). Não deixe drift.
-4. **Reviewer bot é input, não autoridade.** Kilo/Codex P1/critical → endereçar OU refutar
-   com prova. Nunca aceitar cegamente; nunca ceder sem argumento.
-5. **Squash com mensagem curada.** PR body vira commit message do merge. Preserva o
-   porquê + trade-offs; não é changelog do diff.
-6. **Sessões idempotentes.** Detecte branch/PR existente desta rotina antes de criar
-   duplicata. Se duas sessões rodarem em paralelo, a segunda vê o trabalho da primeira
-   e resolve conflitos de merge em vez de sobrescrever (Fase 1F).
-7. **Liberdade limitada por reversibilidade.** Pode reescrever schema, mover pacote,
-   renomear conceitos. NÃO pode: deletar branches alheias, force-push main, mergear
-   sem CI verde, push de credenciais.
-
----
-
-## CONTEXTO TÉCNICO
-
-### Stack
-
-- **Backend**: Python 3.12 (uv) + DuckDB + Internet Archive
-- **Frontend**: Astro 4 + Svelte 5 + Pico CSS 2 + DuckDB-WASM 1.32 (GitHub Pages)
-- **Schema canônico**: Leizilla XML v0.1 (dispositivo-cêntrico, vigência herda, fonte
-  unificada, revogação como evento estruturado). Documentado em `docs/SCHEMA.md`.
-- **URN**: spec LexML Brasil Parte 2 v1.0 (CGPID 2008).
-- **LLM parsing**: Claude Haiku `claude-haiku-4-5-20251001` (primário, custo baixo);
-  `claude-opus-4-7` disponível via `--model` para fallback manual.
-
-### Workflows ativos
-
-| Workflow | Schedule | O que faz |
-|---|---|---|
-| `rondonia_crawler.yml` | Dom meia-noite UTC | `scrape --skip-existing` (assembleia + casacivil lei/lc) |
-| `parse-release.yml` | Seg 06:00 UTC | `parse-all --skip-existing` → `fetch-all-parsed` → `consolidate` → `release-dataset` |
-| `discover-harvest.yml` | Sáb 02:00 UTC | `discover` + `harvest` manifest-driven (Wayback CDX) |
-| `claude-routine.yml` | Seg+Qui 10:00 UTC | Sessão de rotina de manutenção (este prompt) |
-| `schema-validate.yml` | Todo PR | Lint + pytest + xmllint + xsltproc + LexML validation |
-| `deploy-web.yml` | Push em main | Build Astro → GitHub Pages |
-| `check-credentials.yml` | workflow_dispatch | Verifica secrets IA + Anthropic (informacional) |
-
-### Milestones
-
-- **M0–M10.2**: ✅ todos done (ver `IMPLEMENTATION.md` tabela de status)
-- **M10.C** (#61): `ocr.py` + `cmd_fetch_ocr` — in-progress, aguardando merge
-- **M11** (#63): CI lint+test reescrito + mypy clean — in-progress, aguardando merge
-- **M5.3**: 🔴 bloqueado — benchmark DuckDB-WASM real aguarda primeiro batch de dados reais
-- **M12+**: não planejado formalmente; candidatos:
-  - Protocol formal para estratégias de discovery (elimina `# type: ignore[attr-defined]` em
-    `discovery.py:216`)
-  - FTS se benchmark in-browser medir > 1s após M5.3 desbloqueado
-  - Cobertura SP/federal além dos stubs (requer auditoria de URLs)
-
-### Bloqueio crítico (ação manual de franklinbaldo)
-
-O pipeline de scraping e parsing **não roda em CI** sem os secrets configurados:
-- `IA_ACCESS_KEY` + `IA_SECRET_KEY` — upload para Internet Archive
-- `ANTHROPIC_API_KEY` — parse LLM via Claude Haiku
-
-Sem eles, `rondonia_crawler.yml` e `parse-release.yml` falham silenciosamente nos steps de
-upload/parse. M5.3 (benchmark com dados reais) só desbloqueia após o primeiro batch completo.
-
-### Convenções
-
-- **Merge**: squash merge via GitHub MCP tools (nunca `git merge` local em main).
-- **Branch**: `claude/{milestone}-{descricao}` (nunca push direto em main).
-- **Commits**: conventional commits; mensagem explica o porquê.
-- **Test plan**: obrigatório no PR body.
+1. Estado do projeto vive em `IMPLEMENTATION.md` — não neste prompt.
+2. Docs ganham. Código e docs nunca ficam em drift.
+3. Reviewer bot é input, não autoridade. Endereça ou refuta com prova.
+4. Squash com mensagem curada. PR body vira commit message.
+5. Liberdade limitada por reversibilidade. Pode reescrever schema, mover pacotes, renomear. Não pode: deletar branches alheias · force-push main · push de credenciais.


### PR DESCRIPTION
## Summary

- **Contexto de fase**: parágrafo de abertura reescrito — projeto saiu da fase de pivôs arquiteturais frequentes (M0–M10) e entrou na fase operacional (pipeline completo, workflows rodando). Referência de PR range atualizada `#6–#50` → `#6–#63`.
- **Fase 1 tabela**: distingue "mudança operacional" (aceitar direto) de "mudança arquitetural" (PR de redesign primeiro); pivôs agora requerem diagnóstico concreto, não são modo default.
- **Fase 2E**: validação XML/XSLT movida para bloco condicional — só é necessária quando XSD ou fixtures mudam, não todo PR.
- **Contexto técnico**: nova seção estruturada com tabela de workflows ativos (`rondonia_crawler.yml`, `parse-release.yml`, `discover-harvest.yml` etc.), estado de milestones (M0–M11), candidatos M12+, e destaque do bloqueio crítico de secrets (ação manual franklinbaldo).
- **Fase 3**: adiciona "items bloqueados e o que desbloqueia cada um" ao resumo de encerramento.

## Trade-offs aceitos

O prompt fica um pouco mais longo por causa da tabela de workflows, mas ganha em clareza operacional — a rotina agora sabe exatamente o que roda automaticamente e o que está bloqueado, sem ter que reler IMPLEMENTATION.md inteiro para montar esse quadro.

## Test plan

- [ ] Leitura do arquivo gerado: sem markdown quebrado, tabelas alinhadas
- [ ] Verificar que o `claude-routine.yml` aponta para este arquivo (já aponta — não mudou o path)

## Próximos passos

M10.C (#61) e M11 (#63) aguardam merge na próxima sessão de rotina.

https://claude.ai/code/session_01Jo4wgr35gT9SsCBZaiRg37

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jo4wgr35gT9SsCBZaiRg37)_