### PR TITLE
fix: corrigir referência undefined _CASACIVIL_FONTE_URL em cli.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,4 +84,5 @@ follow_imports = "skip"
 [dependency-groups]
 dev = [
     "pytest>=8.4.1",
+    "types-requests>=2.32",
 ]

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -409,16 +409,23 @@ def cmd_scrape(
             elif ente == "ro" and fonte == "casacivil":
                 laws = []
                 from leizilla.discovery import WaybackCdxDiscovery
-                is_mocked = hasattr(WaybackCdxDiscovery, "mock") or hasattr(WaybackCdxDiscovery, "return_value") or "MagicMock" in str(type(WaybackCdxDiscovery))
+
+                is_mocked = (
+                    hasattr(WaybackCdxDiscovery, "mock")
+                    or hasattr(WaybackCdxDiscovery, "return_value")
+                    or "MagicMock" in str(type(WaybackCdxDiscovery))
+                )
                 if "PYTEST_CURRENT_TEST" not in os.environ or is_mocked:
                     try:
-                        echo(f"Consultando API CDX da Wayback Machine para {ente}/{fonte}...")
+                        echo(
+                            f"Consultando API CDX da Wayback Machine para {ente}/{fonte}..."
+                        )
                         cdx_cfg = {
                             "prefix": "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/"
                         }
                         discovery = WaybackCdxDiscovery(cdx_cfg, ente, fonte)
                         discovered = discovery.run()
-                        
+
                         for item in discovered:
                             if item["tipo_documento"] != tipo:
                                 continue
@@ -426,24 +433,34 @@ def cmd_scrape(
                                 # Extract number to filter by start/end range
                                 num = int(item["chave"].split("-")[-1])
                                 if start_coddoc <= num <= end_coddoc:
-                                    laws.append({
-                                        "id": f"{ente}-{fonte}-{item['chave']}",
-                                        "ente": ente,
-                                        "fonte": fonte,
-                                        "chave": item["chave"],
-                                        "titulo": f"{tipo.upper()} {item['chave'].split('-')[-1]} ({ente.upper()})",
-                                        "url_original": _CASACIVIL_FONTE_URL,
-                                        "url_pdf_original": item["url"],
-                                    })
+                                    laws.append(
+                                        {
+                                            "id": f"{ente}-{fonte}-{item['chave']}",
+                                            "ente": ente,
+                                            "fonte": fonte,
+                                            "chave": item["chave"],
+                                            "titulo": f"{tipo.upper()} {item['chave'].split('-')[-1]} ({ente.upper()})",
+                                            "url_original": item.get(
+                                                "url_original",
+                                                "https://www.casacivil.ro.gov.br/leis",
+                                            ),
+                                            "url_pdf_original": item["url"],
+                                        }
+                                    )
                             except ValueError:
                                 continue
-                        echo(f"  Encontradas {len(laws)} leis existentes arquivadas na faixa {start_coddoc}-{end_coddoc}")
+                        echo(
+                            f"  Encontradas {len(laws)} leis existentes arquivadas na faixa {start_coddoc}-{end_coddoc}"
+                        )
                     except Exception as e:
-                        echo(f"  Erro ao consultar CDX ({e}). Usando fallback sequencial.")
+                        echo(
+                            f"  Erro ao consultar CDX ({e}). Usando fallback sequencial."
+                        )
                         laws = []
 
                 if not laws:
                     from leizilla.crawler import discover_casacivil_laws
+
                     laws = discover_casacivil_laws(
                         tipo=tipo,
                         start_num=start_coddoc,
@@ -934,7 +951,11 @@ def cmd_parse_all(
             output_dir.mkdir(parents=True, exist_ok=True)
 
         from leizilla.parser import fetch_ia_html, fetch_ocr, parse_law
-        from leizilla.publisher import InternetArchivePublisher, list_parsed_raw_ids, list_raw_ids
+        from leizilla.publisher import (
+            InternetArchivePublisher,
+            list_parsed_raw_ids,
+            list_raw_ids,
+        )
 
         already_parsed: set[str] = set()
         if skip_existing:
@@ -945,14 +966,24 @@ def cmd_parse_all(
         pub = InternetArchivePublisher() if upload else None
 
         raw_items_on_ia = None
-        is_mocked = hasattr(list_raw_ids, "mock") or hasattr(list_raw_ids, "return_value") or "MagicMock" in str(type(list_raw_ids))
+        is_mocked = (
+            hasattr(list_raw_ids, "mock")
+            or hasattr(list_raw_ids, "return_value")
+            or "MagicMock" in str(type(list_raw_ids))
+        )
         if "PYTEST_CURRENT_TEST" not in os.environ or is_mocked:
             try:
-                echo(f"Consultando IA para obter lista de itens raw disponíveis ({ente}/{fonte})...")
+                echo(
+                    f"Consultando IA para obter lista de itens raw disponíveis ({ente}/{fonte})..."
+                )
                 raw_items_on_ia = list_raw_ids(ente, fonte)
-                echo(f"  {len(raw_items_on_ia)} itens raw encontrados no Internet Archive")
+                echo(
+                    f"  {len(raw_items_on_ia)} itens raw encontrados no Internet Archive"
+                )
             except Exception as e:
-                echo(f"  Aviso: não foi possível listar itens do IA ({e}). Usando fallback sequencial.")
+                echo(
+                    f"  Aviso: não foi possível listar itens do IA ({e}). Usando fallback sequencial."
+                )
 
         # Build target items list
         target_items = []

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -185,7 +185,9 @@ class TestUploadParsed:
         def capture_run(cmd, **kwargs):
             for arg in cmd:
                 if arg.endswith("parsed_meta.json"):
-                    captured_metas.append(json.loads(Path(arg).read_text(encoding="utf-8")))
+                    captured_metas.append(
+                        json.loads(Path(arg).read_text(encoding="utf-8"))
+                    )
             return MagicMock(returncode=0)
 
         with patch("subprocess.run", side_effect=capture_run):

--- a/uv.lock
+++ b/uv.lock
@@ -499,6 +499,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -520,7 +521,10 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.4.1" }]
+dev = [
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "types-requests", specifier = ">=2.32" },
+]
 
 [[package]]
 name = "markdown-it-py"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Corrige erro `F821` (ruff) em `cli.py:435`: variável `_CASACIVIL_FONTE_URL` referenciada mas nunca definida
- Substitui pela URL do portal da Casa Civil via `item.get("url_original", "https://www.casacivil.ro.gov.br/leis")`, permitindo que itens retornados pelo CDX já tragam a URL canônica
- Aplica reformatação automática (ruff) nos arquivos `cli.py` e `test_publisher.py`

## Test plan

- [ ] `uv run leizilla dev lint` — deve passar sem erros F821
- [ ] `uv run leizilla dev check` — lint + format-check + typecheck + test
- [ ] Smoke test: `uv run leizilla scrape --ente ro --fonte casacivil --start-coddoc 1 --end-coddoc 5` não deve lançar `NameError`

https://claude.ai/code/session_016WjVRM4pQEr4x2695A2dJx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WjVRM4pQEr4x2695A2dJx)_