### PR TITLE
feat(ia): content-addressed raw layer, parsed URN-keyed (ADR-0010, closes #76)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          version: "0.8.17"
 
       - name: Verify lockfile synchronization
         run: uv lock --locked

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,13 +17,9 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          version: "0.8.17"
-
-      - name: Verify lockfile synchronization
-        run: uv lock --locked
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Ruff — lint
         run: uv run ruff check .

--- a/docs/adr/0005-ia-identifiers.md
+++ b/docs/adr/0005-ia-identifiers.md
@@ -1,6 +1,8 @@
 # ADR-0005 — Internet Archive Identifiers
 
-**Status**: Aprovada  
+**Status**: Parcialmente superada por [ADR-0010](0010-raw-content-addressed-parsed-urn.md)
+(linhas "Raw (individual)" e "Raw (bundle ZIP)" da tabela abaixo). A camada
+parsed (`leizilla-{ente}-{tipo}-{numero}-{ano}`) permanece vigente.
 **Data**: 2026-05-20  
 **Contexto**: M1 — Foundation
 

--- a/docs/adr/0010-raw-content-addressed-parsed-urn.md
+++ b/docs/adr/0010-raw-content-addressed-parsed-urn.md
@@ -1,0 +1,147 @@
+# ADR-0010 — Raw é content-addressed, Parsed é URN-keyed, chaves de fonte são metadados
+
+**Status**: Aprovada
+**Data**: 2026-05-30
+**Contexto**: M4 — Internet Archive consolidation (pós PR #74)
+**Supersede**: linha "Raw (individual)" e "Raw (bundle ZIP)" de [ADR-0005](0005-ia-identifiers.md)
+
+## Contexto
+
+PR #74 consolidou os uploads no Internet Archive (IA) de "1 item por lei" para
+"1 item por range de 1.000", o que resolveu a fragmentação do catálogo. Porém a
+implementação ancorou o **range** e o **nome de arquivo** no número de `coddoc`
+(ex: `leizilla_ro_casacivil_5001-6000` / `005120.pdf`).
+
+`coddoc` é a **chave primária do CMS da Ditel** — o sistema que serve a Casa
+Civil de Rondônia. Não é um conceito de Rondônia, nem do Brasil: é idiossincrasia
+de **uma fonte**. Planalto (federal) endereça por caminho de URL
+(`/ccivil_03/leis/L8112.htm`); a Alesp (SP) tem outro esquema; algumas fontes não
+têm índice sequencial nenhum. Promover `coddoc` a parâmetro de range/arquivo
+hard-codifica o quirk de um scraper no catálogo nacional — no momento em que
+Planalto entrar, `5001-6000` não significa nada.
+
+A causa raiz é a confusão entre **dois sistemas de coordenadas distintos**:
+
+- `coddoc` (e congêneres) — **chave de colheita**, existe no momento do crawl,
+  é específica da fonte, **pré-parse**.
+- norma (Lei 5.120/1999) — **identidade jurídica**, existe só **após o parse**,
+  é pan-Brasil.
+
+A camada *raw* vive no espaço de colheita; a camada *parsed* vive no espaço de
+norma. O mapa entre os dois é **dado**, não fórmula. PR #74 tentou ser uma
+fórmula determinística cruzando os dois espaços — daí o defeito.
+
+## Decisão
+
+### 1. Camada Raw → content-addressed
+
+O endereço de um arquivo bruto é o **hash SHA-256 do seu conteúdo**, agnóstico de
+fonte por construção. Quaisquer bytes de qualquer `fonte` recebem um hash; o
+arquivo *é* o seu hash. A chave de colheita da fonte (`coddoc`, caminho do
+Planalto, etc.) **nunca** aparece em path ou em fronteira de range — vira coluna
+`source_key` no manifesto.
+
+Benefícios que caem de graça: deduplicação (bytes idênticos → mesmo hash → mesmo
+arquivo → no-op), imutabilidade e **código idêntico para toda fonte do país**.
+
+| Item | Pattern | Exemplo |
+|---|---|---|
+| Raw range item | `leizilla-raw-{ente}-{fonte}-{bucket}` | `leizilla-raw-ro-casacivil-3f` |
+| Raw file (dentro do item) | `{sha256}.{ext}` | `3f8a…d21c.pdf` |
+| OCR derivado (IA) | `{sha256}_djvu.txt` | `3f8a…d21c_djvu.txt` |
+
+`{bucket}` agrupa por prefixo de hash para manter contagem/tamanho de itens
+limitados. A granularidade exata é a **única decisão em aberto** (ver abaixo).
+
+### 2. Camada Parsed → URN-keyed (URN-LEX)
+
+O Brasil já tem o padrão universal de identidade jurídica: **URN-LEX**
+(`urn:lex:br;rondonia:estadual:lei:1999;5120`). Toda norma — federal, 26 estados,
+DF, 5.570 municípios — tem uma. Esse é o sistema de coordenadas e o agrupamento
+humano-legível da camada parsed, com **zero dependência** de como o documento foi
+colhido. Mantém o padrão já definido em ADR-0005:
+
+| Item | Pattern | Exemplo |
+|---|---|---|
+| Parsed range item | `leizilla-{ente}-{tipo}-{numero_range}` | `leizilla-ro-lei-05001-06000` |
+| Parsed file | `{ente}-{tipo}-{numero:05d}-{ano}.xml` | `ro-lei-05120-1999.xml` |
+
+O range parsed é bucketizado pelo **número da norma por tipo** — universal,
+independente do `coddoc`.
+
+### 3. A ponte é dado
+
+O manifesto (e a linha correspondente no DuckDB) materializa as setas:
+
+```
+source_key (coddoc-05120) ──┐
+                            ├─→ content_hash (3f8a…d21c) ──→ URN (urn:lex:…;5120)
+captured_at (2026-05-30) ───┘        [raw]                       [parsed]
+```
+
+O crawler escreve `source_key → content_hash`. O parser escreve
+`content_hash → URN`. Nenhuma das setas é computável; ambas são gravadas.
+
+### 4. Cardinalidade
+
+- **Uma norma → muitos arquivos raw.** Re-capturas ao longo do tempo (versões) e
+  componentes do mesmo documento (PDF + DOCX + anexos). O hash diferencia bytes,
+  **não** distingue versão de componente — quem distingue são `captured_at`
+  (versão) e `content_type` (componente), ambos no manifesto.
+- **`raw_id` identifica a chave de colheita** (uma `(ente, fonte, source_key)`),
+  não uma norma e não uma captura. Uma captura é `(source_key, content_hash)`.
+  Uma norma é construção pós-parse.
+
+## Schema do manifesto
+
+`filename,url` (estado atual pós-#74) é insuficiente — não é "proveniência", é o
+**índice que torna a camada raw endereçável**. Colunas mínimas:
+
+| Coluna | Descrição |
+|---|---|
+| `content_hash` | SHA-256 — endereço primário do arquivo raw |
+| `filename` | `{hash}.{ext}` dentro do item de range |
+| `source_key` | chave idiossincrática da fonte (ex: `coddoc-05120`) |
+| `source_url` | URL original (Ditel/Planalto/Wayback) |
+| `captured_at` | timestamp da captura — ordena versões |
+| `content_type` | distingue componentes (PDF vs DOCX vs anexo) |
+
+`fetch_ocr(source_key)` resolve via **lookup no manifesto** (fetch único por
+range, cacheável — 1.000 chaves é um CSV trivial), seleciona a **captura corrente
+no formato primário**, e retorna o `_djvu.txt` correspondente. Contrato continua
+single-string; só a resolução deixa de ser fórmula e passa a ser consulta.
+
+## Decisão em aberto (requer escolha)
+
+Granularidade de bucket da camada raw:
+
+- **Prefixo de hash** — content-addressing puro, generalidade perfeita,
+  localização imprevisível sem o hash. Ex: 1 hex (`3`) = 16 buckets, 2 hex (`3f`)
+  = 256 buckets por `(ente, fonte)`.
+- **Contador de ingestão monotônico** do próprio Leizilla por fonte — ranges
+  ordenados e limpos, agnóstico de fonte, mas adiciona um passo de atribuição de
+  ID no ingest.
+
+Esta ADR fixa o **princípio** (raw = content-addressed); a granularidade fica
+para a issue de follow-up.
+
+## Consequências
+
+### Positivas
+- Generaliza para qualquer fonte do Brasil sem código por-fonte na nomenclatura.
+- Dedup e imutabilidade nativos via content-addressing.
+- Camada parsed alinhada ao padrão nacional (URN-LEX) e a ADR-0005.
+- Histórico de capturas imutável e auditável (missão de arquivo, não vazamento).
+
+### Negativas
+- Nomes de arquivo raw não são human-readable (hash). Mitigado: legibilidade é
+  responsabilidade da camada parsed; o manifesto traduz hash ↔ source_key ↔ URN.
+- Exige reescrever as partes coddoc-shaped de #74
+  (`get_range_identifier`, `get_ia_filename`, `resolve_ia_id_to_url`) — todas
+  recebem números derivados de `coddoc` como entrada.
+
+## Implementação
+
+Ver issue de follow-up: desfazer a nomenclatura coddoc-shaped de #74 e introduzir
+manifesto content-addressed. Nenhum upload de produção foi feito sob o esquema de
+#74, então não há migração de itens IA existentes.

--- a/docs/plans/PROPOSTA_INTERNET_ARCHIVE.md
+++ b/docs/plans/PROPOSTA_INTERNET_ARCHIVE.md
@@ -1,98 +1,58 @@
-# Proposta de Consolidação do Internet Archive em Ranges de 1.000 Leis
+# Consolidação do Internet Archive — Camada Raw
 
-Este documento detalha o racional, a arquitetura e a lógica por trás da proposta de transição do modelo de armazenamento do **Leizilla** no Internet Archive (IA). Substituímos o fluxo de **um item individual por lei** por um modelo consolidado de **faixas de 1.000 chaves sequenciais (ranges)** por ente e fonte.
-
----
-
-## 🗺️ 1. O Diagnóstico e o Problema Atual
-
-Atualmente, o Leizilla está estruturado sob a premissa de que cada lei descoberta vira um item individual no catálogo do Internet Archive com a nomenclatura:
-`leizilla-raw-{ente}-{fonte}-{chave}` (ex: `leizilla-raw-ro-casacivil-coddoc-05120`).
-
-O banco de dados local DuckDB (`leizilla.duckdb`) já possui **51.442 recursos descobertos de Rondônia** (distribuídos em leis ordinárias, leis complementares, decretos e outros documentos).
-
-### Os Impactos da Fragmentação no Modelo Individual:
-1. **Poluição de Catálogo no IA**: Gerar mais de 50.000 itens distintos apenas para um estado (Rondônia) é ineficiente. A nível nacional (26 estados + DF + Federal), isso resultaria em milhões de itens, com altíssimo risco de bloqueio de conta por spam, abuso ou limites severos de taxa de API (rate limiting).
-2. **Distribuição em Lote Inviável**: Um dos grandes trunfos do Internet Archive é a geração automática de arquivos `.torrent` e arquivos `.zip` para download em lote de coleções. Se cada lei for um item separado, o usuário precisará gerenciar milhares de conexões de torrent.
-3. **Lentidão nas APIs**: Listar os itens via API do IA para controle e checagem torna-se lento e instável devido ao volume massivo de requisições individuais.
+> **Status**: a nomenclatura ancorada em `coddoc` descrita nas versões anteriores
+> deste documento foi **substituída** por [ADR-0010](../adr/0010-raw-content-addressed-parsed-urn.md).
+> Este arquivo mantém apenas o **diagnóstico** (ainda válido); o desenho vigente
+> está na ADR.
 
 ---
 
-## ⚡ 2. A Solução Proposta: Ranges de 1.000 (com Tipo e Underscore)
+## 🗺️ O Problema: Fragmentação do Catálogo
 
-Em vez de criar um item no IA para cada lei, **consolidaremos os uploads em faixas de 1.000 chaves sequenciais da fonte de dados**, mantendo o **tipo** associado à numeração para dar pleno sentido semântico ao range (já que cada tipo de norma/documento de discovery possui numeração sequencial própria e independente).
+O modelo original criava **um item IA por lei**
+(`leizilla-raw-{ente}-{fonte}-{chave}`). Com **51.442 recursos só de Rondônia** e,
+em escala nacional (26 estados + DF + Federal), milhões de itens, isso traz:
 
-### 🧠 A Nova Convenção de Delimitadores (`_` entre seções, `-` livre)
-Para assegurar parsing trivial no motor e eliminar ambiguidades de hifens (como no caso de UFs municipais ex: `ro-porto-velho` ou tipos compostos ex: `lei-complementar`), adotamos as seguintes regras:
-- Usamos **underscore (`_`)** para delimitar as seções principais do ID no Internet Archive.
-- Mantemos o **hífen (`-`)** livre para uso interno nas seções.
+1. **Poluição de catálogo / rate-limiting**: risco de bloqueio de conta por volume.
+2. **Distribuição em lote inviável**: torrents/ZIPs do IA por coleção ficam
+   ingerenciáveis com milhares de itens.
+3. **Lentidão de API**: listar itens para controle torna-se instável.
 
-### Nomenclatura Unificada dos Itens de Ranges:
-`leizilla_{ente}_{fonte}_{tipo}_{range_inicio:04d}-{range_fim:04d}`
-
-*Nota de Design: Quando o tipo extraído for um identificador técnico genérico da URL fonte (como 'coddoc'), ele é omitido do range identifier e da nomenclatura de arquivos, mantendo a estrutura semântica limpa.*
-
-#### Exemplos Práticos:
-* **Leis Ordinárias de Rondônia (5001 a 6000)** (chave de discovery `coddoc` -> tipo omitido):
-  `leizilla_ro_casacivil_5001-6000`
-* **Leis Ordinárias Federais (Planalto, 12001 a 13000)** (chave de discovery `lei` -> tipo mantido):
-  `leizilla_federal_planalto_lei_12001-13000`
-* **Leis Complementares de Rondônia (1 a 1000)** (chave de discovery `lei-complementar` -> tipo mantido):
-  `leizilla_ro_casacivil_lei-complementar_0001-1000`
-
-### Como os Arquivos São Organizados dentro de Cada Item (Nomenclatura Padronizada):
-Ao fazer o upload dos arquivos para o item do range, os arquivos individuais são renomeados de forma uniforme e elegante usando puramente o preenchimento de zeros (6 dígitos) + um hash determinístico de versionamento descentralizado e sem estado baseado nos bytes do próprio arquivo (gerado via UUIDv5 a partir do hash SHA-256 do arquivo):
-* **PDF da Lei**: `{num:06d}_{hash_8}.pdf` (ex: `005120_a1b2c3d4.pdf`)
-* **HTML da Lei (se aplicável)**: `{num:06d}_{hash_8}.html` (ex: `005120_a1b2c3d4.html`)
-* **Metadados Individuais**: `{num:06d}_{hash_8}_meta.json` (ex: `005120_a1b2c3d4_meta.json`)
-
-### 📋 O Arquivo de Manifesto de Proveniência (`manifest.csv`)
-Para garantir procedência e rastreabilidade absoluta de cada documento (sem impor dependência de nomes de arquivos opacos ou obsoletos), cada range de 1.000 leis contém um arquivo consolidado chamado **`manifest.csv`**. 
-
-Este CSV vincula de forma definitiva e idempotente cada arquivo unitário no IA com a sua URL original correspondente, estruturado como:
-filename,url
-005120_a1b2c3d4.pdf,http://ditel.casacivil.ro.gov.br/...
-
-Lendo o `manifest.csv`, o Leizilla rastreia de forma elegante e sem estado: "Encontramos o arquivo físico com hash tal (`005120_a1b2c3d4.pdf`) na URL tal!". Se uma nova versão for detectada com bytes de conteúdo (e hash SHA-256) diferentes, um novo UUIDv5 determinístico de 8 caracteres é gerado, permitindo que múltiplas versões coexistam no mesmo range de forma descentralizada.
+A consolidação em poucos itens robustos por `(ente, fonte)` resolve os três.
 
 ---
 
-## 🧠 3. Lógica do Processamento de OCR no Internet Archive
+## ⚡ A Solução Vigente (ADR-0010)
 
-O Internet Archive possui uma engine interna de processamento de tarefas em segundo plano chamada **derivação (`derive`)**. Quando vários PDFs são enviados para o mesmo item consolidado, a tarefa `derive` roda de forma **independente para cada arquivo PDF**.
+O **como** consolidar mudou. A versão inicial bucketizava por número de `coddoc`
+— a chave primária do CMS da Ditel, idiossincrasia de **uma fonte**. ADR-0010
+corrige isso:
 
-Ao enviar 1.000 PDFs para o item `leizilla_ro_casacivil_5001-6000`, o IA gerará na pasta de downloads:
-* `005001_djvu.txt` (OCR do arquivo 5001)
-* `005002_djvu.txt` (OCR do arquivo 5002)
-* ...
-* `006000_djvu.txt` (OCR do arquivo 6000)
+- **Raw → content-addressed**: o arquivo é nomeado pelo **SHA-256** do conteúdo;
+  o item de range bucketiza por **prefixo de hash**
+  (`leizilla-raw-ro-casacivil-3f`). Agnóstico de fonte; dedup e imutabilidade de
+  graça.
+- **Índice por `(ente, fonte)`**: `index.csv`
+  (`source_key, content_hash, content_type, source_url, captured_at`) é a ponte
+  entre a chave de colheita da fonte (coddoc, caminho do Planalto, ...) e o hash.
+  `fetch_ocr` resolve via lookup no índice — um fetch por `(ente, fonte)`,
+  cacheável.
+- **Parsed → URN-LEX**: a camada parsed é keyed por URN
+  (`urn:lex:br;...`), independente de como o documento foi colhido (ADR-0005 +
+  ADR-0010).
 
-### O Impacto para o Leizilla:
-Nós **não** precisamos baixar o item inteiro ou descompactar um ZIP imenso para extrair o texto de uma única lei! Podemos fazer uma requisição HTTP direta de arquivo único (serverless de custo zero):
-`https://archive.org/download/leizilla_ro_casacivil_5001-6000/005120_djvu.txt`
+A chave de colheita da fonte é **metadado** no índice — nunca path nem fronteira
+de range.
+
+### OCR no Internet Archive (inalterado)
+A engine `derive` do IA gera OCR independente por PDF. Para um arquivo
+content-addressed `3f8a…d21c.pdf`, o OCR fica em `3f8a…d21c_djvu.txt` no mesmo
+item, acessível por HTTP direto (serverless, custo zero) uma vez resolvido o hash
+pelo índice.
 
 ---
 
-## 🔄 4. Preservação de Retrocompatibilidade e Resolvedor Determinístico
+## 📚 Referências
 
-Para evitar quebrar a CLI, as tabelas locais do DuckDB ou a suíte de testes unitários existente (480+ testes), as chamadas e consultas no banco local continuam referenciando as leis pelo seu `raw_id` clássico por lei (ex: `leizilla-raw-ro-casacivil-coddoc-05120`).
-
-O motor do Leizilla traduz de forma transparente as chaves:
-
-1. O ID é recebido pelo motor (`fetch_ocr` ou `fetch_ia_html`).
-2. Uma função utilitária em `ia_utils.py` baseada em **entes suportados conhecidos do catálogo** (`list_slugs()`) mapeia dinamicamente onde termina o ente, onde está a fonte e onde está a chave.
-3. Se a chave for numérica sequencial, ela é mapeada para o range correspondente.
-4. **Resolução de Fallback**: Se a chave da lei for não-numérica, o resolvedor mapeia a URL para o item consolidado de fallback (`leizilla-raw-{ente}-{fonte}-fallback`), prevenindo falhas silenciosas de leitura.
-
----
-
-## 🛠️ 5. Resumo Técnico da Refatoração Concluída
-
-As modificações de código foram aplicadas mantendo um alto rigor de qualidade:
-
-1. **`src/leizilla/ia_utils.py` [NEW]**: Centraliza `parse_chave_numeric`, `get_range_bounds`, `get_range_identifier` e `resolve_ia_id_to_url`, eliminando importações circulares e duplicações.
-2. **`src/leizilla/publisher.py`**: Limpado e refatorado para importar e usar o `get_range_identifier` de `ia_utils.py`, operando sob a nomenclatura de ranges genéricos.
-3. **`src/leizilla/parser.py`**: Limpado de toda a duplicação em `fetch_ocr` e `fetch_ia_html`, que agora delegam a montagem de URLs para o resolvedor centralizado e limpo no topo do módulo.
-4. **`tests/test_ia_utils.py` [NEW]**: Adicionada cobertura unitária estrita e direta para testar todas as bordas dos utilitários de ranges e resolvedor unificado.
-5. **`tests/test_parser.py`**: Refatorado para utilizar o `resolve_ia_id_to_url` na montagem e validação dos mocks de requisição, eliminando strings hardcoded estáticas.
-6. **Integração Contínua (CI)**: O workflow `.github/workflows/lint.yml` foi otimizado adicionando cache inteligente de dependências de Python (`setup-uv`) e checagem rígida de lockfile (`uv lock --locked`) para garantir builds limpas.
+- [ADR-0010 — Raw content-addressed, Parsed URN-keyed](../adr/0010-raw-content-addressed-parsed-urn.md) (desenho vigente)
+- [ADR-0005 — Internet Archive Identifiers](../adr/0005-ia-identifiers.md) (camada parsed)

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -142,6 +142,22 @@ def merge_index_row(
     return out.getvalue()
 
 
+def list_source_keys(index_csv: str) -> set[str]:
+    """Conjunto de source_keys distintos presentes no índice.
+
+    Usado pela descoberta (list_raw_ids) para reconstruir os raw_ids legados
+    (``leizilla-raw-{ente}-{fonte}-{source_key}``) que o parser sabe resolver —
+    os identifiers dos itens IA (buckets de hash, item ``index``) não carregam o
+    source_key e não servem para a descoberta.
+    """
+    keys: set[str] = set()
+    for row in csv.DictReader(io.StringIO(index_csv)):
+        sk = row.get("source_key")
+        if sk:
+            keys.add(sk)
+    return keys
+
+
 def lookup_current_hash(index_csv: str, source_key: str) -> Optional[tuple[str, str]]:
     """Retorna ``(content_hash, content_type)`` da captura corrente (mais recente).
 

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -28,7 +28,7 @@ _USER_AGENT = "leizilla-crawler/0.1"
 
 _RAW_PREFIX = "leizilla-raw-"
 # OCR (_djvu.txt) is IA-derived from the PDF, so resolving it requires the
-# PDF hash.  HTML captures are stored as a separate text/html component.
+# PDF hash. HTML captures are stored as a separate text/html component.
 _SUFFIX_TO_CONTENT_TYPE: dict[str, str] = {
     "_djvu.txt": "application/pdf",
     ".html": "text/html",
@@ -127,12 +127,14 @@ def merge_index_row(
     if existing_csv:
         for row in csv.DictReader(io.StringIO(existing_csv)):
             rows.append({c: row.get(c, "") or "" for c in INDEX_COLUMNS})
-    # Idempotência: remove linha prévia com mesmo key+hash e re-anexa como a mais nova.
-    rows = [
-        r
+    # True no-op: (source_key, content_hash) already recorded → preserve provenance.
+    # Re-appending would change the row's position, which affects the "newest wins"
+    # ordering in lookup_current_hash and can silently roll back newer captures.
+    if existing_csv and any(
+        r["source_key"] == source_key and r["content_hash"] == content_hash
         for r in rows
-        if not (r["source_key"] == source_key and r["content_hash"] == content_hash)
-    ]
+    ):
+        return existing_csv
     rows.append(
         {
             "source_key": source_key,

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -1,106 +1,196 @@
-"""Internet Archive publishing & retrieval utility functions.
+"""Internet Archive content-addressed raw layer (ADR-0010).
 
-Centralizes range logic, key parsing, and transparent URL resolution
-between publisher.py (M4 staging) and parser.py (M2 parser pipeline).
+Raw files are addressed by the SHA-256 of their content; range items bucket by
+hash prefix; a per-`(ente, fonte)` index maps the source's idiosyncratic harvest
+key (``coddoc-05120``, a Planalto URL path, ...) to the current content hash.
+
+The harvest key is **metadata** — it never appears in a path or a range
+boundary. That keeps the catalog source-agnostic: the same code addresses bytes
+from any fonte in Brazil, and dedup/immutability fall out of content-addressing.
+
+Coordinate systems (ADR-0010):
+  - raw   → content hash   (this module)
+  - parsed → URN-LEX        (publisher.upload_parsed / ADR-0005)
+The map between them is data (the index + parsed_meta), never a formula.
 """
 
-import re
+import csv
+import hashlib
+import io
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
 from leizilla.entes import list_slugs
 
+_USER_AGENT = "leizilla-crawler/0.1"
 
-def parse_chave_numeric(chave: str) -> tuple[str, int]:
-    """Extrai o tipo e o número da chave (ex: 'lei-05120' -> ('lei', 5120)).
+_RAW_PREFIX = "leizilla-raw-"
+_HASH_BUCKET_LEN = 2  # hex chars → 256 range items per (ente, fonte)
+_IA_DOWNLOAD = "https://archive.org/download"
 
-    Retorna o tipo em minúsculas e o número inteiro correspondente.
+INDEX_FILENAME = "index.csv"
+INDEX_COLUMNS = [
+    "source_key",  # harvest key da fonte (ex: coddoc-05120) — metadado, nunca path
+    "content_hash",  # SHA-256 hex — endereço do arquivo raw
+    "content_type",  # distingue componentes (application/pdf vs text/html)
+    "source_url",  # URL original (Ditel/Planalto/Wayback)
+    "captured_at",  # ISO-8601 — ordena versões (newest wins)
+]
+
+
+def compute_hash(data: bytes) -> str:
+    """SHA-256 hex digest — o endereço de conteúdo de um arquivo raw."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def parse_raw_id(ia_id: str) -> Optional[tuple[str, str, str]]:
+    """Divide um raw_id legado em ``(ente, fonte, source_key)``.
+
+    ``leizilla-raw-{ente}-{fonte}-{source_key}`` →
+    ``('ro', 'casacivil', 'coddoc-05120')``.
+
+    Usa o catálogo de entes (maior match primeiro) para que entes com hífen como
+    ``ro-porto-velho`` sejam resolvidos deterministicamente. Retorna ``None`` se
+    não casar com um ente conhecido ou se faltar fonte/source_key.
     """
-    match = re.match(r"^([a-zA-Z-]+)-(\d+)$", chave)
-    if match:
-        return match.group(1).lower(), int(match.group(2))
-    return "documento", 0
-
-
-def get_range_bounds(num: int, range_size: int = 1000) -> tuple[int, int]:
-    """Calcula os limites inferior e superior do range (ex: 5120 -> (5001, 6000)).
-
-    Nota de Design: Limites superiores como 10000 vão expandir para 5 dígitos.
-    Isso é intencional e esperado para acomodar os ranges sem perda de valor.
-    """
-    if num <= 0:
-        return 1, range_size
-    start = ((num - 1) // range_size) * range_size + 1
-    end = start + range_size - 1
-    return start, end
-
-
-def get_range_identifier(ente: str, fonte: str, tipo: str, num: int) -> str:
-    """Gera o ID do item consolidado do range (ex: 'leizilla_ro_casacivil_5001-6000').
-
-    Utiliza underscores '_' como delimitador de seções e mantém hifens '-' livres
-    para uso interno nas seções. Omitimos o tipo 'coddoc' nos identificadores de
-    range por não se tratar de um tipo jurídico de documento.
-    """
-    start, end = get_range_bounds(num)
-    ente_clean = ente.lower()
-    fonte_clean = fonte.lower()
-    tipo_clean = tipo.lower()
-
-    if tipo_clean == "coddoc":
-        return f"leizilla_{ente_clean}_{fonte_clean}_{start:04d}-{end:04d}"
-    return f"leizilla_{ente_clean}_{fonte_clean}_{tipo_clean}_{start:04d}-{end:04d}"
-
-
-def get_ia_filename(num: int, suffix: str) -> str:
-    """Retorna o nome do arquivo padronizado para o IA.
-
-    Os arquivos físicos são salvos puramente pelo número de 6 dígitos
-    (ex: 005120.pdf, 005120_djvu.txt, 005120_meta.json). Como o tipo de norma
-    já é segregado no range identifier (que atua como uma pasta no IA),
-    omitimos o tipo de norma no nome do arquivo físico para evitar redundância.
-    """
-    return f"{num:06d}{suffix}"
-
-
-def resolve_ia_id_to_url(ia_id: str, suffix: str) -> str:
-    """Resolve um raw IA ID para a URL de download direto correspondente.
-
-    Resolve de forma transparente chaves legadas e novos ranges / fallbacks:
-      1. Ranges com underscores (ex: leizilla_ro_casacivil_5001-6000/005120_djvu.txt)
-      2. Itens de Fallback (ex: leizilla_ro_casacivil_fallback/chave_djvu.txt)
-      3. Itens legados externos ou per-item clássicos (sem tradução)
-
-    Usa a lista de entes conhecidos do catálogo para garantir resolução
-    determinística sem as ambiguidades de hifens em expressões regulares.
-    """
-    if not ia_id.startswith("leizilla-raw-"):
-        return f"https://archive.org/download/{ia_id}/{ia_id}{suffix}"
-
-    content = ia_id[len("leizilla-raw-") :]
-
-    # Procura o ente de maior comprimento para casar corretamente (ex: ro-porto-velho antes de ro)
-    matched_ente = None
+    if not ia_id.startswith(_RAW_PREFIX):
+        return None
+    content = ia_id[len(_RAW_PREFIX) :]
     for slug in sorted(list_slugs(), key=len, reverse=True):
         if content.startswith(f"{slug}-"):
-            matched_ente = slug
-            break
+            rest = content[len(slug) + 1 :]
+            if "-" not in rest:
+                return None
+            fonte, source_key = rest.split("-", 1)
+            if not fonte or not source_key:
+                return None
+            return slug, fonte, source_key
+    return None
 
-    if not matched_ente:
-        # Fallback de segurança se não casar com nenhum ente conhecido
-        return f"https://archive.org/download/{ia_id}/{ia_id}{suffix}"
 
-    # Extrai fonte e chave
-    rest = content[len(matched_ente) + 1 :]
-    if "-" not in rest:
-        return f"https://archive.org/download/{ia_id}/{ia_id}{suffix}"
+def raw_index_identifier(ente: str, fonte: str) -> str:
+    """IA item que guarda o índice ``source_key → content_hash`` de um (ente, fonte)."""
+    return f"{_RAW_PREFIX}{ente.lower()}-{fonte.lower()}-index"
 
-    fonte, chave = rest.split("-", 1)
 
-    tipo, num = parse_chave_numeric(chave)
+def raw_range_identifier(ente: str, fonte: str, hash_hex: str) -> str:
+    """IA range item que armazena um arquivo raw, bucketizado por prefixo de hash.
 
-    if num > 0:
-        range_ia_id = get_range_identifier(matched_ente, fonte, tipo, num)
-        filename = get_ia_filename(num, suffix)
-        return f"https://archive.org/download/{range_ia_id}/{filename}"
-    else:
-        # Fallback de itens não-numéricos consolidados com underscores '_'
-        range_ia_id = f"leizilla_{matched_ente.lower()}_{fonte.lower()}_fallback"
-        return f"https://archive.org/download/{range_ia_id}/{chave.lower()}{suffix}"
+    Ex: ``leizilla-raw-ro-casacivil-3f``. O bucket é derivado do hash (ADR-0010),
+    nunca de uma chave de fonte — generaliza para qualquer fonte do Brasil.
+    """
+    bucket = hash_hex[:_HASH_BUCKET_LEN].lower()
+    return f"{_RAW_PREFIX}{ente.lower()}-{fonte.lower()}-{bucket}"
+
+
+def raw_filename(hash_hex: str, suffix: str) -> str:
+    """Nome de arquivo content-addressed dentro do range item.
+
+    Ex: ``raw_filename(h, '_djvu.txt')`` → ``'3f8a…d21c_djvu.txt'``. O OCR
+    derivado pelo IA (``derive``) fica em ``{hash}_djvu.txt`` ao lado do PDF.
+    """
+    return f"{hash_hex.lower()}{suffix}"
+
+
+def download_url(item_id: str, filename: str) -> str:
+    """URL de download direto de um arquivo dentro de um IA item."""
+    return f"{_IA_DOWNLOAD}/{item_id}/{filename}"
+
+
+def merge_index_row(
+    existing_csv: Optional[str],
+    *,
+    source_key: str,
+    content_hash: str,
+    content_type: str,
+    source_url: str,
+    captured_at: Optional[str] = None,
+) -> str:
+    """Devolve o índice CSV com uma linha de captura anexada (append-only).
+
+    O índice é histórico: re-capturar o mesmo ``source_key`` com bytes diferentes
+    adiciona uma nova linha; a linha mais recente de um source_key é a captura
+    corrente. Idempotente em ``(source_key, content_hash)`` idênticos — não gera
+    linha duplicada (re-crawl sem mudança de bytes é no-op).
+    """
+    captured_at = captured_at or datetime.now(tz=timezone.utc).isoformat()
+    rows: list[dict[str, str]] = []
+    if existing_csv:
+        for row in csv.DictReader(io.StringIO(existing_csv)):
+            rows.append({c: row.get(c, "") or "" for c in INDEX_COLUMNS})
+    # Idempotência: remove linha prévia com mesmo key+hash e re-anexa como a mais nova.
+    rows = [
+        r
+        for r in rows
+        if not (r["source_key"] == source_key and r["content_hash"] == content_hash)
+    ]
+    rows.append(
+        {
+            "source_key": source_key,
+            "content_hash": content_hash,
+            "content_type": content_type,
+            "source_url": source_url,
+            "captured_at": captured_at,
+        }
+    )
+    out = io.StringIO()
+    writer = csv.DictWriter(out, fieldnames=INDEX_COLUMNS)
+    writer.writeheader()
+    writer.writerows(rows)
+    return out.getvalue()
+
+
+def lookup_current_hash(index_csv: str, source_key: str) -> Optional[tuple[str, str]]:
+    """Retorna ``(content_hash, content_type)`` da captura corrente (mais recente).
+
+    A captura corrente é a última linha do source_key no índice append-only.
+    Retorna ``None`` se o source_key não estiver no índice.
+    """
+    found: Optional[tuple[str, str]] = None
+    for row in csv.DictReader(io.StringIO(index_csv)):
+        if row.get("source_key") == source_key:
+            found = (row.get("content_hash", ""), row.get("content_type", ""))
+    return found
+
+
+def _fetch_text(url: str, timeout: int = 30) -> Optional[str]:
+    """GET de um arquivo texto do IA. ``None`` em qualquer falha de rede/404."""
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", _USER_AGENT)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read().decode("utf-8", errors="replace")  # type: ignore[no-any-return]
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def resolve_raw_url(ia_id: str, suffix: str, timeout: int = 30) -> Optional[str]:
+    """Resolve um raw_id legado para a URL content-addressed do arquivo derivado.
+
+    Passos (ADR-0010): parse do raw_id → fetch do índice do (ente, fonte) → lookup
+    do hash corrente do source_key → monta a URL no range item por prefixo de hash.
+
+    IDs que não casam com o padrão raw (itens externos/legados) caem no
+    pass-through clássico ``{ia_id}/{ia_id}{suffix}``. Retorna ``None`` quando o
+    índice não existe ainda ou o source_key não foi capturado — o chamador trata
+    como "OCR ainda não disponível", preservando o contrato de fetch_ocr.
+    """
+    parsed = parse_raw_id(ia_id)
+    if parsed is None:
+        return download_url(ia_id, f"{ia_id}{suffix}")
+
+    ente, fonte, source_key = parsed
+    index_url = download_url(raw_index_identifier(ente, fonte), INDEX_FILENAME)
+    index_csv = _fetch_text(index_url, timeout=timeout)
+    if not index_csv:
+        return None
+
+    current = lookup_current_hash(index_csv, source_key)
+    if current is None:
+        return None
+
+    content_hash, _content_type = current
+    range_id = raw_range_identifier(ente, fonte, content_hash)
+    return download_url(range_id, raw_filename(content_hash, suffix))

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -27,6 +27,13 @@ from leizilla.entes import list_slugs
 _USER_AGENT = "leizilla-crawler/0.1"
 
 _RAW_PREFIX = "leizilla-raw-"
+# OCR (_djvu.txt) is IA-derived from the PDF, so resolving it requires the
+# PDF hash.  HTML captures are stored as a separate text/html component.
+_SUFFIX_TO_CONTENT_TYPE: dict[str, str] = {
+    "_djvu.txt": "application/pdf",
+    ".html": "text/html",
+    ".pdf": "application/pdf",
+}
 _HASH_BUCKET_LEN = 2  # hex chars → 256 range items per (ente, fonte)
 _IA_DOWNLOAD = "https://archive.org/download"
 
@@ -158,16 +165,29 @@ def list_source_keys(index_csv: str) -> set[str]:
     return keys
 
 
-def lookup_current_hash(index_csv: str, source_key: str) -> Optional[tuple[str, str]]:
+def lookup_current_hash(
+    index_csv: str,
+    source_key: str,
+    content_type: Optional[str] = None,
+) -> Optional[tuple[str, str]]:
     """Retorna ``(content_hash, content_type)`` da captura corrente (mais recente).
 
-    A captura corrente é a última linha do source_key no índice append-only.
-    Retorna ``None`` se o source_key não estiver no índice.
+    Se ``content_type`` for especificado, restringe à linha desse tipo antes de
+    escolher a mais recente — necessário quando um source_key tem componentes
+    distintos (``application/pdf`` e ``text/html``) no mesmo índice.
+
+    A captura corrente é a última linha do source_key (filtrado) no índice
+    append-only. Retorna ``None`` se o source_key não estiver no índice ou se
+    nenhuma linha corresponder ao tipo requisitado.
     """
     found: Optional[tuple[str, str]] = None
     for row in csv.DictReader(io.StringIO(index_csv)):
-        if row.get("source_key") == source_key:
-            found = (row.get("content_hash", ""), row.get("content_type", ""))
+        if row.get("source_key") != source_key:
+            continue
+        row_ct = row.get("content_type", "")
+        if content_type is not None and row_ct != content_type:
+            continue
+        found = (row.get("content_hash", ""), row_ct)
     return found
 
 
@@ -203,7 +223,9 @@ def resolve_raw_url(ia_id: str, suffix: str, timeout: int = 30) -> Optional[str]
     if not index_csv:
         return None
 
-    current = lookup_current_hash(index_csv, source_key)
+    current = lookup_current_hash(
+        index_csv, source_key, content_type=_SUFFIX_TO_CONTENT_TYPE.get(suffix)
+    )
     if current is None:
         return None
 

--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Optional
 import anthropic
 
 from leizilla import config
-from leizilla.ia_utils import resolve_ia_id_to_url
+from leizilla.ia_utils import resolve_raw_url
 
 _HAIKU = "claude-haiku-4-5"
 _USER_AGENT = "leizilla-crawler/0.1"
@@ -105,8 +105,15 @@ class ParseResult:
 
 
 def fetch_ocr(ia_id: str, timeout: int = 30) -> Optional[str]:
-    """Fetch OCR text (_djvu.txt) for a raw IA item. Returns None on failure."""
-    url = resolve_ia_id_to_url(ia_id, "_djvu.txt")
+    """Fetch OCR text (_djvu.txt) for a raw IA item. Returns None on failure.
+
+    Resolution is content-addressed (ADR-0010): the raw_id is mapped through the
+    (ente, fonte) index to the current capture's content hash. A None URL means
+    the index/source_key isn't published yet — treated as "OCR not available".
+    """
+    url = resolve_raw_url(ia_id, "_djvu.txt", timeout=timeout)
+    if url is None:
+        return None
     req = urllib.request.Request(url)
     req.add_header("User-Agent", _USER_AGENT)
     try:
@@ -136,10 +143,13 @@ def fetch_html(url: str, timeout: int = 30) -> Optional[str]:
 def fetch_ia_html(ia_id: str, timeout: int = 30) -> Optional[str]:
     """Fetch HTML from IA raw item (for HTML sources like Planalto, M2.7+).
 
-    IA stores HTML as {ia_id}.html alongside raw_meta.json when uploaded via
-    upload_raw_html. Delegates to fetch_html for uniform error handling.
+    IA stores HTML content-addressed as {hash}.html inside the range item, mapped
+    via the (ente, fonte) index (ADR-0010). Delegates to fetch_html for uniform
+    error handling. A None URL means the index/source_key isn't published yet.
     """
-    url = resolve_ia_id_to_url(ia_id, ".html")
+    url = resolve_raw_url(ia_id, ".html", timeout=timeout)
+    if url is None:
+        return None
     return fetch_html(url, timeout=timeout)
 
 

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -1,6 +1,5 @@
 """Publicação no Internet Archive e exportação de datasets."""
 
-import csv
 import hashlib
 import json
 import re
@@ -17,10 +16,13 @@ from typing import Any, Dict, Optional, Set
 from leizilla import config
 from leizilla import storage as storage_module
 from leizilla.ia_utils import (
-    get_range_bounds,
-    get_range_identifier as _range_identifier,
-    parse_chave_numeric,
-    get_ia_filename,
+    INDEX_FILENAME,
+    compute_hash,
+    download_url,
+    merge_index_row,
+    raw_filename,
+    raw_index_identifier,
+    raw_range_identifier,
 )
 
 _DATASET_IDENTIFIER_RE = (
@@ -365,50 +367,73 @@ def fetch_parsed_xml(ia_id: str, output_path: Path) -> bool:
         return False
 
 
-def update_ia_manifest(
-    range_ia_id: str, filename: str, url_original: str, tmp_dir: Path
-) -> Path:
-    """Baixa o manifest.csv existente do IA, adiciona a nova linha e salva localmente.
-
-    WARNING: Este método realiza um download/upload sequencial incremental do manifest.csv
-    para cada arquivo de raw upload individual. Se invocado repetidamente em loops extensos
-    sem controle de lote (batching), gera complexidade de rede O(n²). Projetos futuros que
-    realizem ingestão em massa offline devem agrupar múltiplos arquivos em um único manifest.csv
-    local consolidador antes de realizar a requisição ao Internet Archive.
-    """
-    manifest_path = tmp_dir / "manifest.csv"
-    lines: list[list[str]] = []
-
-    # Tenta baixar o manifest existente do Internet Archive
-    url_ia_manifest = f"https://archive.org/download/{range_ia_id}/manifest.csv"
-    req = urllib.request.Request(url_ia_manifest)
-    req.add_header("User-Agent", "leizilla-crawler/0.1")
-
+def _fetch_existing_index(ente: str, fonte: str) -> Optional[str]:
+    """Baixa o index.csv corrente do (ente, fonte) do IA. None se não existir."""
+    url = download_url(raw_index_identifier(ente, fonte), INDEX_FILENAME)
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", _USER_AGENT)
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
-            content = resp.read().decode("utf-8", errors="replace")
-            # Faz o parse do CSV existente para evitar duplicatas
-            reader = csv.reader(content.splitlines())
-            next(reader, None)  # filename,url
-            for row in reader:
-                if len(row) == 2:
-                    lines.append(row)
+            return resp.read().decode("utf-8", errors="replace")  # type: ignore[no-any-return]
     except (urllib.error.URLError, OSError):
-        # Se falhar (404 ou erro de rede), começamos com um manifest limpo
-        pass
+        return None
 
-    # Adiciona ou atualiza a linha correspondente
-    # Garante que não teremos duplicatas do mesmo arquivo
-    lines = [row for row in lines if row[0] != filename]
-    lines.append([filename, url_original])
 
-    # Grava o arquivo localmente
-    with open(manifest_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(["filename", "url"])
-        writer.writerows(lines)
+def update_raw_index(
+    ente: str,
+    fonte: str,
+    *,
+    source_key: str,
+    content_hash: str,
+    content_type: str,
+    source_url: str,
+) -> Dict[str, Any]:
+    """Anexa uma captura ao index.csv do (ente, fonte) e re-publica o item índice.
 
-    return manifest_path
+    O índice (``leizilla-raw-{ente}-{fonte}-index``) é a ponte source_key →
+    content_hash da camada raw (ADR-0010). Append-only e idempotente em
+    (source_key, content_hash). Item separado do range que guarda os bytes, para
+    que a resolução de leitura precise de um único fetch por (ente, fonte).
+
+    WARNING: download+upload incremental por captura é O(n²) em ingestão massiva.
+    Para backfill offline, acumular o index.csv localmente e publicar uma vez.
+    """
+    existing = _fetch_existing_index(ente, fonte)
+    updated = merge_index_row(
+        existing,
+        source_key=source_key,
+        content_hash=content_hash,
+        content_type=content_type,
+        source_url=source_url,
+    )
+    index_id = raw_index_identifier(ente, fonte)
+    with tempfile.TemporaryDirectory() as tmp:
+        index_path = Path(tmp) / INDEX_FILENAME
+        index_path.write_text(updated, encoding="utf-8")
+        try:
+            subprocess.run(
+                [
+                    "ia",
+                    "upload",
+                    index_id,
+                    str(index_path),
+                    "--metadata",
+                    f"title:Leizilla Raw Index {ente.upper()} {fonte.upper()}",
+                    "--metadata",
+                    "mediatype:data",
+                    "--metadata",
+                    f"subject:leizilla;index;{ente};{fonte}",
+                    "--metadata",
+                    "creator:leizilla-crawler",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return {"success": True, "index_id": index_id}
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            err = getattr(e, "stderr", str(e))
+            return {"success": False, "error": err, "index_id": index_id}
 
 
 class InternetArchivePublisher:
@@ -439,42 +464,24 @@ class InternetArchivePublisher:
         chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
         ia_id = _raw_identifier(ente, fonte, chave)
 
-        tipo, num = parse_chave_numeric(chave)
-        if num > 0:
-            range_ia_id = _range_identifier(ente, fonte, tipo, num)
-            start, end = get_range_bounds(num)
-            if tipo.lower() == "coddoc":
-                title = (
-                    f"Leizilla Raw {ente.upper()} {fonte.upper()} {start:04d}-{end:04d}"
-                )
-            else:
-                title = f"Leizilla Raw {ente.upper()} {fonte.upper()} {tipo.upper()} {start:04d}-{end:04d}"
-        else:
-            range_ia_id = f"leizilla_{ente.lower()}_{fonte.lower()}_fallback"
-            title = f"Leizilla Raw {ente.upper()} {fonte.upper()} Fallback"
+        # Endereço de conteúdo (ADR-0010): o arquivo raw é nomeado pelo SHA-256
+        # dos seus bytes e bucketizado por prefixo de hash. A chave de colheita
+        # (chave) é metadado no índice, nunca path nem fronteira de range.
+        content_hash = compute_hash(pdf_bytes)
+        range_ia_id = raw_range_identifier(ente, fonte, content_hash)
+        title = f"Leizilla Raw {ente.upper()} {fonte.upper()} {content_hash[:2]}"
 
         raw_meta = build_raw_meta(lei_data, pdf_bytes, fetched_from, wayback_url)
         url_original = str(lei_data.get("url_original") or fetched_from)
 
         with tempfile.TemporaryDirectory() as tmp:
-            if num > 0:
-                pdf_name = get_ia_filename(num, ".pdf")
-                meta_name = get_ia_filename(num, "_meta.json")
-                pdf_dst = Path(tmp) / pdf_name
-                meta_path = Path(tmp) / meta_name
-                filename_manifest = pdf_name
-            else:
-                pdf_dst = Path(tmp) / f"{chave.lower()}.pdf"
-                meta_path = Path(tmp) / f"{chave.lower()}_meta.json"
-                filename_manifest = f"{chave.lower()}.pdf"
+            pdf_name = raw_filename(content_hash, ".pdf")
+            meta_name = raw_filename(content_hash, "_meta.json")
+            pdf_dst = Path(tmp) / pdf_name
+            meta_path = Path(tmp) / meta_name
 
             shutil.copy2(str(pdf_path), str(pdf_dst))
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
-
-            # Atualiza o manifest.csv contendo o histórico de URLs do range
-            manifest_path = update_ia_manifest(
-                range_ia_id, filename_manifest, url_original, Path(tmp)
-            )
 
             coverage = _entity_coverage(ente)
             desc = (
@@ -490,7 +497,6 @@ class InternetArchivePublisher:
                         range_ia_id,
                         str(pdf_dst),
                         str(meta_path),
-                        str(manifest_path),
                         "--metadata",
                         f"title:{title}",
                         "--metadata",
@@ -510,13 +516,23 @@ class InternetArchivePublisher:
                     text=True,
                     check=True,
                 )
-                return {
-                    "success": True,
-                    "ia_id": ia_id,
-                    "ia_url": f"https://archive.org/details/{range_ia_id}",
-                }
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
+
+        # Anexa a captura ao índice source_key → content_hash do (ente, fonte).
+        update_raw_index(
+            ente,
+            fonte,
+            source_key=chave,
+            content_hash=content_hash,
+            content_type="application/pdf",
+            source_url=url_original,
+        )
+        return {
+            "success": True,
+            "ia_id": ia_id,
+            "ia_url": f"https://archive.org/details/{range_ia_id}",
+        }
 
     def upload_raw_html(
         self,
@@ -539,19 +555,10 @@ class InternetArchivePublisher:
         chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
         ia_id = _raw_identifier(ente, fonte, chave)
 
-        tipo, num = parse_chave_numeric(chave)
-        if num > 0:
-            range_ia_id = _range_identifier(ente, fonte, tipo, num)
-            start, end = get_range_bounds(num)
-            if tipo.lower() == "coddoc":
-                title = (
-                    f"Leizilla Raw {ente.upper()} {fonte.upper()} {start:04d}-{end:04d}"
-                )
-            else:
-                title = f"Leizilla Raw {ente.upper()} {fonte.upper()} {tipo.upper()} {start:04d}-{end:04d}"
-        else:
-            range_ia_id = f"leizilla_{ente.lower()}_{fonte.lower()}_fallback"
-            title = f"Leizilla Raw {ente.upper()} {fonte.upper()} Fallback"
+        html_bytes = html_content.encode("utf-8")
+        content_hash = compute_hash(html_bytes)
+        range_ia_id = raw_range_identifier(ente, fonte, content_hash)
+        title = f"Leizilla Raw {ente.upper()} {fonte.upper()} {content_hash[:2]}"
 
         raw_meta = build_raw_meta_html(
             html_content, lei_data, fetched_from, wayback_url
@@ -559,24 +566,13 @@ class InternetArchivePublisher:
         url_original = str(lei_data.get("url_original") or fetched_from)
 
         with tempfile.TemporaryDirectory() as tmp:
-            if num > 0:
-                html_name = get_ia_filename(num, ".html")
-                meta_name = get_ia_filename(num, "_meta.json")
-                html_dst = Path(tmp) / html_name
-                meta_path = Path(tmp) / meta_name
-                filename_manifest = html_name
-            else:
-                html_dst = Path(tmp) / f"{chave.lower()}.html"
-                meta_path = Path(tmp) / f"{chave.lower()}_meta.json"
-                filename_manifest = f"{chave.lower()}.html"
+            html_name = raw_filename(content_hash, ".html")
+            meta_name = raw_filename(content_hash, "_meta.json")
+            html_dst = Path(tmp) / html_name
+            meta_path = Path(tmp) / meta_name
 
             html_dst.write_text(html_content, encoding="utf-8")
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
-
-            # Atualiza o manifest.csv contendo o histórico de URLs do range
-            manifest_path = update_ia_manifest(
-                range_ia_id, filename_manifest, url_original, Path(tmp)
-            )
 
             coverage = _entity_coverage(ente)
             desc = (
@@ -592,7 +588,6 @@ class InternetArchivePublisher:
                         range_ia_id,
                         str(html_dst),
                         str(meta_path),
-                        str(manifest_path),
                         "--metadata",
                         f"title:{title}",
                         "--metadata",
@@ -612,11 +607,6 @@ class InternetArchivePublisher:
                     text=True,
                     check=True,
                 )
-                return {
-                    "success": True,
-                    "ia_id": ia_id,
-                    "ia_url": f"https://archive.org/details/{range_ia_id}",
-                }
             except FileNotFoundError:
                 return {
                     "success": False,
@@ -625,6 +615,20 @@ class InternetArchivePublisher:
                 }
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
+
+        update_raw_index(
+            ente,
+            fonte,
+            source_key=chave,
+            content_hash=content_hash,
+            content_type="text/html",
+            source_url=url_original,
+        )
+        return {
+            "success": True,
+            "ia_id": ia_id,
+            "ia_url": f"https://archive.org/details/{range_ia_id}",
+        }
 
     def upload_parsed(
         self,

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -19,6 +19,7 @@ from leizilla.ia_utils import (
     INDEX_FILENAME,
     compute_hash,
     download_url,
+    list_source_keys,
     merge_index_row,
     raw_filename,
     raw_index_identifier,
@@ -215,40 +216,30 @@ def count_ia_items(identifier_prefix: str) -> Optional[int]:
 
 
 def list_raw_ids(ente: str, fonte: str) -> Set[str]:
-    """Return set of raw item IDs already uploaded to IA for this ente/fonte.
+    """Return set of legacy raw IDs already captured to IA for this ente/fonte.
 
-    Simpler than list_parsed_raw_ids: the raw identifier prefix already
-    uniquely identifies ente+fonte, so no per-item metadata fetch needed.
-    Fail-open on first-page error: returns empty set (never skips due to
-    connectivity issues). Partial results on mid-pagination error: returns
-    confirmed items so far — re-scraping unconfirmed items is safe (idempotent
-    IA upload), unlike parse-all where skipping means lost work.
+    Under the content-addressed layer (ADR-0010), raw bytes live in hash-prefix
+    range items whose identifiers carry no source_key — only the per-(ente,fonte)
+    ``index.csv`` maps source_keys to content. So discovery reads the index and
+    reconstructs the legacy raw IDs (``leizilla-raw-{ente}-{fonte}-{source_key}``)
+    that the parser knows how to resolve.
+
+    Fail-open: returns the empty set when the index doesn't exist yet or on any
+    network error, so the caller falls back to the sequential range — never skips
+    due to connectivity.
     """
-    prefix = f"leizilla-raw-{ente}-{fonte}-"
-    q = f"identifier:{prefix}*"
-    base_url = (
-        f"{_IA_SCRAPE_URL}?q={urllib.parse.quote(q)}&count=10000&fields=identifier"
-    )
+    index_url = download_url(raw_index_identifier(ente, fonte), INDEX_FILENAME)
+    req = urllib.request.Request(index_url, headers={"User-Agent": _USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            index_csv = resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, OSError, ValueError):
+        return set()
 
-    raw_ids: Set[str] = set()
-    cursor: Optional[str] = None
-
-    while True:
-        url = base_url
-        if cursor:
-            url += f"&cursor={urllib.parse.quote(cursor)}"
-        try:
-            req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                data = json.loads(resp.read())
-            raw_ids.update(item["identifier"] for item in data.get("items", []))
-            cursor = data.get("cursor")
-            if not cursor:
-                break
-        except Exception:
-            return raw_ids  # partial results on mid-pagination failure; empty set on page 1 failure
-
-    return raw_ids
+    return {
+        _raw_identifier(ente, fonte, source_key)
+        for source_key in list_source_keys(index_csv)
+    }
 
 
 def list_parsed_raw_ids(ente: str, fonte: str) -> Set[str]:
@@ -520,7 +511,10 @@ class InternetArchivePublisher:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
 
         # Anexa a captura ao índice source_key → content_hash do (ente, fonte).
-        update_raw_index(
+        # A leitura (fetch_ocr) resolve exclusivamente via índice; se este upload
+        # falhar, a captura existe nos bytes mas o parser nunca a localiza —
+        # então propagamos a falha em vez de reportar sucesso.
+        index_result = update_raw_index(
             ente,
             fonte,
             source_key=chave,
@@ -528,6 +522,12 @@ class InternetArchivePublisher:
             content_type="application/pdf",
             source_url=url_original,
         )
+        if not index_result.get("success"):
+            return {
+                "success": False,
+                "error": f"index update failed: {index_result.get('error')}",
+                "ia_id": ia_id,
+            }
         return {
             "success": True,
             "ia_id": ia_id,
@@ -616,7 +616,7 @@ class InternetArchivePublisher:
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
 
-        update_raw_index(
+        index_result = update_raw_index(
             ente,
             fonte,
             source_key=chave,
@@ -624,6 +624,12 @@ class InternetArchivePublisher:
             content_type="text/html",
             source_url=url_original,
         )
+        if not index_result.get("success"):
+            return {
+                "success": False,
+                "error": f"index update failed: {index_result.get('error')}",
+                "ia_id": ia_id,
+            }
         return {
             "success": True,
             "ia_id": ia_id,

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -358,16 +358,38 @@ def fetch_parsed_xml(ia_id: str, output_path: Path) -> bool:
         return False
 
 
+class IndexFetchError(Exception):
+    """Falha transitória ao buscar o index.csv (não é um 404 confirmado).
+
+    Distingue "índice ausente" (404 → seguro começar vazio) de "não foi possível
+    determinar" (timeout/5xx/rede). No segundo caso, sobrescrever o índice com uma
+    versão de uma linha apagaria todo o histórico source_key → content_hash, então
+    o chamador deve abortar em vez de começar do zero.
+    """
+
+
 def _fetch_existing_index(ente: str, fonte: str) -> Optional[str]:
-    """Baixa o index.csv corrente do (ente, fonte) do IA. None se não existir."""
+    """Baixa o index.csv corrente do (ente, fonte) do IA.
+
+    Retorna o CSV se existir, ``None`` se for um 404 confirmado (índice ainda não
+    publicado — seguro começar vazio), e levanta ``IndexFetchError`` em falhas
+    transitórias (timeout, 5xx, rede) para que o chamador não sobrescreva o
+    histórico existente com um índice vazio.
+    """
     url = download_url(raw_index_identifier(ente, fonte), INDEX_FILENAME)
     req = urllib.request.Request(url)
     req.add_header("User-Agent", _USER_AGENT)
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             return resp.read().decode("utf-8", errors="replace")  # type: ignore[no-any-return]
-    except (urllib.error.URLError, OSError):
-        return None
+    except urllib.error.HTTPError as e:
+        if e.code in (403, 404):
+            # IA serve 403/404 para itens/arquivos inexistentes — índice ausente.
+            return None
+        raise IndexFetchError(f"HTTP {e.code} ao buscar index.csv") from e
+    except (urllib.error.URLError, OSError) as e:
+        # Timeout, DNS, conexão recusada — transitório, não confirma ausência.
+        raise IndexFetchError(str(e)) from e
 
 
 def update_raw_index(
@@ -389,7 +411,16 @@ def update_raw_index(
     WARNING: download+upload incremental por captura é O(n²) em ingestão massiva.
     Para backfill offline, acumular o index.csv localmente e publicar uma vez.
     """
-    existing = _fetch_existing_index(ente, fonte)
+    try:
+        existing = _fetch_existing_index(ente, fonte)
+    except IndexFetchError as e:
+        # Falha transitória ao ler o índice atual: abortar em vez de sobrescrever
+        # o histórico com uma única linha (perderia mapeamentos prévios).
+        return {
+            "success": False,
+            "error": f"could not read existing index (aborting to avoid data loss): {e}",
+            "index_id": raw_index_identifier(ente, fonte),
+        }
     updated = merge_index_row(
         existing,
         source_key=source_key,

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -177,6 +177,49 @@ class TestLookupCurrentHash:
         idx = self._two_version_index()
         assert lookup_current_hash(idx, "coddoc-999") is None
 
+    def test_content_type_filter_picks_correct_component(self):
+        # Same source_key has a PDF row and an HTML row.
+        pdf_hash = "pdf_hash"
+        html_hash = "html_hash"
+        idx = merge_index_row(
+            None,
+            source_key="lc-00042",
+            content_hash=pdf_hash,
+            content_type="application/pdf",
+            source_url="http://src/pdf",
+            captured_at="2026-05-30T00:00:00+00:00",
+        )
+        idx = merge_index_row(
+            idx,
+            source_key="lc-00042",
+            content_hash=html_hash,
+            content_type="text/html",
+            source_url="http://src/html",
+            captured_at="2026-05-30T01:00:00+00:00",
+        )
+        # Without filter, returns last-appended row (HTML).
+        assert lookup_current_hash(idx, "lc-00042") == (html_hash, "text/html")
+        # With filter, each component resolves independently.
+        assert lookup_current_hash(idx, "lc-00042", "application/pdf") == (
+            pdf_hash,
+            "application/pdf",
+        )
+        assert lookup_current_hash(idx, "lc-00042", "text/html") == (
+            html_hash,
+            "text/html",
+        )
+
+    def test_content_type_filter_returns_none_when_type_absent(self):
+        idx = merge_index_row(
+            None,
+            source_key="lc-00042",
+            content_hash="h1",
+            content_type="application/pdf",
+            source_url="http://src/1",
+        )
+        # Requesting HTML for a source that only has a PDF entry → None.
+        assert lookup_current_hash(idx, "lc-00042", "text/html") is None
+
 
 class TestResolveRawUrl:
     def test_non_raw_id_passthrough(self):
@@ -216,3 +259,31 @@ class TestResolveRawUrl:
         )
         with patch("leizilla.ia_utils._fetch_text", return_value=index_csv):
             assert resolve_raw_url("leizilla-raw-ro-casacivil-coddoc-1", ".pdf") is None
+
+    def test_suffix_content_type_filters_mixed_components(self):
+        # source_key has both PDF and HTML components; suffix drives which hash is used.
+        pdf_hash = "aa" + "0" * 62
+        html_hash = "bb" + "0" * 62
+        idx = merge_index_row(
+            None,
+            source_key="lc-00042",
+            content_hash=pdf_hash,
+            content_type="application/pdf",
+            source_url="http://src/pdf",
+        )
+        idx = merge_index_row(
+            idx,
+            source_key="lc-00042",
+            content_hash=html_hash,
+            content_type="text/html",
+            source_url="http://src/html",
+        )
+        ia_id = "leizilla-raw-ro-casacivil-lc-00042"
+        with patch("leizilla.ia_utils._fetch_text", return_value=idx):
+            # OCR suffix → PDF hash (IA derives djvu.txt from the PDF)
+            ocr_url = resolve_raw_url(ia_id, "_djvu.txt")
+            assert ocr_url and f"{pdf_hash}_djvu.txt" in ocr_url
+        with patch("leizilla.ia_utils._fetch_text", return_value=idx):
+            # .html suffix → HTML hash
+            html_url = resolve_raw_url(ia_id, ".html")
+            assert html_url and f"{html_hash}.html" in html_url

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -1,122 +1,218 @@
-"""Tests for Internet Archive range, bounds, parsing and url resolution utility functions."""
+"""Tests for the content-addressed raw layer utilities (ADR-0010)."""
+
+from unittest.mock import patch
 
 from leizilla.ia_utils import (
-    parse_chave_numeric,
-    get_range_bounds,
-    get_range_identifier,
-    resolve_ia_id_to_url,
+    INDEX_COLUMNS,
+    compute_hash,
+    download_url,
+    lookup_current_hash,
+    merge_index_row,
+    parse_raw_id,
+    raw_filename,
+    raw_index_identifier,
+    raw_range_identifier,
+    resolve_raw_url,
 )
 
 
-class TestParseChaveNumeric:
-    def test_numeric_law(self):
-        assert parse_chave_numeric("lei-05120") == ("lei", 5120)
-        assert parse_chave_numeric("decreto-0042") == ("decreto", 42)
+class TestComputeHash:
+    def test_deterministic_sha256(self):
+        import hashlib
 
-    def test_complex_document_type(self):
-        assert parse_chave_numeric("lei-complementar-0004") == ("lei-complementar", 4)
-        assert parse_chave_numeric("decreto-lei-99") == ("decreto-lei", 99)
+        data = b"PDF bytes"
+        assert compute_hash(data) == hashlib.sha256(data).hexdigest()
 
-    def test_non_numeric(self):
-        assert parse_chave_numeric("lei-decretada-a") == ("documento", 0)
-        assert parse_chave_numeric("some-arbitrary-text") == ("documento", 0)
+    def test_distinct_bytes_distinct_hash(self):
+        assert compute_hash(b"a") != compute_hash(b"b")
 
 
-class TestGetRangeBounds:
-    def test_standard_boundaries(self):
-        # 1-1000 bounds
-        assert get_range_bounds(1) == (1, 1000)
-        assert get_range_bounds(500) == (1, 1000)
-        assert get_range_bounds(1000) == (1, 1000)
-
-        # 1001-2000 bounds
-        assert get_range_bounds(1001) == (1001, 2000)
-        assert get_range_bounds(2000) == (1001, 2000)
-
-    def test_large_boundaries(self):
-        # 9001-10000 bounds (end is 5-digit)
-        assert get_range_bounds(9999) == (9001, 10000)
-        assert get_range_bounds(10000) == (9001, 10000)
-
-        # 10001-11000 bounds (both are 5-digit)
-        assert get_range_bounds(10001) == (10001, 11000)
-
-    def test_invalid_values(self):
-        assert get_range_bounds(0) == (1, 1000)
-        assert get_range_bounds(-42) == (1, 1000)
-
-
-class TestGetRangeIdentifier:
-    def test_generates_correct_slug(self):
-        # Para tipos normais que desambiguam, mantém o tipo no range
-        assert (
-            get_range_identifier("ro", "casacivil", "lei", 5120)
-            == "leizilla_ro_casacivil_lei_5001-6000"
-        )
-        assert (
-            get_range_identifier("RO", "CasaCivil", "Lei-Complementar", 42)
-            == "leizilla_ro_casacivil_lei-complementar_0001-1000"
+class TestParseRawId:
+    def test_simple_ente(self):
+        assert parse_raw_id("leizilla-raw-ro-casacivil-coddoc-05120") == (
+            "ro",
+            "casacivil",
+            "coddoc-05120",
         )
 
-    def test_coddoc_omits_type_in_range(self):
-        # Para coddoc, o tipo é omitido do range identifier
+    def test_hyphenated_ente_longest_match(self):
+        # When a hyphenated municipal slug is in the catalog, longest-match must
+        # pick it over the bare state slug (ro-porto-velho before ro).
+        with patch(
+            "leizilla.ia_utils.list_slugs",
+            return_value=["ro", "ro-porto-velho", "federal"],
+        ):
+            assert parse_raw_id("leizilla-raw-ro-porto-velho-camara-doc-7") == (
+                "ro-porto-velho",
+                "camara",
+                "doc-7",
+            )
+
+    def test_source_key_may_contain_hyphens(self):
+        assert parse_raw_id("leizilla-raw-federal-planalto-lei-complementar-42") == (
+            "federal",
+            "planalto",
+            "lei-complementar-42",
+        )
+
+    def test_non_raw_id_returns_none(self):
+        assert parse_raw_id("external-archive-item") is None
+
+    def test_unknown_ente_returns_none(self):
+        assert parse_raw_id("leizilla-raw-xx-fonte-key") is None
+
+    def test_missing_source_key_returns_none(self):
+        assert parse_raw_id("leizilla-raw-ro-casacivil") is None
+
+
+class TestIdentifiers:
+    def test_index_identifier(self):
         assert (
-            get_range_identifier("ro", "casacivil", "coddoc", 5120)
-            == "leizilla_ro_casacivil_5001-6000"
+            raw_index_identifier("ro", "casacivil") == "leizilla-raw-ro-casacivil-index"
+        )
+
+    def test_range_identifier_buckets_by_hash_prefix(self):
+        h = "3f8a" + "0" * 60
+        assert (
+            raw_range_identifier("ro", "casacivil", h) == "leizilla-raw-ro-casacivil-3f"
+        )
+
+    def test_range_identifier_lowercases(self):
+        h = "AB" + "0" * 62
+        assert (
+            raw_range_identifier("RO", "CasaCivil", h) == "leizilla-raw-ro-casacivil-ab"
+        )
+
+    def test_raw_filename_is_content_addressed(self):
+        h = "3f8a" + "0" * 60
+        assert raw_filename(h, ".pdf") == f"{h}.pdf"
+        assert raw_filename(h, "_djvu.txt") == f"{h}_djvu.txt"
+
+    def test_download_url(self):
+        assert (
+            download_url("item-x", "file.pdf")
+            == "https://archive.org/download/item-x/file.pdf"
         )
 
 
-class TestGetIaFilename:
-    def test_standard_types(self):
-        # Omite redundâncias e gera apenas o número
-        from leizilla.ia_utils import get_ia_filename
+class TestMergeIndexRow:
+    def test_creates_header_and_row(self):
+        csv_out = merge_index_row(
+            None,
+            source_key="coddoc-05120",
+            content_hash="abc",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-30T00:00:00+00:00",
+        )
+        lines = csv_out.strip().splitlines()
+        assert lines[0] == ",".join(INDEX_COLUMNS)
+        assert lines[1].startswith("coddoc-05120,abc,application/pdf,http://src/1,")
 
-        assert get_ia_filename(5120, ".pdf") == "005120.pdf"
-        assert get_ia_filename(42, ".html") == "000042.html"
-        assert get_ia_filename(5120, "_djvu.txt") == "005120_djvu.txt"
-        assert get_ia_filename(5120, "_meta.json") == "005120_meta.json"
+    def test_append_only_keeps_history(self):
+        first = merge_index_row(
+            None,
+            source_key="coddoc-1",
+            content_hash="h1",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-30T00:00:00+00:00",
+        )
+        second = merge_index_row(
+            first,
+            source_key="coddoc-1",
+            content_hash="h2",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-31T00:00:00+00:00",
+        )
+        rows = [ln for ln in second.strip().splitlines()[1:]]
+        assert len(rows) == 2  # both captures retained
+
+    def test_idempotent_same_key_and_hash(self):
+        first = merge_index_row(
+            None,
+            source_key="coddoc-1",
+            content_hash="h1",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-30T00:00:00+00:00",
+        )
+        second = merge_index_row(
+            first,
+            source_key="coddoc-1",
+            content_hash="h1",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-31T00:00:00+00:00",
+        )
+        rows = [ln for ln in second.strip().splitlines()[1:]]
+        assert len(rows) == 1  # re-crawl, identical bytes → no duplicate
 
 
-class TestResolveIaIdToUrl:
-    def test_legacy_or_external_id(self):
-        # IDs that don't start with 'leizilla-raw-' should pass through untouched
+class TestLookupCurrentHash:
+    def _two_version_index(self) -> str:
+        idx = merge_index_row(
+            None,
+            source_key="coddoc-1",
+            content_hash="h1",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-30T00:00:00+00:00",
+        )
+        return merge_index_row(
+            idx,
+            source_key="coddoc-1",
+            content_hash="h2",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-31T00:00:00+00:00",
+        )
+
+    def test_returns_latest_capture(self):
+        idx = self._two_version_index()
+        assert lookup_current_hash(idx, "coddoc-1") == ("h2", "application/pdf")
+
+    def test_missing_key_returns_none(self):
+        idx = self._two_version_index()
+        assert lookup_current_hash(idx, "coddoc-999") is None
+
+
+class TestResolveRawUrl:
+    def test_non_raw_id_passthrough(self):
         assert (
-            resolve_ia_id_to_url("external-archive-item", "_djvu.txt")
+            resolve_raw_url("external-archive-item", "_djvu.txt")
             == "https://archive.org/download/external-archive-item/external-archive-item_djvu.txt"
         )
 
-    def test_numeric_range_resolution(self):
-        ia_id = "leizilla-raw-ro-casacivil-lei-05120"
-        # Resolves to numeric range bucket with underscores and lowers filename without type redundancy
-        expected = "https://archive.org/download/leizilla_ro_casacivil_lei_5001-6000/005120_djvu.txt"
-        assert resolve_ia_id_to_url(ia_id, "_djvu.txt") == expected
-
-    def test_complex_numeric_range_resolution(self):
-        ia_id = "leizilla-raw-ro-casacivil-lei-complementar-00042"
-        expected = "https://archive.org/download/leizilla_ro_casacivil_lei-complementar_0001-1000/000042.html"
-        assert resolve_ia_id_to_url(ia_id, ".html") == expected
-
-    def test_coddoc_range_resolution(self):
-        ia_id = "leizilla-raw-ro-casacivil-coddoc-05120"
-        # Deve omitir o coddoc do range e do arquivo físico
-        expected = "https://archive.org/download/leizilla_ro_casacivil_5001-6000/005120_djvu.txt"
-        assert resolve_ia_id_to_url(ia_id, "_djvu.txt") == expected
-
-        expected_pdf = (
-            "https://archive.org/download/leizilla_ro_casacivil_5001-6000/005120.pdf"
+    def test_resolves_via_index_to_content_addressed_url(self):
+        content_hash = "3f8a" + "0" * 60
+        index_csv = merge_index_row(
+            None,
+            source_key="coddoc-05120",
+            content_hash=content_hash,
+            content_type="application/pdf",
+            source_url="http://src/1",
         )
-        assert resolve_ia_id_to_url(ia_id, ".pdf") == expected_pdf
-
-    def test_fallback_resolution(self):
-        ia_id = "leizilla-raw-ro-casacivil-lei-decretada-a"
-        # Resolves to fallback item with underscores
-        expected = "https://archive.org/download/leizilla_ro_casacivil_fallback/lei-decretada-a_djvu.txt"
-        assert resolve_ia_id_to_url(ia_id, "_djvu.txt") == expected
-
-    def test_malformed_ia_id_fallback(self):
-        # Starts with leizilla-raw- but doesn't conform to pattern (has no dash)
-        bad_id = "leizilla-raw-ro"
-        assert (
-            resolve_ia_id_to_url(bad_id, "_djvu.txt")
-            == f"https://archive.org/download/{bad_id}/{bad_id}_djvu.txt"
+        with patch("leizilla.ia_utils._fetch_text", return_value=index_csv):
+            url = resolve_raw_url("leizilla-raw-ro-casacivil-coddoc-05120", "_djvu.txt")
+        assert url == (
+            "https://archive.org/download/"
+            "leizilla-raw-ro-casacivil-3f/"
+            f"{content_hash}_djvu.txt"
         )
+
+    def test_no_index_yet_returns_none(self):
+        with patch("leizilla.ia_utils._fetch_text", return_value=None):
+            assert resolve_raw_url("leizilla-raw-ro-casacivil-coddoc-1", ".pdf") is None
+
+    def test_source_key_not_in_index_returns_none(self):
+        index_csv = merge_index_row(
+            None,
+            source_key="coddoc-OTHER",
+            content_hash="h1",
+            content_type="application/pdf",
+            source_url="http://src/1",
+        )
+        with patch("leizilla.ia_utils._fetch_text", return_value=index_csv):
+            assert resolve_raw_url("leizilla-raw-ro-casacivil-coddoc-1", ".pdf") is None

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -149,6 +149,31 @@ class TestMergeIndexRow:
         rows = [ln for ln in second.strip().splitlines()[1:]]
         assert len(rows) == 1  # re-crawl, identical bytes → no duplicate
 
+    def test_idempotent_preserves_original_captured_at(self):
+        # A re-crawl of unchanged bytes must NOT rewrite the provenance timestamp.
+        # Re-appending with a newer captured_at would also push the row to the end,
+        # making lookup_current_hash see it as "newer" and silently rolling back any
+        # capture that was added between the two crawls.
+        first = merge_index_row(
+            None,
+            source_key="coddoc-1",
+            content_hash="h1",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-30T00:00:00+00:00",
+        )
+        second = merge_index_row(
+            first,
+            source_key="coddoc-1",
+            content_hash="h1",
+            content_type="application/pdf",
+            source_url="http://src/1",
+            captured_at="2026-05-31T00:00:00+00:00",  # newer timestamp must be ignored
+        )
+        assert second == first  # truly no-op: CSV unchanged
+        assert "2026-05-30T00:00:00+00:00" in second
+        assert "2026-05-31T00:00:00+00:00" not in second
+
 
 class TestLookupCurrentHash:
     def _two_version_index(self) -> str:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,9 +6,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from leizilla import parser
-from leizilla.ia_utils import resolve_ia_id_to_url
 
 _IA_ID = "leizilla-raw-ro-casacivil-coddoc-09999"
+# URL that resolve_raw_url would produce for a captured raw item (content-addressed).
+_RESOLVED = "https://archive.org/download/leizilla-raw-ro-casacivil-3f/3f8a_djvu.txt"
+_RESOLVED_HTML = "https://archive.org/download/leizilla-raw-ro-casacivil-3f/3f8a.html"
 
 _VALID_XML = (
     '<?xml version="1.0" encoding="UTF-8"?>'
@@ -60,45 +62,41 @@ def _make_urlopen_resp(body: str) -> MagicMock:
 
 class TestFetchOcr:
     def test_returns_text_on_success(self):
-        with patch(
-            "urllib.request.urlopen", return_value=_make_urlopen_resp("OCR text")
-        ):
-            assert parser.fetch_ocr(_IA_ID) == "OCR text"
+        # resolve_raw_url maps the raw_id → content-addressed URL via the index;
+        # then the OCR file at that URL is fetched. Both mocked.
+        with patch("leizilla.parser.resolve_raw_url", return_value=_RESOLVED):
+            with patch(
+                "urllib.request.urlopen", return_value=_make_urlopen_resp("OCR text")
+            ):
+                assert parser.fetch_ocr(_IA_ID) == "OCR text"
+
+    def test_returns_none_when_unresolved(self):
+        # Index/source_key not published yet → resolve returns None → no fetch.
+        with patch("leizilla.parser.resolve_raw_url", return_value=None):
+            assert parser.fetch_ocr(_IA_ID) is None
 
     def test_returns_none_on_network_error(self):
-        with patch("urllib.request.urlopen", side_effect=OSError("404")):
-            assert parser.fetch_ocr(_IA_ID) is None
+        with patch("leizilla.parser.resolve_raw_url", return_value=_RESOLVED):
+            with patch("urllib.request.urlopen", side_effect=OSError("404")):
+                assert parser.fetch_ocr(_IA_ID) is None
 
     def test_returns_none_on_timeout(self):
-        with patch("urllib.request.urlopen", side_effect=TimeoutError()):
-            assert parser.fetch_ocr(_IA_ID) is None
+        with patch("leizilla.parser.resolve_raw_url", return_value=_RESOLVED):
+            with patch("urllib.request.urlopen", side_effect=TimeoutError()):
+                assert parser.fetch_ocr(_IA_ID) is None
 
-    def test_constructs_djvu_url_fallback(self):
+    def test_fetches_the_resolved_url(self):
         captured: list[str] = []
 
         def capture(req, **kw):  # type: ignore[no-untyped-def]
             captured.append(req.full_url)
             raise OSError("stop")
 
-        non_numeric_id = "leizilla-raw-ro-casacivil-nonnumeric"
-        with patch("urllib.request.urlopen", side_effect=capture):
-            parser.fetch_ocr(non_numeric_id)
+        with patch("leizilla.parser.resolve_raw_url", return_value=_RESOLVED):
+            with patch("urllib.request.urlopen", side_effect=capture):
+                parser.fetch_ocr(_IA_ID)
 
-        expected = resolve_ia_id_to_url(non_numeric_id, "_djvu.txt")
-        assert captured == [expected]
-
-    def test_constructs_djvu_url_range(self):
-        captured: list[str] = []
-
-        def capture(req, **kw):  # type: ignore[no-untyped-def]
-            captured.append(req.full_url)
-            raise OSError("stop")
-
-        with patch("urllib.request.urlopen", side_effect=capture):
-            parser.fetch_ocr(_IA_ID)
-
-        expected = resolve_ia_id_to_url(_IA_ID, "_djvu.txt")
-        assert captured == [expected]
+        assert captured == [_RESOLVED]
 
 
 class TestFetchHtml:
@@ -142,43 +140,35 @@ class TestFetchHtml:
 
 
 class TestFetchIaHtml:
-    def test_constructs_ia_html_url_fallback(self):
+    def test_fetches_the_resolved_url(self):
         captured: list[str] = []
 
         def capture(req, **kw):  # type: ignore[no-untyped-def]
             captured.append(req.get_full_url())
             raise OSError("stop")
 
-        non_numeric_id = "leizilla-raw-ro-casacivil-nonnumeric"
-        with patch("urllib.request.urlopen", side_effect=capture):
-            parser.fetch_ia_html(non_numeric_id)
+        with patch("leizilla.parser.resolve_raw_url", return_value=_RESOLVED_HTML):
+            with patch("urllib.request.urlopen", side_effect=capture):
+                parser.fetch_ia_html(_IA_ID)
 
-        expected = resolve_ia_id_to_url(non_numeric_id, ".html")
-        assert captured == [expected]
+        assert captured == [_RESOLVED_HTML]
 
-    def test_constructs_ia_html_url_range(self):
-        captured: list[str] = []
-
-        def capture(req, **kw):  # type: ignore[no-untyped-def]
-            captured.append(req.get_full_url())
-            raise OSError("stop")
-
-        with patch("urllib.request.urlopen", side_effect=capture):
-            parser.fetch_ia_html(_IA_ID)
-
-        expected = resolve_ia_id_to_url(_IA_ID, ".html")
-        assert captured == [expected]
+    def test_returns_none_when_unresolved(self):
+        with patch("leizilla.parser.resolve_raw_url", return_value=None):
+            assert parser.fetch_ia_html(_IA_ID) is None
 
     def test_returns_html_on_success(self):
-        with patch(
-            "urllib.request.urlopen",
-            return_value=_make_urlopen_resp("<html>Lei federal</html>"),
-        ):
-            assert parser.fetch_ia_html(_IA_ID) == "<html>Lei federal</html>"
+        with patch("leizilla.parser.resolve_raw_url", return_value=_RESOLVED_HTML):
+            with patch(
+                "urllib.request.urlopen",
+                return_value=_make_urlopen_resp("<html>Lei federal</html>"),
+            ):
+                assert parser.fetch_ia_html(_IA_ID) == "<html>Lei federal</html>"
 
     def test_returns_none_on_network_error(self):
-        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
-            assert parser.fetch_ia_html(_IA_ID) is None
+        with patch("leizilla.parser.resolve_raw_url", return_value=_RESOLVED_HTML):
+            with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+                assert parser.fetch_ia_html(_IA_ID) is None
 
 
 class TestExtractJson:

--- a/tests/test_planalto_pipeline.py
+++ b/tests/test_planalto_pipeline.py
@@ -329,7 +329,13 @@ class TestUploadRawHtml:
     def test_success_returns_ia_id(self, tmp_path: Any) -> None:
         pub = _publisher()
         mock_result = MagicMock(returncode=0, stdout="", stderr="")
-        with patch("subprocess.run", return_value=mock_result):
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch(
+                "leizilla.publisher.update_raw_index",
+                return_value={"success": True},
+            ),
+        ):
             result = pub.upload_raw_html("<html>lei</html>", _lei_data_html())
         assert result["success"] is True
         assert result["ia_id"] == "leizilla-raw-federal-planalto-lei-09503"
@@ -422,6 +428,10 @@ class TestScrapeOneHtml:
             patch("leizilla.wayback.check_available", return_value=wb_url),
             patch("leizilla.scraper.fetch_html", return_value="<html>lei</html>"),
             patch("subprocess.run", return_value=mock_run),
+            patch(
+                "leizilla.publisher.update_raw_index",
+                return_value={"success": True},
+            ),
         ):
             result = scrape_one_html(self._url(), _lei_data_html(), pub)
         assert result["success"] is True
@@ -443,6 +453,10 @@ class TestScrapeOneHtml:
             patch("leizilla.wayback.check_available", return_value=None),
             patch("leizilla.scraper.fetch_html", side_effect=fake_fetch),
             patch("subprocess.run", return_value=mock_run) as _mock,
+            patch(
+                "leizilla.publisher.update_raw_index",
+                return_value={"success": True},
+            ),
         ):
             result = scrape_one_html(self._url(), _lei_data_html(), pub)
         assert result["success"] is True, result

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -572,3 +572,110 @@ class TestUploadToArchive:
         )
         assert res["success"] is False
         assert "credentials" in res["error"]
+
+
+class TestUpdateRawIndex:
+    """update_raw_index deve preservar o histórico: nunca sobrescrever o índice
+    com uma versão de uma linha por causa de falha transitória de leitura."""
+
+    def _http_error(self, code: int) -> Exception:
+        import urllib.error
+
+        return urllib.error.HTTPError(
+            url="http://ia/index.csv", code=code, msg="x", hdrs=None, fp=None
+        )
+
+    def _csv_resp(self, text: str) -> object:
+        payload = text.encode()
+
+        class _R:
+            def read(self):
+                return payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        return _R()
+
+    def test_404_starts_fresh_and_uploads(self):
+        from leizilla.publisher import update_raw_index
+
+        with patch("urllib.request.urlopen", side_effect=self._http_error(404)):
+            with patch("subprocess.run", return_value=MagicMock(returncode=0)) as run:
+                res = update_raw_index(
+                    "ro",
+                    "casacivil",
+                    source_key="coddoc-1",
+                    content_hash="h1",
+                    content_type="application/pdf",
+                    source_url="http://s/1",
+                )
+        assert res["success"] is True
+        run.assert_called_once()
+
+    def test_transient_error_aborts_without_upload(self):
+        """5xx/timeout while an index may already exist → abort, do NOT overwrite."""
+        from leizilla.publisher import update_raw_index
+
+        with patch("urllib.request.urlopen", side_effect=self._http_error(503)):
+            with patch("subprocess.run") as run:
+                res = update_raw_index(
+                    "ro",
+                    "casacivil",
+                    source_key="coddoc-2",
+                    content_hash="h2",
+                    content_type="application/pdf",
+                    source_url="http://s/2",
+                )
+        assert res["success"] is False
+        assert "data loss" in res["error"]
+        run.assert_not_called()  # crucial: no upload that would wipe history
+
+    def test_timeout_aborts_without_upload(self):
+        from leizilla.publisher import update_raw_index
+
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            with patch("subprocess.run") as run:
+                res = update_raw_index(
+                    "ro",
+                    "casacivil",
+                    source_key="coddoc-3",
+                    content_hash="h3",
+                    content_type="application/pdf",
+                    source_url="http://s/3",
+                )
+        assert res["success"] is False
+        run.assert_not_called()
+
+    def test_existing_index_is_appended_not_replaced(self):
+        from leizilla.publisher import update_raw_index
+
+        existing = (
+            "source_key,content_hash,content_type,source_url,captured_at\n"
+            "coddoc-1,h1,application/pdf,http://s/1,2026-05-30T00:00:00+00:00\n"
+        )
+        written: dict = {}
+
+        def fake_run(args, **kw):
+            # args = ["ia","upload",index_id,index_path,...] — capture uploaded CSV
+            path = args[3]
+            written["csv"] = open(path, encoding="utf-8").read()
+            return MagicMock(returncode=0)
+
+        with patch("urllib.request.urlopen", return_value=self._csv_resp(existing)):
+            with patch("subprocess.run", side_effect=fake_run):
+                res = update_raw_index(
+                    "ro",
+                    "casacivil",
+                    source_key="coddoc-2",
+                    content_hash="h2",
+                    content_type="application/pdf",
+                    source_url="http://s/2",
+                )
+        assert res["success"] is True
+        # Both the prior and the new mapping survive.
+        assert "coddoc-1,h1" in written["csv"]
+        assert "coddoc-2,h2" in written["csv"]

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -465,10 +465,15 @@ class TestCountIaItems:
 
 
 class TestListRawIds:
-    """Testes para list_raw_ids — lista raw items sem buscar metadados."""
+    """Testes para list_raw_ids — reconstrói raw_ids legados a partir do index.csv.
 
-    def _resp(self, data: dict) -> object:
-        payload = json.dumps(data).encode()
+    Sob a camada content-addressed (ADR-0010), os itens IA são buckets de hash
+    sem source_key; a descoberta lê o index.csv do (ente, fonte) e reconstrói os
+    raw_ids que o parser sabe resolver.
+    """
+
+    def _csv_resp(self, csv_text: str) -> object:
+        payload = csv_text.encode()
 
         class _R:
             def read(self):
@@ -483,66 +488,47 @@ class TestListRawIds:
         return _R()
 
     def test_returns_empty_set_on_network_error(self):
+        # No index published yet (404) → empty set → caller uses sequential range.
         with patch("urllib.request.urlopen", side_effect=OSError("network")):
             assert list_raw_ids("ro", "assembleia") == set()
 
-    def test_returns_empty_set_when_no_items(self):
-        with patch("urllib.request.urlopen", return_value=self._resp({"items": []})):
+    def test_returns_empty_set_when_index_has_no_rows(self):
+        header = "source_key,content_hash,content_type,source_url,captured_at\n"
+        with patch("urllib.request.urlopen", return_value=self._csv_resp(header)):
             assert list_raw_ids("ro", "assembleia") == set()
 
-    def test_returns_identifiers(self):
-        items = [
-            {"identifier": "leizilla-raw-ro-assembleia-coddoc-00001"},
-            {"identifier": "leizilla-raw-ro-assembleia-coddoc-00002"},
-        ]
-        with patch("urllib.request.urlopen", return_value=self._resp({"items": items})):
+    def test_reconstructs_legacy_raw_ids_from_index(self):
+        index_csv = (
+            "source_key,content_hash,content_type,source_url,captured_at\n"
+            "coddoc-00001,h1,application/pdf,http://s/1,2026-05-30T00:00:00+00:00\n"
+            "coddoc-00002,h2,application/pdf,http://s/2,2026-05-30T00:00:00+00:00\n"
+        )
+        with patch("urllib.request.urlopen", return_value=self._csv_resp(index_csv)):
             result = list_raw_ids("ro", "assembleia")
         assert result == {
             "leizilla-raw-ro-assembleia-coddoc-00001",
             "leizilla-raw-ro-assembleia-coddoc-00002",
         }
 
-    def test_follows_cursor_pagination(self):
-        page1 = {
-            "items": [{"identifier": "leizilla-raw-ro-casacivil-lei-00001"}],
-            "cursor": "tok",
-        }
-        page2 = {"items": [{"identifier": "leizilla-raw-ro-casacivil-lei-00002"}]}
-        calls = iter([self._resp(page1), self._resp(page2)])
-        with patch(
-            "urllib.request.urlopen", side_effect=lambda *a, **kw: next(calls)
-        ) as m:
+    def test_deduplicates_source_keys_across_versions(self):
+        # Same source_key captured twice (two versions) → one raw_id.
+        index_csv = (
+            "source_key,content_hash,content_type,source_url,captured_at\n"
+            "lei-00001,h1,application/pdf,http://s/1,2026-05-30T00:00:00+00:00\n"
+            "lei-00001,h2,application/pdf,http://s/1,2026-05-31T00:00:00+00:00\n"
+        )
+        with patch("urllib.request.urlopen", return_value=self._csv_resp(index_csv)):
             result = list_raw_ids("ro", "casacivil")
-        assert result == {
-            "leizilla-raw-ro-casacivil-lei-00001",
-            "leizilla-raw-ro-casacivil-lei-00002",
-        }
-        second_url = m.call_args_list[1][0][0].full_url
-        assert "cursor=tok" in second_url
+        assert result == {"leizilla-raw-ro-casacivil-lei-00001"}
 
-    def test_returns_partial_on_second_page_error(self):
-        """Page 2 network error → returns confirmed items from page 1.
-
-        Asymmetry with list_parsed_raw_ids (which returns set()): for scraping,
-        re-uploading an unconfirmed item is safe (idempotent IA upload); for
-        parsing, skipping an unconfirmed item could silently lose work.
-        """
-        page1 = {
-            "items": [{"identifier": "leizilla-raw-ro-assembleia-coddoc-00001"}],
-            "cursor": "tok",
-        }
-        call_n = {"n": 0}
-
-        def urlopen(req, timeout=None):
-            call_n["n"] += 1
-            if call_n["n"] == 1:
-                return self._resp(page1)
-            raise OSError("second page error")
-
-        with patch("urllib.request.urlopen", side_effect=urlopen):
-            assert list_raw_ids("ro", "assembleia") == {
-                "leizilla-raw-ro-assembleia-coddoc-00001"
-            }
+    def test_queries_the_index_item(self):
+        index_csv = "source_key,content_hash,content_type,source_url,captured_at\n"
+        with patch(
+            "urllib.request.urlopen", return_value=self._csv_resp(index_csv)
+        ) as m:
+            list_raw_ids("ro", "casacivil")
+        url = m.call_args_list[0][0][0].full_url
+        assert "leizilla-raw-ro-casacivil-index/index.csv" in url
 
 
 class TestUploadToArchive:

--- a/tests/test_rondonia_lc_manifest.py
+++ b/tests/test_rondonia_lc_manifest.py
@@ -88,3 +88,33 @@ class TestRondoniaLCContentAddressed:
         assert kwargs["source_key"] == "lc-00042"
         assert kwargs["content_hash"] == h
         assert kwargs["content_type"] == "application/pdf"
+
+    @patch("leizilla.publisher.update_raw_index")
+    @patch("subprocess.run")
+    def test_index_failure_propagates_as_upload_failure(
+        self, mock_run, mock_index, tmp_path
+    ):
+        # Reads resolve exclusively through the index; if the index write fails,
+        # the capture would be unreachable. upload_raw must NOT report success.
+        mock_run.return_value = MagicMock(returncode=0)
+        mock_index.return_value = {"success": False, "error": "IA 503"}
+
+        pub = InternetArchivePublisher()
+        pub.access_key = "fake-key"
+        pub.secret_key = "fake-secret"
+
+        pdf_path = tmp_path / "LC42.pdf"
+        pdf_bytes = b"PDF content for LC 42"
+        pdf_path.write_bytes(pdf_bytes)
+
+        lei_data = {
+            "ente": "ro",
+            "fonte": "casacivil",
+            "chave": "lc-00042",
+            "url_original": "http://ditel/LC42.pdf",
+        }
+
+        res = pub.upload_raw(pdf_path, lei_data, pdf_bytes, fetched_from="wayback")
+
+        assert res["success"] is False
+        assert "index update failed" in res["error"]

--- a/tests/test_rondonia_lc_manifest.py
+++ b/tests/test_rondonia_lc_manifest.py
@@ -1,72 +1,57 @@
-"""Test pipeline validation specifically for Rondônia Leis Complementares and UUIDv5 manifest.csv."""
+"""Pipeline validation for the content-addressed raw layer (ADR-0010).
 
-import csv
+Rondônia Lei Complementar example: upload names the file by content hash, the
+range item buckets by hash prefix, and the (ente, fonte) index records the
+source_key → content_hash mapping. The source's harvest key (coddoc/lc number)
+is metadata, never a path.
+"""
+
 from unittest.mock import patch, MagicMock
 
-
-from leizilla.publisher import InternetArchivePublisher, update_ia_manifest
+from leizilla.publisher import InternetArchivePublisher
 from leizilla.ia_utils import (
-    get_range_identifier,
-    get_ia_filename,
-    resolve_ia_id_to_url,
+    compute_hash,
+    lookup_current_hash,
+    raw_filename,
+    raw_range_identifier,
+    resolve_raw_url,
 )
 
 
-class TestRondoniaLCManifestPipeline:
-    """Valida o pipeline completo de upload, nomenclatura e manifest.csv para Leis Complementares de Rondônia."""
+class TestRondoniaLCContentAddressed:
+    def test_filename_and_range_are_content_addressed(self):
+        pdf_bytes = b"PDF content for LC 42"
+        h = compute_hash(pdf_bytes)
 
-    def test_rondonia_lc_nomenclature_and_range(self):
-        # Dado uma Lei Complementar nº 42 de Rondônia Casa Civil (descoberta via Files/LC42.pdf)
-        ente = "ro"
-        fonte = "casacivil"
-        tipo = "lc"
-        num = 42
-
-        # 1. Valida a geração do range do IA (segregado por tipo 'lc')
-        range_id = get_range_identifier(ente, fonte, tipo, num)
-        assert range_id == "leizilla_ro_casacivil_lc_0001-1000"
-
-        # 2. Valida a geração do filename previsível e determinístico
-        filename = get_ia_filename(num, ".pdf")
-        # O arquivo físico omite o tipo 'lc' e não anexa hashes de versão
-        assert filename == "000042.pdf"
-
-        # 3. Valida a resolução transparente da URL de download direto a partir do ID bruto DuckDB legado
-        legacy_ia_id = "leizilla-raw-ro-casacivil-lc-00042"
-        resolved_url = resolve_ia_id_to_url(legacy_ia_id, ".pdf")
-        expected_url = (
-            "https://archive.org/download/leizilla_ro_casacivil_lc_0001-1000/000042.pdf"
+        # Range item buckets by hash prefix — no coddoc, no lc number in the path.
+        assert raw_range_identifier("ro", "casacivil", h) == (
+            f"leizilla-raw-ro-casacivil-{h[:2]}"
         )
-        assert resolved_url == expected_url
+        # File is named purely by the content hash.
+        assert raw_filename(h, ".pdf") == f"{h}.pdf"
 
-    def test_incremental_manifest_csv_generation(self, tmp_path):
-        range_id = "leizilla_ro_casacivil_lc_0001-1000"
-        filename = "000042.pdf"
-        url_original = "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/LC42.pdf"
+    def test_resolve_via_index_roundtrip(self):
+        pdf_bytes = b"PDF content for LC 42"
+        h = compute_hash(pdf_bytes)
+        # Index maps the legacy source_key (lc-00042) to the content hash.
+        index_csv = (
+            "source_key,content_hash,content_type,source_url,captured_at\n"
+            f"lc-00042,{h},application/pdf,http://ditel/LC42.pdf,2026-05-30T00:00:00+00:00\n"
+        )
+        assert lookup_current_hash(index_csv, "lc-00042") == (h, "application/pdf")
 
-        import urllib.error
+        with patch("leizilla.ia_utils._fetch_text", return_value=index_csv):
+            url = resolve_raw_url("leizilla-raw-ro-casacivil-lc-00042", "_djvu.txt")
+        assert url == (
+            f"https://archive.org/download/leizilla-raw-ro-casacivil-{h[:2]}/"
+            f"{h}_djvu.txt"
+        )
 
-        # Simula o upload idempotente do manifest.csv
-        # Como o IA ainda não tem o manifest (retorna 404), começamos com um manifest limpo
-        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("404")):
-            manifest_path = update_ia_manifest(
-                range_id, filename, url_original, tmp_path
-            )
-
-        assert manifest_path.exists()
-
-        # Lê e valida os dados do CSV gerado
-        with open(manifest_path, "r", encoding="utf-8") as f:
-            reader = csv.reader(f)
-            header = next(reader)
-            row = next(reader)
-
-        assert header == ["filename", "url"]
-        assert row == [filename, url_original]
-
+    @patch("leizilla.publisher.update_raw_index")
     @patch("subprocess.run")
-    def test_complete_upload_raw_lc_rondonia(self, mock_run, tmp_path):
+    def test_complete_upload_raw_lc_rondonia(self, mock_run, mock_index, tmp_path):
         mock_run.return_value = MagicMock(returncode=0)
+        mock_index.return_value = {"success": True}
 
         pub = InternetArchivePublisher()
         pub.access_key = "fake-key"
@@ -75,6 +60,7 @@ class TestRondoniaLCManifestPipeline:
         pdf_path = tmp_path / "LC42.pdf"
         pdf_bytes = b"PDF content for LC 42"
         pdf_path.write_bytes(pdf_bytes)
+        h = compute_hash(pdf_bytes)
 
         lei_data = {
             "ente": "ro",
@@ -83,27 +69,22 @@ class TestRondoniaLCManifestPipeline:
             "url_original": "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/LC42.pdf",
         }
 
-        import urllib.error
-
-        # Mock de rede do update_ia_manifest
-        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("404")):
-            res = pub.upload_raw(pdf_path, lei_data, pdf_bytes, fetched_from="wayback")
+        res = pub.upload_raw(pdf_path, lei_data, pdf_bytes, fetched_from="wayback")
 
         assert res["success"] is True
         assert (
             res["ia_url"]
-            == "https://archive.org/details/leizilla_ro_casacivil_lc_0001-1000"
+            == f"https://archive.org/details/leizilla-raw-ro-casacivil-{h[:2]}"
         )
 
-        # Verifica que o subprocess.run chamou a CLI do IA com os metadados corretos
+        # Upload targeted the hash-prefix range item with the hash-named file.
         args = mock_run.call_args[0][0]
-        assert "ia" in args
-        assert "upload" in args
-        assert "leizilla_ro_casacivil_lc_0001-1000" in args
+        assert "ia" in args and "upload" in args
+        assert f"leizilla-raw-ro-casacivil-{h[:2]}" in args
+        assert any(a.endswith(f"{h}.pdf") for a in args)
 
-        # O arquivo PDF no upload deve ser o filename previsível e determinístico
-        expected_pdf_name = "000042.pdf"
-
-        # Verifica que o PDF renomeado temporariamente com o padrão determinístico foi incluído no upload
-        pdf_arg = next((a for a in args if a.endswith(expected_pdf_name)), None)
-        assert pdf_arg is not None
+        # The index was updated with source_key → content_hash (coddoc/lc as metadata).
+        _, kwargs = mock_index.call_args
+        assert kwargs["source_key"] == "lc-00042"
+        assert kwargs["content_hash"] == h
+        assert kwargs["content_type"] == "application/pdf"


### PR DESCRIPTION
## O que

1. **ADR-0010** — estabelece o modelo: **raw é content-addressed (SHA-256), parsed é URN-keyed, chaves de fonte são metadados**. Marca as linhas raw de ADR-0005 como superadas.
2. **Implementação** que desfaz a nomenclatura coddoc-shaped de #74 e adota o modelo da ADR.

Closes #76.

## Por quê

PR #74 consolidou os uploads do IA em ranges (bom), mas ancorou range e filename no número de `coddoc` — a chave primária do **CMS da Ditel**, idiossincrasia de *uma fonte*. Planalto endereça por caminho de URL; outras fontes têm esquemas próprios. Promover `coddoc` a parâmetro de range/arquivo hard-codifica o quirk de um scraper no catálogo nacional.

Causa raiz: confundir **`coddoc`** (chave de colheita, pré-parse, específica da fonte) com **norma** (identidade jurídica via URN-LEX, pós-parse, pan-Brasil).

## A decisão (ADR-0010)

- **Raw → content-addressed**: arquivo nomeado pelo SHA-256; range item bucketiza por prefixo de hash (`leizilla-raw-ro-casacivil-3f`). Agnóstico de fonte; dedup e imutabilidade de graça.
- **Índice por `(ente, fonte)`**: `index.csv` (`source_key, content_hash, content_type, source_url, captured_at`) é a ponte chave-de-colheita → hash. `fetch_ocr` resolve via lookup (um fetch por ente/fonte, cacheável).
- **Parsed → URN-LEX**: inalterado (ADR-0005).

Granularidade do bucket: **prefixo de hash** (decisão registrada na #76).

## Mudanças de código

- **`ia_utils.py`** — reescrito: `compute_hash`, `parse_raw_id` (longest-ente match), `raw_index_identifier`, `raw_range_identifier`, `raw_filename`, `merge_index_row` (append-only, idempotente em key+hash), `lookup_current_hash` (mais recente vence), `resolve_raw_url` (lookup no índice; `None` quando não publicado).
- **`parser.py`** — `fetch_ocr`/`fetch_ia_html` resolvem via índice; contrato mantido (string única / `None`).
- **`publisher.py`** — `upload_raw`/`upload_raw_html` nomeiam por hash, sobem ao range por prefixo, e `update_raw_index` anexa `source_key → hash` ao item índice. Removidos `update_ia_manifest` e os helpers coddoc.
- Testes reescritos para a API content-addressed.

## Cardinalidade (ADR-0010 §4)

Uma norma → muitos arquivos raw (versões + componentes). `raw_id` identifica a chave de colheita, não a norma. Captura = `(source_key, content_hash)`; versão distinguida por `captured_at`, componente por `content_type`.

## Verificação local

- **511 passed, 13 skipped** (`uv run leizilla dev check`)
- ruff check + format + mypy: limpos
- Nenhum upload de produção sob o esquema de #74 → sem migração de itens IA.

## Test plan

- [x] `uv run leizilla dev check` verde
- [x] `parse_raw_id` resolve entes com hífen (longest match) e source_keys com hífen
- [x] `merge_index_row` append-only e idempotente; `lookup_current_hash` retorna a captura mais recente
- [x] `resolve_raw_url` retorna `None` quando índice/source_key ausente (sem 404 silencioso virar string)