### PR TITLE
feat(ia): ADR-0011 identity-keyed raw layer (+ ia auth fix, web redesign)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,16 @@ data/                # local DuckDB + artifacts (gitignored)
   SHA-256 (source-agnostic, dedup-by-construction); parsed norms are keyed by
   URN-LEX. The harvest key (`coddoc`, URL path, …) is metadata in an `index.csv`,
   never a path or range boundary. ADR-0010 supersedes ADR-0005's raw-item scheme.
+- **ADR-0011 — identity-keyed navigable catalog; identity is evidence, not an
+  ingestion gate.** The raw IA item is a navigable range bucket per `(ente, fonte,
+  tipo, número)` with content-addressed files inside. **Capturing a resource is
+  decided by discovery *context*** (a legislation-aware strategy targeted it —
+  pattern/listing/title), **not** by reading the document: everything discovered is
+  preserved content-addressed. `(tipo, número)` is a best-effort hypothesis refined
+  downstream (pattern → listing → OCR/parse) that *promotes* a resource into the
+  navigable catalog; un-numbered resources wait in a
+  `leizilla_{ente}_{fonte}_unidentified` holding area (IA still OCRs them), never
+  discarded. Reconciliation promotes them once tipo+número are known.
 
 The codebase is **fail-open by design**: Wayback save failures, missing
 robots.txt, and IA query errors return empty/None rather than aborting batch jobs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,14 +122,17 @@ data/                # local DuckDB + artifacts (gitignored)
   never a path or range boundary. ADR-0010 supersedes ADR-0005's raw-item scheme.
 - **ADR-0011 — identity-keyed navigable catalog; identity is evidence, not an
   ingestion gate.** The raw IA item is a navigable range bucket per `(ente, fonte,
-  tipo, número)` with content-addressed files inside. **Capturing a resource is
-  decided by discovery *context*** (a legislation-aware strategy targeted it —
-  pattern/listing/title), **not** by reading the document: everything discovered is
-  preserved content-addressed. `(tipo, número)` is a best-effort hypothesis refined
-  downstream (pattern → listing → OCR/parse) that *promotes* a resource into the
-  navigable catalog; un-numbered resources wait in a
-  `leizilla_{ente}_{fonte}_unidentified` holding area (IA still OCRs them), never
-  discarded. Reconciliation promotes them once tipo+número are known.
+  tipo, número)` with content-addressed files inside. **Extracting `(tipo, número)`
+  from discovery *context* is the primary job and resolves >90%** — the number lives
+  in the page metadata / lead-in listing pages / URL-filename pattern (ALRO title,
+  casacivil `L{N}.pdf`, Planalto URL path), read *before* fetching the PDF; the
+  identified resource goes straight to the catalog. "Un-numbered" shouldn't happen
+  on the normal path — if it does often for a source, strengthen that source's
+  discovery strategy. The residual <10% needs a deliberate **special strategy** per
+  source (e.g. fetch → IA OCR → parse); meanwhile those bytes are **preserved** in a
+  `leizilla_{ente}_{fonte}_unidentified` holding area (the exception, never
+  discarded) and promoted by reconciliation. Capture is decided by context, not by
+  reading the document.
 
 The codebase is **fail-open by design**: Wayback save failures, missing
 robots.txt, and IA query errors return empty/None rather than aborting batch jobs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ All commands run as `uv run leizilla <command>`. Most take `--ente` (default `ro
 |---|---|
 | `discover --ente ro` | run manifest discovery → enqueue resources |
 | `harvest --ente ro --limit 100` | process the pending queue (scrape + upload) |
+| `reconcile --ente ro [--fonte assembleia]` | promote `_unidentified` holding files into range items once discovery context yields `(tipo, número)` (ADR-0011 §1) |
 | `scrape --ente ro --fonte casacivil --tipo lei --start-coddoc 1 --end-coddoc 10` | range scrape one source |
 | `bundle-raw --ente ro --fonte casacivil` | consolidate raw PDFs into one IA item (torrents) |
 | `fetch-ocr --ente ro --limit 100` | pull IA OCR text into DuckDB |

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -137,8 +137,10 @@ identificar a norma como `{tipo}-{número:05d}` (ex.: `lei-05120`, `lc-00042`,
 
 Dentro do item: `{uuid5}.pdf` / `{uuid5}_djvu.txt` (OCR derivado pelo IA) /
 `{uuid5}_meta.json`, e um `index.csv` mapeando `(tipo, número, rendição, formato)
-→ {uuid5, sha256, captured_at}` (newest-wins). Versões e rendições coexistem como
-arquivos hash distintos; dedup e detecção de colisão usam o `sha256` completo.
+→ {uuid5, sha256, captured_at, source}` (newest-wins). A coluna `source` é a
+chave de colheita / URL de origem (ADR-0010), mapeando cada arquivo à sua fonte
+— é o que permite à identidade descartar o `coddoc`. Versões e rendições coexistem
+como arquivos hash distintos; dedup e detecção de colisão usam o `sha256` completo.
 
 **Justificativa**: IA faz OCR **apenas** em PDFs individuais (não em ZIP), e
 agrupar por range mantém o catálogo navegável e o número de items sob controle.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -114,18 +114,34 @@ Implicações que decorrem disso (e estão em outras seções):
 
 (Carregado da v1 — esta parte funciona inalterada.)
 
-### 1.1 Raw items — individual por PDF
+### 1.1 Raw items — identity-keyed range buckets (ADR-0011)
 
-**Pattern**: `leizilla-raw-{ente}-{fonte}-{chave}`
+> **Atualizado por [ADR-0011](adr/0011-raw-identity-keyed-range-items.md).** A
+> camada raw deixou de ter "um item IA por PDF". Hoje o item IA é um *range
+> bucket* por **identidade** `(ente, fonte, tipo, número)`, e os arquivos dentro
+> dele são content-addressed (UUIDv5 truncado). O `leizilla-raw-{ente}-{fonte}-{chave}`
+> abaixo permanece como o **raw_id lógico** (chave no DuckDB/CLI e em `<fonte
+> ia-id="…">`); ele não é mais o identificador do item IA — é resolvido para a URL
+> real via o `index.csv` do item.
 
-| ente | fonte | chave | Exemplo |
+**raw_id lógico**: `leizilla-raw-{ente}-{fonte}-{chave}`, onde `{chave}` deve
+identificar a norma como `{tipo}-{número:05d}` (ex.: `lei-05120`, `lc-00042`,
+`decreto-01234`). **Reject-until-identified**: chaves não-identificantes (`coddoc`,
+`seq`, `fallback`, `documento`) não entram na coleção.
+
+| ente | fonte | chave | Item IA (range) |
 |---|---|---|---|
-| `ro` | `casacivil` | `coddoc-{N:05d}` | `leizilla-raw-ro-casacivil-coddoc-00042` |
-| `ro` | `assembleia` | `coddoc-{N:05d}` | `leizilla-raw-ro-assembleia-coddoc-00042` |
-| `ro` | `diario` | `{YYYY-MM-DD}-p{pagina:04d}` | `leizilla-raw-ro-diario-2003-06-15-p0012` |
-| `federal` | `planalto` | `{tipo}-{numero:05d}` | `leizilla-raw-federal-planalto-lei-12345` |
+| `ro` | `casacivil` | `{tipo}-{N:05d}` (de `L{N}.pdf`) | `leizilla_ro_casacivil_lei_5001-6000` |
+| `federal` | `planalto` | `{tipo}-{N:05d}` | `leizilla_federal_planalto_lei_12001-13000` |
+| `ro` | `assembleia` | só `coddoc` hoje → **deferida** até expor tipo+número | — |
 
-**Justificativa**: IA faz OCR **apenas** em PDFs individuais (não em PDFs dentro de ZIP). Permalink por PDF facilita citação. Manifest CSV escala para milhares de items.
+Dentro do item: `{uuid5}.pdf` / `{uuid5}_djvu.txt` (OCR derivado pelo IA) /
+`{uuid5}_meta.json`, e um `index.csv` mapeando `(tipo, número, rendição, formato)
+→ {uuid5, sha256, captured_at}` (newest-wins). Versões e rendições coexistem como
+arquivos hash distintos; dedup e detecção de colisão usam o `sha256` completo.
+
+**Justificativa**: IA faz OCR **apenas** em PDFs individuais (não em ZIP), e
+agrupar por range mantém o catálogo navegável e o número de items sob controle.
 
 ### 1.2 Raw items — bundle ZIP semanal (redundância)
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -127,14 +127,15 @@ Implicações que decorrem disso (e estão em outras seções):
 **raw_id lógico**: `leizilla-raw-{ente}-{fonte}-{chave}`, onde `{chave}` identifica
 a norma como `{tipo}-{número:05d}` (ex.: `lei-05120`, `lc-00042`, `decreto-01234`).
 
-**Identidade é evidência, não catraca de ingestão** (ADR-0011, §1 revisada): a
-captura é decidida pelo **contexto da descoberta** (uma estratégia ciente de
-legislação apontou para o recurso), não pela leitura do documento. Tudo o que se
-descobre é **preservado** content-addressed; a identidade `(tipo, número)` é uma
-hipótese refinada a jusante (padrão → listagem → OCR/parse) que **promove** o
-recurso ao item de range. Chaves não-identificantes (`coddoc`, `seq`, `fallback`,
-`documento`) ainda não entram no **catálogo navegável** — ficam na área de espera
-`leizilla_{ente}_{fonte}_unidentified` até a reconciliação, nunca descartadas.
+**Identidade é evidência, não catraca de ingestão** (ADR-0011, §1 revisada):
+**extrair `(tipo, número)` do contexto da descoberta** (metadados / páginas que
+levam ao PDF, padrão de URL/nome) é a tarefa primária e resolve >90% dos casos —
+o recurso identificado vai direto ao catálogo. "Sem número" **não deveria acontecer
+na rota normal**; o resíduo (<10%) exige uma **estratégia especial** por fonte e,
+até resolver, fica **preservado** na área de espera content-addressed
+`leizilla_{ente}_{fonte}_unidentified` (o IA faz OCR), promovido por reconciliação.
+A área de espera é a **exceção**, nunca um descarte — capturar é decidido pelo
+contexto, não pela leitura do documento.
 
 | ente | fonte | chave | Item IA (range) |
 |---|---|---|---|

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -124,16 +124,24 @@ Implicações que decorrem disso (e estão em outras seções):
 > ia-id="…">`); ele não é mais o identificador do item IA — é resolvido para a URL
 > real via o `index.csv` do item.
 
-**raw_id lógico**: `leizilla-raw-{ente}-{fonte}-{chave}`, onde `{chave}` deve
-identificar a norma como `{tipo}-{número:05d}` (ex.: `lei-05120`, `lc-00042`,
-`decreto-01234`). **Reject-until-identified**: chaves não-identificantes (`coddoc`,
-`seq`, `fallback`, `documento`) não entram na coleção.
+**raw_id lógico**: `leizilla-raw-{ente}-{fonte}-{chave}`, onde `{chave}` identifica
+a norma como `{tipo}-{número:05d}` (ex.: `lei-05120`, `lc-00042`, `decreto-01234`).
+
+**Identidade é evidência, não catraca de ingestão** (ADR-0011, §1 revisada): a
+captura é decidida pelo **contexto da descoberta** (uma estratégia ciente de
+legislação apontou para o recurso), não pela leitura do documento. Tudo o que se
+descobre é **preservado** content-addressed; a identidade `(tipo, número)` é uma
+hipótese refinada a jusante (padrão → listagem → OCR/parse) que **promove** o
+recurso ao item de range. Chaves não-identificantes (`coddoc`, `seq`, `fallback`,
+`documento`) ainda não entram no **catálogo navegável** — ficam na área de espera
+`leizilla_{ente}_{fonte}_unidentified` até a reconciliação, nunca descartadas.
 
 | ente | fonte | chave | Item IA (range) |
 |---|---|---|---|
 | `ro` | `casacivil` | `{tipo}-{N:05d}` (de `L{N}.pdf`) | `leizilla_ro_casacivil_lei_5001-6000` |
 | `federal` | `planalto` | `{tipo}-{N:05d}` | `leizilla_federal_planalto_lei_12001-13000` |
-| `ro` | `assembleia` | só `coddoc` hoje → **deferida** até expor tipo+número | — |
+| `ro` | `assembleia` | `{tipo}-{N:05d}` (título da página) | `leizilla_ro_assembleia_lei_5001-6000` |
+| (qualquer) | (qualquer) | sem número resolvido → **preservado**, aguardando reconciliação | `leizilla_{ente}_{fonte}_unidentified` |
 
 Dentro do item: `{uuid5}.pdf` / `{uuid5}_djvu.txt` (OCR derivado pelo IA) /
 `{uuid5}_meta.json`, e um `index.csv` mapeando `(tipo, número, rendição, formato)

--- a/docs/adr/0010-raw-content-addressed-parsed-urn.md
+++ b/docs/adr/0010-raw-content-addressed-parsed-urn.md
@@ -1,9 +1,14 @@
 # ADR-0010 — Raw é content-addressed, Parsed é URN-keyed, chaves de fonte são metadados
 
-**Status**: Aprovada
+**Status**: Parcialmente superada (camada Raw) — ver [ADR-0011](0011-raw-identity-keyed-range-items.md)
 **Data**: 2026-05-30
 **Contexto**: M4 — Internet Archive consolidation (pós PR #74)
 **Supersede**: linha "Raw (individual)" e "Raw (bundle ZIP)" de [ADR-0005](0005-ia-identifiers.md)
+**Superada por**: a camada **Raw** desta ADR (content-addressed, itens
+bucketizados por hash) foi substituída por
+[ADR-0011](0011-raw-identity-keyed-range-items.md) — raw identity-keyed por
+`(ente, fonte, tipo, número)`, arquivos content-addressed dentro do item. A parte
+**Parsed é URN-keyed** permanece vigente.
 
 ## Contexto
 

--- a/docs/adr/0011-raw-identity-keyed-range-items.md
+++ b/docs/adr/0011-raw-identity-keyed-range-items.md
@@ -170,12 +170,20 @@ A camada parsed permanece **URN-keyed** (URN-LEX), conforme ADR-0010/ADR-0005.
   `parser` (resolução via index), `discovery` (captura por contexto, sem descarte),
   e a suíte de testes.
 
+## Implementado
+
+- **Passo de reconciliação** (`_unidentified` → item de range): o comando
+  `leizilla reconcile` re-roda a descoberta com os extratores atuais (re-derivação
+  **por contexto**), monta o mapa `source-URL → (tipo, número)` e promove os
+  arquivos preservados agora identificáveis. Os bytes vêm do **IA** (item de
+  espera), nunca do portal de origem (ADR-0004); a linha promovida sai do índice de
+  espera via `remove_index_rows`.
+
 ## Em aberto
 
-- **Passo de reconciliação** (`_unidentified` → item de range): promove um recurso
-  preservado quando tipo+número passam a ser conhecidos (padrão melhor, detalhe da
-  listagem, ou OCR+parse). Os bytes, o `source` e o OCR já estão preservados, então
-  a promoção é uma operação de manifesto + (possível) cópia entre itens.
+- **Reconciliação por OCR+parse** para o resíduo cujo número só existe no corpo do
+  documento (o `<10%` que a re-derivação por contexto não cobre). A re-derivação
+  por contexto já está implementada; falta a variante que lê o `_djvu.txt`.
 - Capturar o **contexto de descoberta** como proveniência rica (estratégia/página
   que encontrou o recurso, âncora, seção) — hoje `source` guarda só a URL.
 - Confirmar empiricamente se o número de `casacivil` (`L{N}.pdf`) coincide com o

--- a/docs/adr/0011-raw-identity-keyed-range-items.md
+++ b/docs/adr/0011-raw-identity-keyed-range-items.md
@@ -1,11 +1,33 @@
-# ADR-0011 — Raw é identity-keyed por (ente, fonte, tipo, número); arquivos content-addressed dentro do item; só se admite o que sabemos identificar
+# ADR-0011 — Raw é capturado por contexto (content-addressed); o catálogo navegável é identity-keyed por (ente, fonte, tipo, número); identidade é evidência refinada a jusante, não catraca de ingestão
 
-**Status**: Aprovada
+**Status**: Aprovada (revisada 2026-06-02 — ver "Revisão" abaixo)
 **Data**: 2026-06-02
 **Contexto**: M4 — Internet Archive, revisão do esquema raw (decisão do owner)
 **Supersede**: a camada **Raw** de [ADR-0010](0010-raw-content-addressed-parsed-urn.md)
 (itens bucketizados por prefixo de hash). Mantém intacta a parte **Parsed é
 URN-keyed** de ADR-0010/[ADR-0005](0005-ia-identifiers.md).
+
+## Revisão (2026-06-02) — identidade é evidência, não catraca
+
+A primeira versão desta ADR tinha um **gate de ingestão "identidade ou nada"**:
+recursos sem `(tipo, número)` extraível na descoberta eram **descartados**. Isso
+foi revertido por confundir duas perguntas distintas e por contrariar o ethos de
+preservação de [ADR-0001](0001-projeto-estatico-duckdb-torrent.md) (arquivar tudo:
+storage do IA é grátis e permanente, fontes gov.br são frágeis):
+
+1. **"Devemos capturar?"** é respondido pelo **contexto da descoberta**, não pela
+   leitura do documento. Um recurso só aparece porque uma estratégia ciente de
+   legislação apontou para ele — logo já há **evidência positiva de que é norma**
+   antes de abrir o PDF.
+2. **"Que norma é esta (tipo, número)?"** é uma **hipótese refinada a jusante**
+   (padrão → listagem → OCR/parse), confidence-gated. Não é pré-condição de
+   captura — e *não pode* ser, já que o **próprio OCR do IA** é o que muitas vezes
+   revela o número.
+
+A decisão revisada (§1) preserva tudo o que se descobre e usa identidade para
+**promover** ao catálogo navegável, não para barrar a entrada. As seções §2–§5
+(itens navegáveis, arquivos content-addressed, `index.csv`, sem `-rN`) seguem
+válidas — passam a ser a camada de **saída classificada**, não a catraca.
 
 ## Contexto
 
@@ -38,13 +60,33 @@ coordenada nacional uniforme na camada raw — essa é a função da camada **pa
 
 ## Decisão
 
-### 1. Gate de ingestão — identidade ou nada
+### 1. Ingestão — capturar é dirigido por contexto; identidade é evidência, não catraca
 
-A identidade de ingestão é `(ente, fonte, tipo, número)`, extraída na descoberta.
-**Reject-until-identified**: recursos sem `(tipo, número)` — p.ex. o browse por
-`coddoc` puro da ALRO assembleia — **não** são adicionados; são descartados e
-logados até que a descoberta produza tipo+número. Isso **elimina os fallbacks de
-lixo** atuais (`("documento","fallback-…")`, `("lei","seq-NNNNN")`).
+Dois fatos distintos, que a versão original confundia num só "gate":
+
+- **"Devemos capturar este recurso?"** — respondido na **descoberta, pelo
+  contexto**. Um recurso só aparece porque uma estratégia ciente de legislação
+  apontou para ele: um padrão de URL do manifesto, um template sequencial, um
+  prefixo CDX, ou uma página de listagem cuja seção/âncora diz "Leis Ordinárias /
+  Lei nº 5120". **Por construção, a estratégia já afirma "isto é uma norma"** —
+  antes de abrir o PDF. Logo **capturamos os bytes** (content-addressed) e o
+  **contexto de descoberta** como proveniência. A captura **nunca** é condicionada
+  a extrair um número de uma chave.
+- **"Que norma é esta — tipo, número, com que confiança?"** — uma **hipótese
+  best-effort** derivada do mesmo contexto (nome de arquivo → número em casacivil;
+  título → número na ALRO; caminho de URL → número no Planalto; linha da listagem
+  → número), **refinada a jusante** (outro padrão, um detalhe da página, ou
+  OCR+parse) e **confidence-gated**. É *isto* que **promove** o recurso ao catálogo
+  navegável identity-keyed (§2).
+
+Falhar em ler o número de um nome de arquivo **não** rebaixa o recurso a "coisa
+desconhecida": ele segue sendo uma **norma-presumida com número ainda não lido**.
+Descartá-lo jogaria fora a evidência positiva que já tínhamos. Em vez disso, um
+recurso sem `(tipo, número)` resolvido fica **preservado** numa área de espera
+content-addressed (`leizilla_{ente}_{fonte}_unidentified`), onde o IA faz OCR; um
+passo de **reconciliação** o promove ao item de range assim que tipo+número são
+conhecidos. Os antigos fallbacks de lixo (`("documento","fallback-…")`,
+`("lei","seq-NNNNN")`) são substituídos por essa área de espera — não por descarte.
 
 ### 2. Item IA — range bucket por identidade
 
@@ -110,15 +152,25 @@ A camada parsed permanece **URN-keyed** (URN-LEX), conforme ADR-0010/ADR-0005.
   `casacivil` o número é o do arquivo `L{N}.pdf` (que ADR-0010 nota ser o `coddoc`
   da Ditel); aceitamos isso porque não há colisão entre fontes e a identidade
   normativa nacional vive no parsed (URN-LEX).
-- **ALRO assembleia (coddoc puro) fica deferida** até a descoberta extrair
-  tipo+número (ou até mapearmos coddoc→norma via parse).
+- **Nada com evidência de descoberta é perdido.** Recursos sem número resolvido
+  são preservados na área de espera `_unidentified` (content-addressed + OCR do
+  IA), não descartados — alinhado ao ethos de arquivo da ADR-0001.
+- **ALRO assembleia** entra normalmente: o título da página rende tipo+número na
+  descoberta, então vai direto ao catálogo; títulos não-parseáveis ficam na área
+  de espera até a reconciliação.
 - **Requer** um classificador de rendição por fonte (rótulos do portal → vocab) e
   reescrita de `ia_utils`, `publisher` (identificadores + index com rendição),
-  `parser` (resolução via index), `discovery` (gate + remoção dos fallbacks), e a
-  suíte de testes.
+  `parser` (resolução via index), `discovery` (captura por contexto, sem descarte),
+  e a suíte de testes.
 
 ## Em aberto
 
+- **Passo de reconciliação** (`_unidentified` → item de range): promove um recurso
+  preservado quando tipo+número passam a ser conhecidos (padrão melhor, detalhe da
+  listagem, ou OCR+parse). Os bytes, o `source` e o OCR já estão preservados, então
+  a promoção é uma operação de manifesto + (possível) cópia entre itens.
+- Capturar o **contexto de descoberta** como proveniência rica (estratégia/página
+  que encontrou o recurso, âncora, seção) — hoje `source` guarda só a URL.
 - Confirmar empiricamente se o número de `casacivil` (`L{N}.pdf`) coincide com o
   número da lei ou é o `coddoc` do CMS. Não bloqueia esta decisão (o item é
   namespaced por fonte), mas afeta a legibilidade dos ranges.

--- a/docs/adr/0011-raw-identity-keyed-range-items.md
+++ b/docs/adr/0011-raw-identity-keyed-range-items.md
@@ -78,11 +78,16 @@ discriminador) — nunca um overwrite silencioso.
 
 ### 4. `index.csv` por item — o mapa identidade → arquivo
 
-Mapeia `(tipo, número, rendição, formato) → {uuid5_8, sha256, captured_at}`,
+Mapeia `(tipo, número, rendição, formato) → {uuid5_8, sha256, captured_at, source}`,
 append-only, **newest-wins**. Rendição (`original`, `compilada`, `atual`, …) e
 formato (`pdf`, `docx`, `html`) são **metadados no índice, não no nome do
 arquivo**. Quando a rendição não puder ser classificada pela fonte, fica vazia
 (`unclassified`) — o arquivo ainda é admitido (já é content-addressed).
+
+A coluna **`source`** guarda a chave de colheita / URL de origem (ADR-0010): é
+o que mapeia cada arquivo de volta à sua fonte. É justamente por o índice
+preservar a proveniência que a **identidade pode descartar o `coddoc`** — o
+índice de navegação da ALRO vira metadado em `source`, nunca a chave de identidade.
 
 ### 5. Sem `-rN`
 

--- a/docs/adr/0011-raw-identity-keyed-range-items.md
+++ b/docs/adr/0011-raw-identity-keyed-range-items.md
@@ -19,10 +19,10 @@ storage do IA é grátis e permanente, fontes gov.br são frágeis):
    leitura do documento. Um recurso só aparece porque uma estratégia ciente de
    legislação apontou para ele — logo já há **evidência positiva de que é norma**
    antes de abrir o PDF.
-2. **"Que norma é esta (tipo, número)?"** é uma **hipótese refinada a jusante**
-   (padrão → listagem → OCR/parse), confidence-gated. Não é pré-condição de
-   captura — e *não pode* ser, já que o **próprio OCR do IA** é o que muitas vezes
-   revela o número.
+2. **"Que norma é esta (tipo, número)?"** é extraído do **contexto da descoberta**
+   (metadados / páginas que levam ao PDF) na grande maioria dos casos (>90%). Não é
+   pré-condição de captura — e *não pode* ser no resíduo, já que aí o **próprio OCR
+   do IA** é o que revela o número (galinha-e-ovo: sem upload não há OCR).
 
 A decisão revisada (§1) preserva tudo o que se descobre e usa identidade para
 **promover** ao catálogo navegável, não para barrar a entrada. As seções §2–§5
@@ -72,21 +72,28 @@ Dois fatos distintos, que a versão original confundia num só "gate":
   antes de abrir o PDF. Logo **capturamos os bytes** (content-addressed) e o
   **contexto de descoberta** como proveniência. A captura **nunca** é condicionada
   a extrair um número de uma chave.
-- **"Que norma é esta — tipo, número, com que confiança?"** — uma **hipótese
-  best-effort** derivada do mesmo contexto (nome de arquivo → número em casacivil;
-  título → número na ALRO; caminho de URL → número no Planalto; linha da listagem
-  → número), **refinada a jusante** (outro padrão, um detalhe da página, ou
-  OCR+parse) e **confidence-gated**. É *isto* que **promove** o recurso ao catálogo
-  navegável identity-keyed (§2).
+- **"Que norma é esta — tipo, número?"** — extraído do **mesmo contexto**: nome de
+  arquivo → número em casacivil; título da página → número na ALRO; caminho de URL
+  → número no Planalto; linha/metadado da listagem → número. É *isto* que **promove**
+  o recurso ao catálogo navegável identity-keyed (§2).
 
-Falhar em ler o número de um nome de arquivo **não** rebaixa o recurso a "coisa
-desconhecida": ele segue sendo uma **norma-presumida com número ainda não lido**.
-Descartá-lo jogaria fora a evidência positiva que já tínhamos. Em vez disso, um
-recurso sem `(tipo, número)` resolvido fica **preservado** numa área de espera
-content-addressed (`leizilla_{ente}_{fonte}_unidentified`), onde o IA faz OCR; um
-passo de **reconciliação** o promove ao item de range assim que tipo+número são
-conhecidos. Os antigos fallbacks de lixo (`("documento","fallback-…")`,
-`("lei","seq-NNNNN")`) são substituídos por essa área de espera — não por descarte.
+**Extrair a identidade do contexto é a tarefa primária da descoberta — e resolve a
+grande maioria dos casos (>90%).** O número está nos **metadados ou nas páginas que
+levam ao PDF**; a estratégia de descoberta **deve ler esse contexto** — não é um
+sweep cego de URLs. Quando o contexto rende `(tipo, número)`, o recurso vai **direto
+ao catálogo**. **"Sem número" não deveria acontecer na rota normal**; se acontece com
+frequência numa fonte, é sinal de que a estratégia de descoberta daquela fonte
+precisa ser **reforçada**, não de que devemos relaxar o catálogo.
+
+O resíduo (<10%) — fontes cujo número **não** está no contexto — exige uma
+**estratégia especial** por fonte (p.ex. baixar → OCR do IA → parse para ler o
+número, ou heurística específica). Até resolver, esses bytes ficam **preservados**
+numa área de espera content-addressed (`leizilla_{ente}_{fonte}_unidentified`),
+onde o IA faz OCR; um passo de **reconciliação** os promove ao item de range. A
+área de espera é a **exceção** (rede de segurança), não um depósito de rotina —
+nunca há descarte. Os antigos fallbacks de lixo (`("documento","fallback-…")`,
+`("lei","seq-NNNNN")`) somem: ou a identidade é extraída do contexto, ou o recurso
+fica preservado aguardando reconciliação.
 
 ### 2. Item IA — range bucket por identidade
 

--- a/docs/adr/0011-raw-identity-keyed-range-items.md
+++ b/docs/adr/0011-raw-identity-keyed-range-items.md
@@ -1,0 +1,120 @@
+# ADR-0011 — Raw é identity-keyed por (ente, fonte, tipo, número); arquivos content-addressed dentro do item; só se admite o que sabemos identificar
+
+**Status**: Aprovada
+**Data**: 2026-06-02
+**Contexto**: M4 — Internet Archive, revisão do esquema raw (decisão do owner)
+**Supersede**: a camada **Raw** de [ADR-0010](0010-raw-content-addressed-parsed-urn.md)
+(itens bucketizados por prefixo de hash). Mantém intacta a parte **Parsed é
+URN-keyed** de ADR-0010/[ADR-0005](0005-ia-identifiers.md).
+
+## Contexto
+
+ADR-0010 tornou a camada raw **content-addressed**: o endereço de um arquivo era
+o SHA-256 dos seus bytes, os itens IA eram bucketizados por prefixo de hash
+(`leizilla-raw-ro-casacivil-3f`), e um `index.csv` mapeava a chave de colheita →
+hash. Isso entregou agnosticismo de fonte e deduplicação por construção, mas a um
+custo: **o catálogo ficou ilegível** (não dá para saber o que é `…-3f` sem abrir
+metadados) e **toda leitura exige o índice**.
+
+Para uma coleção de **legislação**, a unidade natural é a **norma**, e a tese do
+owner é: *o mínimo para uma norma entrar na coleção é sabermos seu **tipo** e seu
+**número**. Se sabemos, usamos como identidade; se não sabemos, não adicionamos.*
+
+Isso é coerente com o resto do sistema, que já é identity-keyed:
+`discovered_resources` guarda `tipo_documento`/`chave`; `discovery.parse_filename`
+extrai `(tipo, número)` de nomes como `L5120.pdf → ("lei","lei-05120")`; a camada
+parsed usa URN-LEX; a política de re-scrape do SCHEMA versiona por `{chave}-rN`.
+A camada raw content-addressed era o ponto fora da curva.
+
+**Reversão consciente de ADR-0010.** ADR-0010 argumentou que o número de
+`casacivil` (`L{N}.pdf`) é o `coddoc` do CMS da Ditel — uma idiossincrasia de
+fonte, pré-parse — e que promovê-lo a fronteira de range "não significa nada para
+o Planalto". Aceitamos a premissa e mesmo assim escolhemos identity-keying,
+porque **cada item é namespaced por `(ente, fonte, tipo)`**: `5001-6000` só
+precisa significar algo dentro de `ro/casacivil/lei`; o Planalto recebe
+`federal/planalto/lei_*`, com a sua própria numeração. Não há pretensão de uma
+coordenada nacional uniforme na camada raw — essa é a função da camada **parsed
+(URN-LEX)**, que permanece a identidade jurídica pan-Brasil.
+
+## Decisão
+
+### 1. Gate de ingestão — identidade ou nada
+
+A identidade de ingestão é `(ente, fonte, tipo, número)`, extraída na descoberta.
+**Reject-until-identified**: recursos sem `(tipo, número)` — p.ex. o browse por
+`coddoc` puro da ALRO assembleia — **não** são adicionados; são descartados e
+logados até que a descoberta produza tipo+número. Isso **elimina os fallbacks de
+lixo** atuais (`("documento","fallback-…")`, `("lei","seq-NNNNN")`).
+
+### 2. Item IA — range bucket por identidade
+
+| | Pattern | Exemplo |
+|---|---|---|
+| Item raw | `leizilla_{ente}_{fonte}_{tipo}_{start:04d}-{end:04d}` | `leizilla_ro_casacivil_lei_5001-6000` |
+
+Faixas de 1.000 por `(ente, fonte, tipo)`. `_` separa as seções; `-` é livre
+dentro de uma seção (ex.: `lei-complementar`). O item é **navegável** — o nome
+diz ente, fonte, tipo e faixa de números.
+
+### 3. Arquivo — content-addressed por UUIDv5 truncado
+
+Dentro do item, cada arquivo é nomeado por um hash determinístico do conteúdo:
+
+```
+uuid5_8 = str(uuid.uuid5(uuid.NAMESPACE_DNS, sha256_hex(bytes)))[:8]
+```
+
+| | Pattern | Exemplo |
+|---|---|---|
+| Arquivo bruto | `{uuid5_8}.{ext}` | `a1b2c3d4.pdf` |
+| OCR derivado (IA) | `{uuid5_8}_djvu.txt` | `a1b2c3d4_djvu.txt` |
+| Metadados | `{uuid5_8}_meta.json` | `a1b2c3d4_meta.json` |
+
+Colisão só importa **dentro de um item** (escopo de ≤1.000 leis × poucas
+rendições/capturas), onde a probabilidade é < 1%. O `index.csv` guarda o
+**SHA-256 completo**, então uma colisão real (mesmo nome curto, bytes diferentes)
+é **detectada na escrita** e tratada (estende o comprimento ou adiciona
+discriminador) — nunca um overwrite silencioso.
+
+### 4. `index.csv` por item — o mapa identidade → arquivo
+
+Mapeia `(tipo, número, rendição, formato) → {uuid5_8, sha256, captured_at}`,
+append-only, **newest-wins**. Rendição (`original`, `compilada`, `atual`, …) e
+formato (`pdf`, `docx`, `html`) são **metadados no índice, não no nome do
+arquivo**. Quando a rendição não puder ser classificada pela fonte, fica vazia
+(`unclassified`) — o arquivo ainda é admitido (já é content-addressed).
+
+### 5. Sem `-rN`
+
+Versionamento e dedup **caem de graça** do content-addressing dos arquivos:
+bytes diferentes → hash diferente → arquivo novo coexistindo; bytes idênticos →
+mesmo hash → no-op (dedup). "Versão corrente" = `captured_at` mais recente por
+`(identidade, rendição, formato)` no índice. Não há sufixo de versão.
+
+### 6. Parsed — inalterado
+
+A camada parsed permanece **URN-keyed** (URN-LEX), conforme ADR-0010/ADR-0005.
+
+## Consequências
+
+- **Catálogo navegável** no nível do item; arquivos seguem opacos (hash), mas o
+  `index.csv` os descreve por tipo/número/rendição.
+- **Mantém os ganhos de ADR-0010 que importam**: dedup e imutabilidade, via
+  content-addressing dos arquivos.
+- **Numeração é por fonte**, namespaced por `(ente, fonte, tipo)`. Para
+  `casacivil` o número é o do arquivo `L{N}.pdf` (que ADR-0010 nota ser o `coddoc`
+  da Ditel); aceitamos isso porque não há colisão entre fontes e a identidade
+  normativa nacional vive no parsed (URN-LEX).
+- **ALRO assembleia (coddoc puro) fica deferida** até a descoberta extrair
+  tipo+número (ou até mapearmos coddoc→norma via parse).
+- **Requer** um classificador de rendição por fonte (rótulos do portal → vocab) e
+  reescrita de `ia_utils`, `publisher` (identificadores + index com rendição),
+  `parser` (resolução via index), `discovery` (gate + remoção dos fallbacks), e a
+  suíte de testes.
+
+## Em aberto
+
+- Confirmar empiricamente se o número de `casacivil` (`L{N}.pdf`) coincide com o
+  número da lei ou é o `coddoc` do CMS. Não bloqueia esta decisão (o item é
+  namespaced por fonte), mas afeta a legibilidade dos ranges.
+- Vocabulário canônico de rendições e o mapa rótulo-da-fonte → vocab.

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -714,9 +714,10 @@ def cmd_stats(
 
     if ia:
         echo("Internet Archive:")
-        raw_count = count_ia_items(f"leizilla-raw-{ente}-")
-        # Prefix leizilla-{ente}- matches ONLY parsed items: raw/bundle/dataset
-        # all have an extra word before the ente slug (leizilla-raw-ro-, etc.)
+        # Raw items são range buckets identity-keyed com underscore (ADR-0011):
+        # leizilla_{ente}_{fonte}_{tipo}_{range}. Parsed/dataset usam hífen, então
+        # o prefixo underscore casa só com raw, e leizilla-{ente}- só com parsed.
+        raw_count = count_ia_items(f"leizilla_{ente}_")
         parsed_count = count_ia_items(f"leizilla-{ente}-")
         dataset_count = count_ia_items(f"leizilla-dataset-{ente}-")
 

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -38,6 +38,63 @@ def cmd_discover(
         raise typer.Exit(1)
 
 
+@app.command("reconcile")
+def cmd_reconcile(
+    ente: str = typer.Option("ro", help="Ente federativo"),
+    fonte: Optional[str] = typer.Option(
+        None, help="Fonte específica (None = todas as fontes do manifesto)"
+    ),
+) -> None:
+    """Promove recursos da área de espera `_unidentified` para o item de range.
+
+    Re-roda a descoberta com os extratores atuais (ADR-0011 §1, re-derivação por
+    contexto), monta o mapa URL→(tipo, número) e promove os arquivos preservados
+    cuja identidade agora é conhecida — sem re-baixar do portal de origem.
+    """
+    echo(f"Reconciliando área de espera para {ente}" + (f"/{fonte}" if fonte else ""))
+    try:
+        from leizilla.discovery import discover_resources
+        from leizilla.ia_utils import parse_identity
+        from leizilla.publisher import InternetArchivePublisher
+
+        resources = discover_resources(ente, fonte)
+        # Mapa de identidade por URL de origem, só para recursos agora identificáveis.
+        identity_by_source: dict[str, tuple[str, int]] = {}
+        fontes_seen: set[str] = set()
+        for res in resources:
+            fontes_seen.add(res["fonte"])
+            ident = parse_identity(res.get("chave", ""))
+            if ident is not None:
+                identity_by_source[res["url"]] = ident
+
+        pub = InternetArchivePublisher()
+        total_promoted = 0
+        total_remaining = 0
+        for f in sorted(fontes_seen):
+            by_source = {
+                r["url"]: identity_by_source[r["url"]]
+                for r in resources
+                if r["fonte"] == f and r["url"] in identity_by_source
+            }
+            result = pub.reconcile_unidentified(ente, f, by_source)
+            if not result.get("success"):
+                echo(f"  {f}: erro — {result.get('error')}")
+                continue
+            total_promoted += result["promoted"]
+            total_remaining += result["remaining"]
+            echo(
+                f"  {f}: {result['promoted']} promovidos, "
+                f"{result['remaining']} ainda na espera"
+            )
+        echo(
+            f"Reconciliação concluída: {total_promoted} promovidos, "
+            f"{total_remaining} aguardando."
+        )
+    except Exception as e:
+        echo(f"Erro: {e}")
+        raise typer.Exit(1)
+
+
 @app.command("harvest")
 def cmd_harvest(
     ente: Optional[str] = typer.Option(

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -1002,9 +1002,10 @@ def cmd_parse_all(
                 if not item_tipo or not num_part.isdigit():
                     continue
                 num = int(num_part)
-                if fonte == "assembleia" and item_tipo != "coddoc":
-                    continue
-                if fonte != "assembleia" and item_tipo != tipo:
+                # Items na coleção são identity-keyed (ADR-0011); casa pelo tipo
+                # normativo para qualquer fonte. (assembleia só terá itens aqui
+                # quando expor tipo+número — ver follow-up de identidade ALRO.)
+                if item_tipo != tipo:
                     continue
                 if start_coddoc <= num <= end_coddoc:
                     target_items.append((num, raw_id))

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -70,6 +70,7 @@ def cmd_reconcile(
         pub = InternetArchivePublisher()
         total_promoted = 0
         total_remaining = 0
+        failed_fontes: list[str] = []
         for f in sorted(fontes_seen):
             by_source = {
                 r["url"]: identity_by_source[r["url"]]
@@ -79,6 +80,7 @@ def cmd_reconcile(
             result = pub.reconcile_unidentified(ente, f, by_source)
             if not result.get("success"):
                 echo(f"  {f}: erro — {result.get('error')}")
+                failed_fontes.append(f)
                 continue
             total_promoted += result["promoted"]
             total_remaining += result["remaining"]
@@ -90,6 +92,13 @@ def cmd_reconcile(
             f"Reconciliação concluída: {total_promoted} promovidos, "
             f"{total_remaining} aguardando."
         )
+        if failed_fontes:
+            # Sai nonzero para a automação detectar a limpeza parcial (rows
+            # promovidas podem seguir na espera).
+            echo(f"Falha em: {', '.join(failed_fontes)}")
+            raise typer.Exit(1)
+    except typer.Exit:
+        raise
     except Exception as e:
         echo(f"Erro: {e}")
         raise typer.Exit(1)

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 import typer
 from typer import echo
@@ -349,6 +349,9 @@ def cmd_upload(
             return
 
         uploaded = 0
+        # Índice acumulado por item de range no lote (evita lost-update do
+        # index.csv entre uploads ao mesmo item — IA não tem read-after-write).
+        index_cache: Dict[str, str] = {}
         for law in to_upload[:limit]:
             try:
                 pdf_path = Path(law["local_pdf_path"])
@@ -356,7 +359,11 @@ def cmd_upload(
                     continue
                 pdf_bytes = pdf_path.read_bytes()
                 result = publisher.upload_raw(
-                    pdf_path, law, pdf_bytes, fetched_from="source-fallback"
+                    pdf_path,
+                    law,
+                    pdf_bytes,
+                    fetched_from="source-fallback",
+                    index_cache=index_cache,
                 )
                 if result.get("success"):
                     db.update_lei(law["id"], {"url_pdf_ia": result["ia_url"]})
@@ -437,6 +444,9 @@ def cmd_scrape(
             )
             ok = 0
             skipped_ok = 0
+            # Índice acumulado por item de range no lote (evita lost-update do
+            # index.csv entre uploads ao mesmo item — IA não tem read-after-write).
+            index_cache: Dict[str, str] = {}
             for law in laws:
                 fonte_url = law.get("url_original")
                 if not fonte_url:
@@ -448,7 +458,9 @@ def cmd_scrape(
                     if ia_id in already_scraped:
                         skipped_ok += 1
                         continue
-                result = scrape_one_html(fonte_url, law, publisher, rate_limiter)
+                result = scrape_one_html(
+                    fonte_url, law, publisher, rate_limiter, index_cache
+                )
                 if result.get("success"):
                     echo(f"  OK: {result.get('ia_id', '?')}")
                     ok += 1
@@ -535,6 +547,9 @@ def cmd_scrape(
 
             ok = 0
             skipped_ok = 0
+            # Índice acumulado por item de range no lote (evita lost-update do
+            # index.csv entre uploads ao mesmo item — IA não tem read-after-write).
+            index_cache: Dict[str, str] = {}
             for law in laws:
                 pdf_url = law.get("url_pdf_original")
                 fonte_url = law.get("url_original")
@@ -547,7 +562,9 @@ def cmd_scrape(
                     if ia_id in already_scraped:
                         skipped_ok += 1
                         continue
-                result = scrape_one(fonte_url, pdf_url, law, publisher, rate_limiter)
+                result = scrape_one(
+                    fonte_url, pdf_url, law, publisher, rate_limiter, index_cache
+                )
                 if result.get("success"):
                     echo(f"  OK: {result.get('ia_id', '?')}")
                     ok += 1

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -1010,11 +1010,12 @@ def cmd_parse_all(
                 if start_coddoc <= num <= end_coddoc:
                     target_items.append((num, raw_id))
         else:
+            # Fallback sequencial: a coleção é identity-keyed (ADR-0011), então
+            # iteramos por {tipo}-{número} para qualquer fonte. O range agora é de
+            # números normativos (não de coddoc); assembleia usa a identidade real
+            # extraída na descoberta, igual às demais fontes.
             for num in range(start_coddoc, end_coddoc + 1):
-                if fonte == "assembleia":
-                    chave = f"coddoc-{num:05d}"
-                else:
-                    chave = f"{tipo}-{num:05d}"
+                chave = f"{tipo}-{num:05d}"
                 raw_id = f"leizilla-raw-{ente}-{fonte}-{chave}"
                 target_items.append((num, raw_id))
 

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -957,6 +957,7 @@ def cmd_parse_all(
             list_parsed_raw_ids,
             list_raw_ids,
         )
+        from leizilla.ia_utils import parse_raw_id
 
         already_parsed: set[str] = set()
         if skip_existing:
@@ -990,19 +991,23 @@ def cmd_parse_all(
         target_items = []
         if raw_items_on_ia:
             for raw_id in sorted(raw_items_on_ia):
-                parts = raw_id.split("-")
-                if len(parts) >= 6:
-                    try:
-                        num = int(parts[-1])
-                        item_tipo = parts[-2]
-                        if fonte == "assembleia" and item_tipo != "coddoc":
-                            continue
-                        if fonte != "assembleia" and item_tipo != tipo:
-                            continue
-                        if start_coddoc <= num <= end_coddoc:
-                            target_items.append((num, raw_id))
-                    except ValueError:
-                        continue
+                # Parse via the ente catalog (handles hyphenated entes like
+                # ro-porto-velho) and split the chave on its LAST hyphen so
+                # hyphenated tipos (lei-complementar) survive intact.
+                parsed = parse_raw_id(raw_id)
+                if parsed is None:
+                    continue
+                _ente, _fonte, chave = parsed
+                item_tipo, _, num_part = chave.rpartition("-")
+                if not item_tipo or not num_part.isdigit():
+                    continue
+                num = int(num_part)
+                if fonte == "assembleia" and item_tipo != "coddoc":
+                    continue
+                if fonte != "assembleia" and item_tipo != tipo:
+                    continue
+                if start_coddoc <= num <= end_coddoc:
+                    target_items.append((num, raw_id))
         else:
             for num in range(start_coddoc, end_coddoc + 1):
                 if fonte == "assembleia":

--- a/src/leizilla/crawler.py
+++ b/src/leizilla/crawler.py
@@ -52,10 +52,11 @@ def parse_titulo_identity(titulo: str) -> Optional[Tuple[str, int]]:
     tipo = next((vocab for needle, vocab in _TITULO_TIPOS if needle in t), None)
     if tipo is None:
         return None
-    # Número ancorado no marcador ordinal seguido de dígitos (com pontos de
-    # milhar). Aceita qualquer combinação de "º/°/o", ponto e espaço entre o "n" e
-    # o número — cobre "nº", "n°", "n.", e a abreviação "n.º" (ex.: "LEI N.º 6.084").
-    m = re.search(r"n[º°o.\s]*(\d[\d.]*)", t)
+    # Número ancorado num marcador ordinal REAL (º/°/.) após um "n" em fronteira de
+    # palavra — exige pelo menos um desses marcadores para não casar o "n" de
+    # palavras comuns como "ano"/"no" seguidas de um ano (ex.: "RESOLUÇÃO ... ANO
+    # 2020" não deve render número 2020). Cobre "nº", "n°", "n.", "n.º".
+    m = re.search(r"\bn[º°o.\s]*[º°.]\s*(\d[\d.]*)", t)
     if not m:
         return None
     numero = int(m.group(1).replace(".", ""))

--- a/src/leizilla/crawler.py
+++ b/src/leizilla/crawler.py
@@ -3,9 +3,10 @@
 import asyncio
 import logging
 import re
+import unicodedata
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urljoin
 
 import requests
@@ -15,6 +16,50 @@ from leizilla import config
 
 _CASACIVIL_FILES_BASE = "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files"
 _CASACIVIL_FONTE_URL = "http://ditel.casacivil.ro.gov.br/COTEL/Livros/"
+
+# Tipos normativos reconhecíveis no título de uma página de norma, do mais
+# específico para o mais genérico (ordem importa: "lei complementar" antes de
+# "lei", "decreto-lei" antes de "decreto"). Mapeia para o vocabulário de tipo.
+_TITULO_TIPOS: List[Tuple[str, str]] = [
+    ("lei complementar", "lc"),
+    ("decreto-lei", "decreto-lei"),
+    ("decreto lei", "decreto-lei"),
+    ("emenda constitucional", "emenda-constitucional"),
+    ("medida provisoria", "medida-provisoria"),
+    ("decreto", "decreto"),
+    ("resolucao", "resolucao"),
+    ("portaria", "portaria"),
+    ("lei", "lei"),
+]
+
+
+def _strip_accents(text: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFD", text) if unicodedata.category(c) != "Mn"
+    )
+
+
+def parse_titulo_identity(titulo: str) -> Optional[Tuple[str, int]]:
+    """Extrai ``(tipo, número)`` do título de uma página de norma, ou ``None``.
+
+    Ex.: ``"LEI Nº 5.120, DE 22 DE JUNHO DE 1999" → ("lei", 5120)``;
+    ``"LEI COMPLEMENTAR Nº 42…" → ("lc", 42)``. O número é ancorado no ``Nº``
+    para não confundir com o ano. Retorna ``None`` quando o tipo ou o número não
+    podem ser determinados com confiança — o chamador trata como não-identificado
+    (reject-until-identified, ADR-0011).
+    """
+    t = _strip_accents(titulo or "").lower()
+    tipo = next((vocab for needle, vocab in _TITULO_TIPOS if needle in t), None)
+    if tipo is None:
+        return None
+    # Número ancorado em "nº"/"n°"/"n." seguido de dígitos (com pontos de milhar).
+    m = re.search(r"n[º°o.]?\s*(\d[\d.]*)", t)
+    if not m:
+        return None
+    numero = int(m.group(1).replace(".", ""))
+    if numero <= 0:
+        return None
+    return tipo, numero
 
 
 def discover_casacivil_laws(
@@ -109,11 +154,23 @@ class LeisCrawler:
                         if pdf_url and not pdf_url.startswith("http"):
                             pdf_url = urljoin(base_url, pdf_url)
 
+                    # Identidade normativa (ADR-0011): extraímos tipo+número do
+                    # título. coddoc é só o índice de navegação da ALRO. Sem
+                    # identidade, a chave fica como coddoc (será adiada na coleta).
+                    identity = parse_titulo_identity(title)
+                    if identity is not None:
+                        tipo, numero = identity
+                        chave = f"{tipo}-{numero:05d}"
+                    else:
+                        tipo = "documento"
+                        chave = f"coddoc-{coddoc:05d}"
+
                     law: Dict[str, Any] = {
-                        "id": f"ro-assembleia-coddoc-{coddoc:05d}",
+                        "id": f"ro-assembleia-{chave}",
                         "ente": "ro",
                         "fonte": "assembleia",
-                        "chave": f"coddoc-{coddoc:05d}",
+                        "tipo": tipo,
+                        "chave": chave,
                         "titulo": title.strip(),
                         "url_original": url,
                         "url_pdf_original": pdf_url,

--- a/src/leizilla/crawler.py
+++ b/src/leizilla/crawler.py
@@ -52,8 +52,10 @@ def parse_titulo_identity(titulo: str) -> Optional[Tuple[str, int]]:
     tipo = next((vocab for needle, vocab in _TITULO_TIPOS if needle in t), None)
     if tipo is None:
         return None
-    # Número ancorado em "nº"/"n°"/"n." seguido de dígitos (com pontos de milhar).
-    m = re.search(r"n[º°o.]?\s*(\d[\d.]*)", t)
+    # Número ancorado no marcador ordinal seguido de dígitos (com pontos de
+    # milhar). Aceita qualquer combinação de "º/°/o", ponto e espaço entre o "n" e
+    # o número — cobre "nº", "n°", "n.", e a abreviação "n.º" (ex.: "LEI N.º 6.084").
+    m = re.search(r"n[º°o.\s]*(\d[\d.]*)", t)
     if not m:
         return None
     numero = int(m.group(1).replace(".", ""))

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -180,7 +180,9 @@ class PlaywrightCrawlerDiscovery(DiscoveryStrategy):
                         "url": pdf_url,
                         "ente": self.ente,
                         "fonte": self.fonte,
-                        "tipo_documento": "lei",  # ALRO scrape padrão é lei
+                        # tipo/chave da identidade extraída do título (ADR-0011);
+                        # fallback para coddoc quando não identificável (adiado).
+                        "tipo_documento": law.get("tipo", "documento"),
                         "chave": law.get("chave", f"coddoc-{law.get('coddoc'):05d}"),
                         "status": "pending",
                         "wayback_snapshot": None,

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -215,36 +215,39 @@ def load_manifest(ente: str) -> Dict[str, Any]:
     return data
 
 
-def run_discovery(ente: str, storage: DuckDBStorage) -> int:
-    """Lê o manifesto do ente, executa todas as estratégias de descoberta e salva os resources."""
+def discover_resources(ente: str, fonte: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Roda as estratégias do manifesto e **retorna** os resources (sem inserir).
+
+    Diferente de ``run_discovery`` (que persiste), serve à reconciliação: re-deriva
+    identidades com os extratores *atuais* (possivelmente melhorados), independente
+    das linhas já gravadas em ``discovered_resources``. ``fonte`` filtra para uma
+    fonte específica.
+    """
     manifest = load_manifest(ente)
-    total_added = 0
-
-    for fonte, fonte_cfg in manifest.get("fontes", {}).items():
+    out: List[Dict[str, Any]] = []
+    for f, fonte_cfg in manifest.get("fontes", {}).items():
+        if fonte is not None and f != fonte:
+            continue
         for discovery_cfg in fonte_cfg.get("discovery", []):
-            strategy_name = discovery_cfg.get("strategy")
-            strategy_cls = STRATEGIES.get(strategy_name)
-
+            strategy_cls = STRATEGIES.get(discovery_cfg.get("strategy"))
             if not strategy_cls:
                 logger.warning(
-                    f"Estratégia de descoberta '{strategy_name}' não suportada/encontrada."
+                    f"Estratégia '{discovery_cfg.get('strategy')}' não suportada."
                 )
                 continue
-
             try:
-                runner = strategy_cls(discovery_cfg, ente, fonte)
-                resources = runner.run()
-                logger.info(
-                    f"Estratégia '{strategy_name}' descobriu {len(resources)} resources."
-                )
-
-                for res in resources:
-                    storage.insert_resource(res)
-                    total_added += 1
-
+                out.extend(strategy_cls(discovery_cfg, ente, f).run())
             except Exception as e:
                 logger.error(
-                    f"Falha ao executar estratégia '{strategy_name}' para {ente}/{fonte}: {e}"
+                    f"Falha na estratégia '{discovery_cfg.get('strategy')}' "
+                    f"para {ente}/{f}: {e}"
                 )
+    return out
 
-    return total_added
+
+def run_discovery(ente: str, storage: DuckDBStorage) -> int:
+    """Lê o manifesto do ente, executa todas as estratégias e salva os resources."""
+    resources = discover_resources(ente)
+    for res in resources:
+        storage.insert_resource(res)
+    return len(resources)

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -10,6 +10,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from leizilla.ia_utils import parse_identity
 from leizilla.storage import DuckDBStorage
 
 logger = logging.getLogger(__name__)
@@ -80,9 +81,10 @@ class WaybackCdxDiscovery(DiscoveryStrategy):
                 filename = orig_url.split("/")[-1]
                 tipo, chave = parse_filename(filename)
                 if not tipo or not chave:
-                    # Se não casar com os padrões comuns, use fallback baseado no nome limpo
-                    name_clean = filename.rsplit(".", 1)[0].replace(" ", "_")
-                    tipo, chave = "documento", f"fallback-{name_clean}"
+                    # Reject-until-identified (ADR-0011): sem (tipo, número) não
+                    # enfileiramos — não inserir mantém o recurso redescobrível
+                    # numa próxima passada que saiba identificá-lo.
+                    continue
 
                 wayback_url = f"https://web.archive.org/web/{timestamp}/{orig_url}"
                 resources.append(
@@ -120,7 +122,8 @@ class SequentialDiscovery(DiscoveryStrategy):
                 filename = url.split("/")[-1]
                 tipo, chave = parse_filename(filename)
                 if not tipo or not chave:
-                    tipo, chave = "lei", f"seq-{num:05d}"
+                    # Reject-until-identified (ADR-0011): pula URLs sem identidade.
+                    continue
                 resources.append(
                     {
                         "url": url,
@@ -174,7 +177,11 @@ class PlaywrightCrawlerDiscovery(DiscoveryStrategy):
         resources = []
         for law in laws:
             pdf_url = law.get("url_pdf_original")
-            if pdf_url:
+            chave = law.get("chave", "")
+            # Reject-until-identified (ADR-0011): a ALRO é navegada por coddoc,
+            # mas só entram normas cujo título rendeu (tipo, número). Títulos não
+            # parseáveis ficam de fora — redescobríveis numa próxima passada.
+            if pdf_url and parse_identity(chave) is not None:
                 resources.append(
                     {
                         "url": pdf_url,

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -81,10 +81,12 @@ class WaybackCdxDiscovery(DiscoveryStrategy):
                 tipo, chave = parse_filename(filename)
                 if not tipo or not chave:
                     # Identidade é evidência, não catraca (ADR-0011 §1): capturamos
-                    # mesmo sem (tipo, número) no nome. tipo desconhecido (""), chave
-                    # = harvest key (nome do arquivo); o upload roteia para a área de
-                    # espera _unidentified, preservando os bytes (nunca descarte).
-                    tipo, chave = "", filename.rsplit(".", 1)[0]
+                    # mesmo sem (tipo, número) no nome. Prefixo NÃO-identificante
+                    # "documento-" garante que parse_identity devolva None — senão um
+                    # stem com forma "{palavra}-{dígitos}" (ex.: "oficio-123") seria
+                    # promovido a um range navegável espúrio em vez da área de espera
+                    # _unidentified. O harvest key (nome do arquivo) fica preservado.
+                    tipo, chave = "", f"documento-{filename.rsplit('.', 1)[0]}"
 
                 wayback_url = f"https://web.archive.org/web/{timestamp}/{orig_url}"
                 resources.append(
@@ -123,8 +125,9 @@ class SequentialDiscovery(DiscoveryStrategy):
                 tipo, chave = parse_filename(filename)
                 if not tipo or not chave:
                     # Captura mesmo sem identidade (ADR-0011 §1): vai à área de
-                    # espera _unidentified; chave = harvest key (nome do arquivo).
-                    tipo, chave = "", filename.rsplit(".", 1)[0]
+                    # espera _unidentified. Prefixo NÃO-identificante "documento-"
+                    # garante parse_identity → None mesmo para stems "{palavra}-{díg}".
+                    tipo, chave = "", f"documento-{filename.rsplit('.', 1)[0]}"
                 resources.append(
                     {
                         "url": url,

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -10,7 +10,6 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from leizilla.ia_utils import parse_identity
 from leizilla.storage import DuckDBStorage
 
 logger = logging.getLogger(__name__)
@@ -81,10 +80,11 @@ class WaybackCdxDiscovery(DiscoveryStrategy):
                 filename = orig_url.split("/")[-1]
                 tipo, chave = parse_filename(filename)
                 if not tipo or not chave:
-                    # Reject-until-identified (ADR-0011): sem (tipo, número) não
-                    # enfileiramos — não inserir mantém o recurso redescobrível
-                    # numa próxima passada que saiba identificá-lo.
-                    continue
+                    # Identidade é evidência, não catraca (ADR-0011 §1): capturamos
+                    # mesmo sem (tipo, número) no nome. tipo desconhecido (""), chave
+                    # = harvest key (nome do arquivo); o upload roteia para a área de
+                    # espera _unidentified, preservando os bytes (nunca descarte).
+                    tipo, chave = "", filename.rsplit(".", 1)[0]
 
                 wayback_url = f"https://web.archive.org/web/{timestamp}/{orig_url}"
                 resources.append(
@@ -122,8 +122,9 @@ class SequentialDiscovery(DiscoveryStrategy):
                 filename = url.split("/")[-1]
                 tipo, chave = parse_filename(filename)
                 if not tipo or not chave:
-                    # Reject-until-identified (ADR-0011): pula URLs sem identidade.
-                    continue
+                    # Captura mesmo sem identidade (ADR-0011 §1): vai à área de
+                    # espera _unidentified; chave = harvest key (nome do arquivo).
+                    tipo, chave = "", filename.rsplit(".", 1)[0]
                 resources.append(
                     {
                         "url": url,
@@ -177,11 +178,10 @@ class PlaywrightCrawlerDiscovery(DiscoveryStrategy):
         resources = []
         for law in laws:
             pdf_url = law.get("url_pdf_original")
-            chave = law.get("chave", "")
-            # Reject-until-identified (ADR-0011): a ALRO é navegada por coddoc,
-            # mas só entram normas cujo título rendeu (tipo, número). Títulos não
-            # parseáveis ficam de fora — redescobríveis numa próxima passada.
-            if pdf_url and parse_identity(chave) is not None:
+            # Captura por contexto (ADR-0011 §1): o título da página rende
+            # (tipo, número) em >90% (parse_titulo_identity) → vai ao catálogo;
+            # o resíduo (coddoc puro) é preservado na área de espera _unidentified.
+            if pdf_url:
                 resources.append(
                     {
                         "url": pdf_url,

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -212,6 +212,26 @@ def merge_index_row(
     return out.getvalue()
 
 
+def remove_index_rows(index_csv: str, uuid5s: set[str]) -> str:
+    """Reescreve o index.csv sem as linhas cujos ``uuid5`` estão em ``uuid5s``.
+
+    Usado pela reconciliação ao **promover** arquivos da área de espera
+    ``_unidentified`` para o item de range: a linha sai do índice de espera depois
+    que o arquivo passa a constar no índice do range (o arquivo content-addressed
+    pode permanecer fisicamente no item de espera — dedup por hash o torna inócuo).
+    """
+    rows = [
+        {c: r.get(c, "") or "" for c in INDEX_COLUMNS}
+        for r in csv.DictReader(io.StringIO(index_csv))
+        if r.get("uuid5") not in uuid5s
+    ]
+    out = io.StringIO()
+    writer = csv.DictWriter(out, fieldnames=INDEX_COLUMNS)
+    writer.writeheader()
+    writer.writerows(rows)
+    return out.getvalue()
+
+
 def uuid5_collision(index_csv: str, *, uuid5: str, sha256: str) -> bool:
     """True se ``uuid5`` já existe no índice com um SHA-256 diferente.
 

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -87,7 +87,12 @@ def parse_identity(chave: str) -> Optional[tuple[str, int]]:
     if not m:
         return None
     tipo, numero = m.group(1), int(m.group(2))
-    if tipo in _NON_IDENTIFYING_TIPOS:
+    # Rejeita se o PRIMEIRO segmento for não-identificante (ex.: "coddoc",
+    # "documento-oficio-123"). O grupo de tipo no regex é guloso e engloba hífens,
+    # então sem checar o primeiro segmento um stem de fallback com forma
+    # "{palavra}-{dígitos}" (ex.: "documento-oficio-123") escaparia da área de
+    # espera para um range navegável sob um tipo espúrio.
+    if tipo.split("-", 1)[0] in _NON_IDENTIFYING_TIPOS:
         return None
     return tipo, numero
 

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -173,7 +173,8 @@ def merge_index_row(
     Idempotente em ``(tipo, numero, rendicao, formato, sha256)`` — re-capturar os
     mesmos bytes é no-op (preserva a ordem/proveniência). Bytes diferentes para a
     mesma ``(tipo, numero, rendicao, formato)`` anexam uma linha nova; a mais
-    recente é a corrente.
+    recente é a corrente. Para linhas **não identificadas** (sem número), ``source``
+    também entra na chave de idempotência, pois a reconciliação casa por ``source``.
     """
     captured_at = captured_at or datetime.now(tz=timezone.utc).isoformat()
     rows: list[dict[str, str]] = []
@@ -182,16 +183,25 @@ def merge_index_row(
             rows.append({c: row.get(c, "") or "" for c in INDEX_COLUMNS})
     # numero ausente (área de espera _unidentified): grava vazio até reconciliar.
     numero_s = "" if numero is None else str(numero)
+
     # No-op verdadeiro: mesma identidade+rendição+formato já registrada com estes
-    # bytes → preserva (re-anexar mudaria a posição e o "newest wins").
-    if existing_csv and any(
-        r["tipo"] == tipo
-        and r["numero"] == numero_s
-        and r["rendicao"] == rendicao
-        and r["formato"] == formato
-        and r["sha256"] == sha256
-        for r in rows
-    ):
+    # bytes → preserva (re-anexar mudaria a posição e o "newest wins"). Para linhas
+    # **não identificadas** (sem número, área de espera) `source` entra na chave: a
+    # reconciliação casa por `source`, então bytes iguais de origens distintas
+    # precisam coexistir — senão a 2ª origem (talvez a única promovível) some.
+    def _is_noop(r: dict[str, str]) -> bool:
+        same = (
+            r["tipo"] == tipo
+            and r["numero"] == numero_s
+            and r["rendicao"] == rendicao
+            and r["formato"] == formato
+            and r["sha256"] == sha256
+        )
+        if numero_s == "":
+            same = same and r.get("source", "") == source
+        return same
+
+    if existing_csv and any(_is_noop(r) for r in rows):
         return existing_csv
     rows.append(
         {

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -55,6 +55,7 @@ INDEX_COLUMNS = [
     "uuid5",  # nome content-addressed do arquivo (UUIDv5 truncado)
     "sha256",  # hash completo — dedup + detecção de colisão de uuid5
     "captured_at",  # ISO-8601 — ordena versões (newest wins)
+    "source",  # chave de colheita / URL de origem (ADR-0010): mapeia arquivo→fonte
 ]
 
 
@@ -151,6 +152,7 @@ def merge_index_row(
     uuid5: str,
     sha256: str,
     captured_at: Optional[str] = None,
+    source: str = "",
 ) -> str:
     """Devolve o index.csv com a captura anexada (append-only, newest-wins).
 
@@ -185,6 +187,7 @@ def merge_index_row(
             "uuid5": uuid5,
             "sha256": sha256,
             "captured_at": captured_at,
+            "source": source,
         }
     )
     out = io.StringIO()

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -7,10 +7,12 @@ número)``: o item IA é um *range bucket* por identidade
 ``index.csv`` por item mapeia ``(tipo, número, rendição, formato)`` → arquivo,
 newest-wins.
 
-Só se admite o que sabemos identificar: uma chave de colheita sem ``(tipo,
-número)`` normativo (ex.: ``coddoc`` puro) **não** produz identidade — o chamador
-deve descartá-la (reject-until-identified). A identidade jurídica pan-Brasil
-continua na camada *parsed* (URN-LEX, ADR-0005/0010).
+Identidade é evidência, não catraca (ADR-0011 §1): uma chave de colheita sem
+``(tipo, número)`` normativo (ex.: ``coddoc`` puro) não produz identidade — o
+recurso não vai ao catálogo navegável, mas é **preservado** na área de espera
+``leizilla_{ente}_{fonte}_unidentified`` (o IA faz OCR) até a reconciliação, nunca
+descartado. A identidade jurídica pan-Brasil continua na camada *parsed* (URN-LEX,
+ADR-0005/0010).
 """
 
 import csv
@@ -35,7 +37,8 @@ _UUID5_LEN = (
 )
 
 # Tipos que NÃO identificam uma norma: são chaves de colheita idiossincráticas da
-# fonte (ADR-0011). Uma chave com esses tipos não entra na coleção raw.
+# fonte (ADR-0011). Uma chave com esses tipos não entra no catálogo navegável —
+# é preservada na área de espera _unidentified até a reconciliação.
 _NON_IDENTIFYING_TIPOS = {"coddoc", "documento", "fallback", "seq"}
 
 # OCR (_djvu.txt) é derivado pelo IA a partir do PDF; resolvê-lo usa o arquivo PDF.
@@ -78,7 +81,7 @@ def parse_identity(chave: str) -> Optional[tuple[str, int]]:
 
     ``'lei-05120' → ('lei', 5120)``. Retorna ``None`` se a chave não casar com
     ``{tipo}-{número}`` ou se o tipo for não-identificante (``coddoc`` etc.) —
-    nesse caso a norma não tem identidade conhecida e não deve ser adicionada.
+    nesse caso o recurso é preservado na área de espera, não promovido ao catálogo.
     """
     m = re.match(r"^([a-z][a-z0-9-]*)-(\d+)$", chave.strip().lower())
     if not m:
@@ -114,6 +117,17 @@ def raw_filename(uuid5: str, suffix: str) -> str:
     return f"{uuid5}{suffix}"
 
 
+def unidentified_item_identifier(ente: str, fonte: str) -> str:
+    """Item IA de espera para recursos sem ``(tipo, número)`` resolvido (ADR-0011 §1).
+
+    ``leizilla_{ente}_{fonte}_unidentified``. Rede de segurança (exceção, não rota
+    normal): bytes capturados por contexto mas ainda sem número são **preservados**
+    aqui — o IA faz OCR — até a reconciliação extrair a identidade e promovê-los ao
+    item de range. Nunca há descarte.
+    """
+    return f"leizilla_{ente.lower()}_{fonte.lower()}_unidentified"
+
+
 def download_url(item_id: str, filename: str) -> str:
     """URL de download direto de um arquivo dentro de um IA item."""
     return f"{_IA_DOWNLOAD}/{item_id}/{filename}"
@@ -146,7 +160,7 @@ def merge_index_row(
     existing_csv: Optional[str],
     *,
     tipo: str,
-    numero: int,
+    numero: Optional[int],
     rendicao: str,
     formato: str,
     uuid5: str,
@@ -166,7 +180,8 @@ def merge_index_row(
     if existing_csv:
         for row in csv.DictReader(io.StringIO(existing_csv)):
             rows.append({c: row.get(c, "") or "" for c in INDEX_COLUMNS})
-    numero_s = str(numero)
+    # numero ausente (área de espera _unidentified): grava vazio até reconciliar.
+    numero_s = "" if numero is None else str(numero)
     # No-op verdadeiro: mesma identidade+rendição+formato já registrada com estes
     # bytes → preserva (re-anexar mudaria a posição e o "newest wins").
     if existing_csv and any(

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -1,66 +1,130 @@
-"""Internet Archive content-addressed raw layer (ADR-0010).
+"""Internet Archive raw layer — identity-keyed items, content-addressed files (ADR-0011).
 
-Raw files are addressed by the SHA-256 of their content; range items bucket by
-hash prefix; a per-`(ente, fonte)` index maps the source's idiosyncratic harvest
-key (``coddoc-05120``, a Planalto URL path, ...) to the current content hash.
+A camada raw é endereçada pela **identidade da norma** ``(ente, fonte, tipo,
+número)``: o item IA é um *range bucket* por identidade
+(``leizilla_{ente}_{fonte}_{tipo}_{start}-{end}``), e cada arquivo dentro do item
+é nomeado por um hash determinístico do conteúdo (UUIDv5 truncado). Um
+``index.csv`` por item mapeia ``(tipo, número, rendição, formato)`` → arquivo,
+newest-wins.
 
-The harvest key is **metadata** — it never appears in a path or a range
-boundary. That keeps the catalog source-agnostic: the same code addresses bytes
-from any fonte in Brazil, and dedup/immutability fall out of content-addressing.
-
-Coordinate systems (ADR-0010):
-  - raw   → content hash   (this module)
-  - parsed → URN-LEX        (publisher.upload_parsed / ADR-0005)
-The map between them is data (the index + parsed_meta), never a formula.
+Só se admite o que sabemos identificar: uma chave de colheita sem ``(tipo,
+número)`` normativo (ex.: ``coddoc`` puro) **não** produz identidade — o chamador
+deve descartá-la (reject-until-identified). A identidade jurídica pan-Brasil
+continua na camada *parsed* (URN-LEX, ADR-0005/0010).
 """
 
 import csv
 import hashlib
 import io
+import re
 import urllib.error
 import urllib.request
+import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
 from leizilla.entes import list_slugs
 
 _USER_AGENT = "leizilla-crawler/0.1"
-
-_RAW_PREFIX = "leizilla-raw-"
-# OCR (_djvu.txt) is IA-derived from the PDF, so resolving it requires the
-# PDF hash. HTML captures are stored as a separate text/html component.
-_SUFFIX_TO_CONTENT_TYPE: dict[str, str] = {
-    "_djvu.txt": "application/pdf",
-    ".html": "text/html",
-    ".pdf": "application/pdf",
-}
-_HASH_BUCKET_LEN = 2  # hex chars → 256 range items per (ente, fonte)
+_RAW_PREFIX = "leizilla-raw-"  # forma legada do raw_id (chave no DuckDB/CLI)
 _IA_DOWNLOAD = "https://archive.org/download"
+
+_RANGE_SIZE = 1000
+_UUID5_LEN = (
+    8  # colisão só importa dentro de um item (~1000 leis); sha256 no index detecta
+)
+
+# Tipos que NÃO identificam uma norma: são chaves de colheita idiossincráticas da
+# fonte (ADR-0011). Uma chave com esses tipos não entra na coleção raw.
+_NON_IDENTIFYING_TIPOS = {"coddoc", "documento", "fallback", "seq"}
+
+# OCR (_djvu.txt) é derivado pelo IA a partir do PDF; resolvê-lo usa o arquivo PDF.
+_SUFFIX_TO_FORMATO: dict[str, str] = {
+    "_djvu.txt": "pdf",
+    ".pdf": "pdf",
+    ".html": "html",
+    ".docx": "docx",
+}
 
 INDEX_FILENAME = "index.csv"
 INDEX_COLUMNS = [
-    "source_key",  # harvest key da fonte (ex: coddoc-05120) — metadado, nunca path
-    "content_hash",  # SHA-256 hex — endereço do arquivo raw
-    "content_type",  # distingue componentes (application/pdf vs text/html)
-    "source_url",  # URL original (Ditel/Planalto/Wayback)
+    "tipo",  # tipo normativo (lei, lc, decreto, ...)
+    "numero",  # número da norma na fonte
+    "rendicao",  # original | compilada | atual | "" (unclassified)
+    "formato",  # pdf | html | docx
+    "uuid5",  # nome content-addressed do arquivo (UUIDv5 truncado)
+    "sha256",  # hash completo — dedup + detecção de colisão de uuid5
     "captured_at",  # ISO-8601 — ordena versões (newest wins)
 ]
 
 
 def compute_hash(data: bytes) -> str:
-    """SHA-256 hex digest — o endereço de conteúdo de um arquivo raw."""
+    """SHA-256 hex digest — discriminador de conteúdo (dedup + detecção de colisão)."""
     return hashlib.sha256(data).hexdigest()
 
 
+def uuid5_name(data: bytes, length: int = _UUID5_LEN) -> str:
+    """Nome de arquivo content-addressed: UUIDv5(SHA-256) truncado.
+
+    Determinístico nos bytes; bytes idênticos → mesmo nome (dedup por construção).
+    """
+    sha = compute_hash(data)
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, sha))[:length]
+
+
+def parse_identity(chave: str) -> Optional[tuple[str, int]]:
+    """Extrai ``(tipo, número)`` de uma chave de colheita, ou ``None``.
+
+    ``'lei-05120' → ('lei', 5120)``. Retorna ``None`` se a chave não casar com
+    ``{tipo}-{número}`` ou se o tipo for não-identificante (``coddoc`` etc.) —
+    nesse caso a norma não tem identidade conhecida e não deve ser adicionada.
+    """
+    m = re.match(r"^([a-z][a-z0-9-]*)-(\d+)$", chave.strip().lower())
+    if not m:
+        return None
+    tipo, numero = m.group(1), int(m.group(2))
+    if tipo in _NON_IDENTIFYING_TIPOS:
+        return None
+    return tipo, numero
+
+
+def range_bounds(num: int, size: int = _RANGE_SIZE) -> tuple[int, int]:
+    """Limites do range de ``num`` (ex.: 5120 → (5001, 6000))."""
+    if num <= 0:
+        return 1, size
+    start = ((num - 1) // size) * size + 1
+    return start, start + size - 1
+
+
+def range_item_identifier(ente: str, fonte: str, tipo: str, num: int) -> str:
+    """Item IA (range bucket) por identidade: ``leizilla_{ente}_{fonte}_{tipo}_{start}-{end}``.
+
+    Ex.: ``leizilla_ro_casacivil_lei_5001-6000``. Namespaced por ``(ente, fonte,
+    tipo)`` — a numeração é da fonte; a identidade nacional vive no parsed.
+    """
+    start, end = range_bounds(num)
+    return (
+        f"leizilla_{ente.lower()}_{fonte.lower()}_{tipo.lower()}_{start:04d}-{end:04d}"
+    )
+
+
+def raw_filename(uuid5: str, suffix: str) -> str:
+    """Nome do arquivo dentro do item: ``{uuid5}{suffix}`` (ex.: ``a1b2c3d4_djvu.txt``)."""
+    return f"{uuid5}{suffix}"
+
+
+def download_url(item_id: str, filename: str) -> str:
+    """URL de download direto de um arquivo dentro de um IA item."""
+    return f"{_IA_DOWNLOAD}/{item_id}/{filename}"
+
+
 def parse_raw_id(ia_id: str) -> Optional[tuple[str, str, str]]:
-    """Divide um raw_id legado em ``(ente, fonte, source_key)``.
+    """Divide um raw_id legado em ``(ente, fonte, chave)``.
 
-    ``leizilla-raw-{ente}-{fonte}-{source_key}`` →
-    ``('ro', 'casacivil', 'coddoc-05120')``.
-
-    Usa o catálogo de entes (maior match primeiro) para que entes com hífen como
-    ``ro-porto-velho`` sejam resolvidos deterministicamente. Retorna ``None`` se
-    não casar com um ente conhecido ou se faltar fonte/source_key.
+    ``leizilla-raw-{ente}-{fonte}-{chave}`` → ``('ro', 'casacivil', 'lei-05120')``.
+    Usa o catálogo de entes (maior match primeiro) para resolver entes com hífen
+    (``ro-porto-velho``). Retorna ``None`` se não casar com ente conhecido ou se
+    faltar fonte/chave.
     """
     if not ia_id.startswith(_RAW_PREFIX):
         return None
@@ -70,77 +134,56 @@ def parse_raw_id(ia_id: str) -> Optional[tuple[str, str, str]]:
             rest = content[len(slug) + 1 :]
             if "-" not in rest:
                 return None
-            fonte, source_key = rest.split("-", 1)
-            if not fonte or not source_key:
+            fonte, chave = rest.split("-", 1)
+            if not fonte or not chave:
                 return None
-            return slug, fonte, source_key
+            return slug, fonte, chave
     return None
-
-
-def raw_index_identifier(ente: str, fonte: str) -> str:
-    """IA item que guarda o índice ``source_key → content_hash`` de um (ente, fonte)."""
-    return f"{_RAW_PREFIX}{ente.lower()}-{fonte.lower()}-index"
-
-
-def raw_range_identifier(ente: str, fonte: str, hash_hex: str) -> str:
-    """IA range item que armazena um arquivo raw, bucketizado por prefixo de hash.
-
-    Ex: ``leizilla-raw-ro-casacivil-3f``. O bucket é derivado do hash (ADR-0010),
-    nunca de uma chave de fonte — generaliza para qualquer fonte do Brasil.
-    """
-    bucket = hash_hex[:_HASH_BUCKET_LEN].lower()
-    return f"{_RAW_PREFIX}{ente.lower()}-{fonte.lower()}-{bucket}"
-
-
-def raw_filename(hash_hex: str, suffix: str) -> str:
-    """Nome de arquivo content-addressed dentro do range item.
-
-    Ex: ``raw_filename(h, '_djvu.txt')`` → ``'3f8a…d21c_djvu.txt'``. O OCR
-    derivado pelo IA (``derive``) fica em ``{hash}_djvu.txt`` ao lado do PDF.
-    """
-    return f"{hash_hex.lower()}{suffix}"
-
-
-def download_url(item_id: str, filename: str) -> str:
-    """URL de download direto de um arquivo dentro de um IA item."""
-    return f"{_IA_DOWNLOAD}/{item_id}/{filename}"
 
 
 def merge_index_row(
     existing_csv: Optional[str],
     *,
-    source_key: str,
-    content_hash: str,
-    content_type: str,
-    source_url: str,
+    tipo: str,
+    numero: int,
+    rendicao: str,
+    formato: str,
+    uuid5: str,
+    sha256: str,
     captured_at: Optional[str] = None,
 ) -> str:
-    """Devolve o índice CSV com uma linha de captura anexada (append-only).
+    """Devolve o index.csv com a captura anexada (append-only, newest-wins).
 
-    O índice é histórico: re-capturar o mesmo ``source_key`` com bytes diferentes
-    adiciona uma nova linha; a linha mais recente de um source_key é a captura
-    corrente. Idempotente em ``(source_key, content_hash)`` idênticos — não gera
-    linha duplicada (re-crawl sem mudança de bytes é no-op).
+    Idempotente em ``(tipo, numero, rendicao, formato, sha256)`` — re-capturar os
+    mesmos bytes é no-op (preserva a ordem/proveniência). Bytes diferentes para a
+    mesma ``(tipo, numero, rendicao, formato)`` anexam uma linha nova; a mais
+    recente é a corrente.
     """
     captured_at = captured_at or datetime.now(tz=timezone.utc).isoformat()
     rows: list[dict[str, str]] = []
     if existing_csv:
         for row in csv.DictReader(io.StringIO(existing_csv)):
             rows.append({c: row.get(c, "") or "" for c in INDEX_COLUMNS})
-    # True no-op: (source_key, content_hash) already recorded → preserve provenance.
-    # Re-appending would change the row's position, which affects the "newest wins"
-    # ordering in lookup_current_hash and can silently roll back newer captures.
+    numero_s = str(numero)
+    # No-op verdadeiro: mesma identidade+rendição+formato já registrada com estes
+    # bytes → preserva (re-anexar mudaria a posição e o "newest wins").
     if existing_csv and any(
-        r["source_key"] == source_key and r["content_hash"] == content_hash
+        r["tipo"] == tipo
+        and r["numero"] == numero_s
+        and r["rendicao"] == rendicao
+        and r["formato"] == formato
+        and r["sha256"] == sha256
         for r in rows
     ):
         return existing_csv
     rows.append(
         {
-            "source_key": source_key,
-            "content_hash": content_hash,
-            "content_type": content_type,
-            "source_url": source_url,
+            "tipo": tipo,
+            "numero": numero_s,
+            "rendicao": rendicao,
+            "formato": formato,
+            "uuid5": uuid5,
+            "sha256": sha256,
             "captured_at": captured_at,
         }
     )
@@ -151,46 +194,58 @@ def merge_index_row(
     return out.getvalue()
 
 
-def list_source_keys(index_csv: str) -> set[str]:
-    """Conjunto de source_keys distintos presentes no índice.
+def uuid5_collision(index_csv: str, *, uuid5: str, sha256: str) -> bool:
+    """True se ``uuid5`` já existe no índice com um SHA-256 diferente.
 
-    Usado pela descoberta (list_raw_ids) para reconstruir os raw_ids legados
-    (``leizilla-raw-{ente}-{fonte}-{source_key}``) que o parser sabe resolver —
-    os identifiers dos itens IA (buckets de hash, item ``index``) não carregam o
-    source_key e não servem para a descoberta.
+    Detecta a colisão rara de UUIDv5 truncado dentro de um item (mesmo nome curto,
+    bytes diferentes) — o chamador trata em vez de sobrescrever silenciosamente.
+    """
+    for row in csv.DictReader(io.StringIO(index_csv)):
+        if row.get("uuid5") == uuid5 and row.get("sha256") != sha256:
+            return True
+    return False
+
+
+def lookup_current(
+    index_csv: str,
+    tipo: str,
+    numero: int,
+    *,
+    rendicao: Optional[str] = None,
+    formato: Optional[str] = None,
+) -> Optional[dict[str, str]]:
+    """Retorna a linha corrente (mais recente) para ``(tipo, numero[, rendição][, formato])``.
+
+    Filtra por rendição/formato quando especificados (necessário porque uma norma
+    pode ter componentes distintos — pdf/original, html/atual). A corrente é a
+    última linha que casa no índice append-only. ``None`` se nada casar.
+    """
+    numero_s = str(numero)
+    found: Optional[dict[str, str]] = None
+    for row in csv.DictReader(io.StringIO(index_csv)):
+        if row.get("tipo") != tipo or row.get("numero") != numero_s:
+            continue
+        if rendicao is not None and row.get("rendicao", "") != rendicao:
+            continue
+        if formato is not None and row.get("formato", "") != formato:
+            continue
+        found = {c: row.get(c, "") or "" for c in INDEX_COLUMNS}
+    return found
+
+
+def list_identities(index_csv: str) -> set[str]:
+    """Conjunto de chaves ``{tipo}-{numero:05d}`` distintas no índice.
+
+    Usado pela descoberta (list_raw_ids) para reconstruir os raw_ids legados que o
+    parser sabe resolver. O identifier do item (range) não carrega norma a norma.
     """
     keys: set[str] = set()
     for row in csv.DictReader(io.StringIO(index_csv)):
-        sk = row.get("source_key")
-        if sk:
-            keys.add(sk)
+        tipo = row.get("tipo")
+        numero = row.get("numero")
+        if tipo and numero and numero.isdigit():
+            keys.add(f"{tipo}-{int(numero):05d}")
     return keys
-
-
-def lookup_current_hash(
-    index_csv: str,
-    source_key: str,
-    content_type: Optional[str] = None,
-) -> Optional[tuple[str, str]]:
-    """Retorna ``(content_hash, content_type)`` da captura corrente (mais recente).
-
-    Se ``content_type`` for especificado, restringe à linha desse tipo antes de
-    escolher a mais recente — necessário quando um source_key tem componentes
-    distintos (``application/pdf`` e ``text/html``) no mesmo índice.
-
-    A captura corrente é a última linha do source_key (filtrado) no índice
-    append-only. Retorna ``None`` se o source_key não estiver no índice ou se
-    nenhuma linha corresponder ao tipo requisitado.
-    """
-    found: Optional[tuple[str, str]] = None
-    for row in csv.DictReader(io.StringIO(index_csv)):
-        if row.get("source_key") != source_key:
-            continue
-        row_ct = row.get("content_type", "")
-        if content_type is not None and row_ct != content_type:
-            continue
-        found = (row.get("content_hash", ""), row_ct)
-    return found
 
 
 def _fetch_text(url: str, timeout: int = 30) -> Optional[str]:
@@ -204,33 +259,44 @@ def _fetch_text(url: str, timeout: int = 30) -> Optional[str]:
         return None
 
 
-def resolve_raw_url(ia_id: str, suffix: str, timeout: int = 30) -> Optional[str]:
-    """Resolve um raw_id legado para a URL content-addressed do arquivo derivado.
+def resolve_raw_url(
+    ia_id: str,
+    suffix: str,
+    timeout: int = 30,
+    rendicao: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve um raw_id legado para a URL content-addressed do arquivo (ADR-0011).
 
-    Passos (ADR-0010): parse do raw_id → fetch do índice do (ente, fonte) → lookup
-    do hash corrente do source_key → monta a URL no range item por prefixo de hash.
+    Passos: parse do raw_id → identidade ``(tipo, número)`` → item de range →
+    fetch do index.csv → lookup do arquivo corrente → monta a URL.
 
     IDs que não casam com o padrão raw (itens externos/legados) caem no
-    pass-through clássico ``{ia_id}/{ia_id}{suffix}``. Retorna ``None`` quando o
-    índice não existe ainda ou o source_key não foi capturado — o chamador trata
-    como "OCR ainda não disponível", preservando o contrato de fetch_ocr.
+    pass-through clássico ``{ia_id}/{ia_id}{suffix}``. Retorna ``None`` quando a
+    chave não tem identidade (não está na coleção), o índice não existe ainda, ou
+    a norma/rendição não foi capturada — o chamador trata como "ainda indisponível".
     """
     parsed = parse_raw_id(ia_id)
     if parsed is None:
         return download_url(ia_id, f"{ia_id}{suffix}")
 
-    ente, fonte, source_key = parsed
-    index_url = download_url(raw_index_identifier(ente, fonte), INDEX_FILENAME)
-    index_csv = _fetch_text(index_url, timeout=timeout)
+    ente, fonte, chave = parsed
+    identity = parse_identity(chave)
+    if identity is None:
+        return None  # sem (tipo, número) → não está na coleção
+
+    tipo, numero = identity
+    item_id = range_item_identifier(ente, fonte, tipo, numero)
+    index_csv = _fetch_text(download_url(item_id, INDEX_FILENAME), timeout=timeout)
     if not index_csv:
         return None
 
-    current = lookup_current_hash(
-        index_csv, source_key, content_type=_SUFFIX_TO_CONTENT_TYPE.get(suffix)
+    row = lookup_current(
+        index_csv,
+        tipo,
+        numero,
+        rendicao=rendicao,
+        formato=_SUFFIX_TO_FORMATO.get(suffix),
     )
-    if current is None:
+    if row is None:
         return None
-
-    content_hash, _content_type = current
-    range_id = raw_range_identifier(ente, fonte, content_hash)
-    return download_url(range_id, raw_filename(content_hash, suffix))
+    return download_url(item_id, raw_filename(row["uuid5"], suffix))

--- a/src/leizilla/ia_utils.py
+++ b/src/leizilla/ia_utils.py
@@ -222,18 +222,19 @@ def merge_index_row(
     return out.getvalue()
 
 
-def remove_index_rows(index_csv: str, uuid5s: set[str]) -> str:
-    """Reescreve o index.csv sem as linhas cujos ``uuid5`` estão em ``uuid5s``.
+def remove_index_rows(index_csv: str, keys: set[tuple[str, str]]) -> str:
+    """Reescreve o index.csv sem as linhas cujo ``(uuid5, source)`` está em ``keys``.
 
     Usado pela reconciliação ao **promover** arquivos da área de espera
-    ``_unidentified`` para o item de range: a linha sai do índice de espera depois
-    que o arquivo passa a constar no índice do range (o arquivo content-addressed
-    pode permanecer fisicamente no item de espera — dedup por hash o torna inócuo).
+    ``_unidentified`` para o item de range. Removemos por ``(uuid5, source)``, não
+    só por ``uuid5``: dois arquivos de bytes idênticos mas origens distintas
+    compartilham o ``uuid5`` (dedup por conteúdo), e promover só uma origem **não**
+    pode apagar o alias ainda não identificado da outra.
     """
     rows = [
         {c: r.get(c, "") or "" for c in INDEX_COLUMNS}
         for r in csv.DictReader(io.StringIO(index_csv))
-        if r.get("uuid5") not in uuid5s
+        if (r.get("uuid5", ""), r.get("source", "")) not in keys
     ]
     out = io.StringIO()
     writer = csv.DictWriter(out, fieldnames=INDEX_COLUMNS)

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -977,6 +977,7 @@ class InternetArchivePublisher:
         # subida e a sobrescreveria (lost update).
         range_index_cache: Dict[str, Optional[str]] = {}
         failed_ranges: Set[str] = set()
+        range_upload_failures = 0  # identidade conhecida, mas upload ao range falhou
         for row in rows:
             if row["numero"]:  # já identificado nesta área (não deveria ocorrer)
                 continue
@@ -1045,6 +1046,11 @@ class InternetArchivePublisher:
             ):
                 range_index_cache[range_id] = merged  # acumula só em sucesso
                 promoted_keys.add((row["uuid5"], row["source"]))
+            else:
+                # Tinha identidade mas o upload ao range falhou (IA/rede/CLI). Fica
+                # como remaining — mas isso é indistinguível de "ainda sem
+                # identidade"; sinalizamos como falha para a automação não ler exit 0.
+                range_upload_failures += 1
 
         # As promoções ao range já aconteceram; só falta tirar essas linhas do
         # índice de espera. Se essa reescrita falhar, os arquivos seguem listados
@@ -1062,7 +1068,7 @@ class InternetArchivePublisher:
             if not r["numero"] and (r["uuid5"], r["source"]) not in cleaned
         )
         result: Dict[str, Any] = {
-            "success": index_rewrite_ok,
+            "success": index_rewrite_ok and range_upload_failures == 0,
             "promoted": len(promoted_keys),
             "remaining": remaining,
             "item_id": holding_id,
@@ -1071,6 +1077,11 @@ class InternetArchivePublisher:
             result["error"] = (
                 "arquivos promovidos ao range, mas a reescrita do índice de espera "
                 "falhou — linhas promovidas ainda constam em _unidentified"
+            )
+        elif range_upload_failures:
+            result["error"] = (
+                f"{range_upload_failures} recurso(s) com identidade falharam no "
+                "upload ao item de range — ainda em _unidentified, re-tentar"
             )
         return result
 

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -590,8 +590,11 @@ class InternetArchivePublisher:
         # Proveniência (ADR-0010): mapeia o arquivo de volta à sua origem de
         # colheita (URL original; coddoc/path embutido). É como descartamos o
         # coddoc da identidade sem perder a rastreabilidade.
+        # Proveniência == URL do recurso que a descoberta usa como chave
+        # (`res["url"]`), para a reconciliação casar. Para a ALRO esse é o PDF
+        # (`url_pdf_original`), não a página de listagem (`url_original`).
         source = str(
-            lei_data.get("url_original") or lei_data.get("url_pdf_original") or ""
+            lei_data.get("url_pdf_original") or lei_data.get("url_original") or ""
         )
 
         raw_meta = build_raw_meta(lei_data, pdf_bytes, fetched_from, wayback_url)
@@ -704,8 +707,11 @@ class InternetArchivePublisher:
             item_id = range_item_identifier(ente, fonte, tipo, numero)
             title = _range_title(ente, fonte, tipo, numero)
         rendicao = str(lei_data.get("rendicao", ""))
+        # Proveniência == URL do recurso que a descoberta usa como chave
+        # (`res["url"]`), para a reconciliação casar. Para a ALRO esse é o PDF
+        # (`url_pdf_original`), não a página de listagem (`url_original`).
         source = str(
-            lei_data.get("url_original") or lei_data.get("url_pdf_original") or ""
+            lei_data.get("url_pdf_original") or lei_data.get("url_original") or ""
         )
 
         html_bytes = html_content.encode("utf-8")

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -810,34 +810,23 @@ class InternetArchivePublisher:
             "identified": identity is not None,
         }
 
-    def _promote_to_range(
+    def _upload_to_range(
         self,
+        range_id: str,
+        content: bytes,
+        filename: str,
+        index_csv: str,
         ente: str,
         fonte: str,
         tipo: str,
         numero: int,
-        content: bytes,
-        row: Dict[str, str],
-    ) -> Optional[str]:
-        """Sobe um arquivo preservado para o item de range com a identidade agora
-        conhecida. Devolve o ``uuid5`` promovido, ou ``None`` em falha."""
-        range_id = range_item_identifier(ente, fonte, tipo, numero)
-        try:
-            uuid5, index_csv = _resolve_uuid5_and_index(
-                range_id,
-                content,
-                tipo=tipo,
-                numero=numero,
-                rendicao=row.get("rendicao", ""),
-                formato=row.get("formato", "pdf"),
-                source=row.get("source", ""),
-            )
-        except IndexFetchError as e:
-            logger.warning("reconcile: índice do range ilegível (%s): %s", range_id, e)
-            return None
-        suffix = _FORMATO_SUFFIX.get(row.get("formato", "pdf"), ".pdf")
+    ) -> bool:
+        """Escreve o arquivo + o ``index.csv`` (já mesclado pelo chamador) e sobe ao
+        item de range. O index vem pronto para que promoções ao MESMO range numa
+        execução acumulem num único índice — evita o lost-update de releituras
+        sucessivas contra o IA eventualmente-consistente."""
         with tempfile.TemporaryDirectory() as tmp:
-            fdst = Path(tmp) / raw_filename(uuid5, suffix)
+            fdst = Path(tmp) / filename
             fdst.write_bytes(content)
             index_path = Path(tmp) / INDEX_FILENAME
             index_path.write_text(index_csv, encoding="utf-8")
@@ -869,8 +858,8 @@ class InternetArchivePublisher:
                 logger.warning(
                     "reconcile: upload ao range falhou (%s): %s", range_id, e
                 )
-                return None
-        return uuid5
+                return False
+        return True
 
     def _upload_index_only(self, item_id: str, index_csv: str) -> bool:
         """Reescreve o index.csv de um item (usado para tirar do índice de espera o
@@ -912,7 +901,12 @@ class InternetArchivePublisher:
         bytes vêm do **IA** (item de espera), nunca do portal frágil (ADR-0004).
         """
         if not self.access_key or not self.secret_key:
-            return {"success": False, "error": "IA credentials not configured"}
+            return {
+                "success": False,
+                "error": "IA credentials not configured",
+                "promoted": 0,
+                "remaining": 0,
+            }
         holding_id = unidentified_item_identifier(ente, fonte)
         try:
             holding_index = _fetch_existing_index(holding_id)
@@ -920,6 +914,8 @@ class InternetArchivePublisher:
             return {
                 "success": False,
                 "error": f"could not read holding index: {e}",
+                "promoted": 0,
+                "remaining": 0,
                 "item_id": holding_id,
             }
         if not holding_index:
@@ -937,12 +933,19 @@ class InternetArchivePublisher:
         # Chaveamos por (uuid5, source): bytes idênticos de origens distintas
         # compartilham o uuid5, mas só a origem identificável deve sair da espera.
         promoted_keys: Set[tuple[str, str]] = set()
+        # Index.csv acumulado por range NESTA execução. Promoções ao mesmo range
+        # crescem um único índice (uma leitura por range): sem isso, cada upload
+        # releria do IA — eventualmente consistente — um índice sem a linha recém-
+        # subida e a sobrescreveria (lost update).
+        range_index_cache: Dict[str, Optional[str]] = {}
+        failed_ranges: Set[str] = set()
         for row in rows:
             if row["numero"]:  # já identificado nesta área (não deveria ocorrer)
                 continue
             ident = identity_by_source.get(row["source"])
             if ident is None:
                 continue
+            tipo, numero = ident
             suffix = _FORMATO_SUFFIX.get(row["formato"], ".pdf")
             try:
                 content = _fetch_item_file_bytes(
@@ -951,9 +954,44 @@ class InternetArchivePublisher:
             except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
                 logger.warning("reconcile: download de %s falhou: %s", row["uuid5"], e)
                 continue
-            tipo, numero = ident
-            promoted = self._promote_to_range(ente, fonte, tipo, numero, content, row)
-            if promoted is not None:
+            range_id = range_item_identifier(ente, fonte, tipo, numero)
+            if range_id in failed_ranges:
+                continue
+            if range_id not in range_index_cache:
+                try:
+                    range_index_cache[range_id] = _fetch_existing_index(range_id)
+                except IndexFetchError as e:
+                    logger.warning(
+                        "reconcile: índice do range ilegível (%s): %s", range_id, e
+                    )
+                    failed_ranges.add(range_id)
+                    continue
+            base = range_index_cache[range_id]
+            sha256 = compute_hash(content)
+            uuid5 = uuid5_name(content)
+            if base and uuid5_collision(base, uuid5=uuid5, sha256=sha256):
+                uuid5 = uuid5_name(content, length=32)
+            merged = merge_index_row(
+                base or None,
+                tipo=tipo,
+                numero=numero,
+                rendicao=row["rendicao"],
+                formato=row["formato"],
+                uuid5=uuid5,
+                sha256=sha256,
+                source=row["source"],
+            )
+            if self._upload_to_range(
+                range_id,
+                content,
+                raw_filename(uuid5, suffix),
+                merged,
+                ente,
+                fonte,
+                tipo,
+                numero,
+            ):
+                range_index_cache[range_id] = merged  # acumula só em sucesso
                 promoted_keys.add((row["uuid5"], row["source"]))
 
         # As promoções ao range já aconteceram; só falta tirar essas linhas do

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -2,8 +2,11 @@
 
 import atexit
 import configparser
+import csv
 import hashlib
+import io
 import json
+import logging
 import os
 import re
 import shutil
@@ -19,6 +22,7 @@ from typing import Any, Dict, Optional, Set
 from leizilla import config
 from leizilla import storage as storage_module
 from leizilla.ia_utils import (
+    INDEX_COLUMNS,
     INDEX_FILENAME,
     compute_hash,
     download_url,
@@ -28,6 +32,7 @@ from leizilla.ia_utils import (
     range_bounds,
     range_item_identifier,
     raw_filename,
+    remove_index_rows,
     unidentified_item_identifier,
     uuid5_collision,
     uuid5_name,
@@ -38,6 +43,8 @@ _DATASET_IDENTIFIER_RE = (
 )
 
 _USER_AGENT = "leizilla-crawler/0.1"
+
+logger = logging.getLogger(__name__)
 
 
 def _entity_coverage(ente: str) -> str:
@@ -436,6 +443,22 @@ def _fetch_existing_index(item_id: str) -> Optional[str]:
         raise IndexFetchError(str(e)) from e
 
 
+# formato (coluna do index) → sufixo de arquivo dentro do item.
+_FORMATO_SUFFIX: Dict[str, str] = {"pdf": ".pdf", "html": ".html", "docx": ".docx"}
+
+
+def _fetch_item_file_bytes(item_id: str, filename: str) -> bytes:
+    """Baixa os bytes de um arquivo de dentro de um IA item (sem re-buscar a fonte).
+
+    A reconciliação promove arquivos já preservados no item de espera usando os
+    bytes do **IA**, nunca re-baixando do portal frágil (ADR-0004).
+    """
+    url = download_url(item_id, filename)
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read()  # type: ignore[no-any-return]
+
+
 def _resolve_uuid5_and_index(
     item_id: str,
     content_bytes: bytes,
@@ -767,6 +790,164 @@ class InternetArchivePublisher:
             "uuid5": uuid5,
             "item_id": item_id,
             "identified": identity is not None,
+        }
+
+    def _promote_to_range(
+        self,
+        ente: str,
+        fonte: str,
+        tipo: str,
+        numero: int,
+        content: bytes,
+        row: Dict[str, str],
+    ) -> Optional[str]:
+        """Sobe um arquivo preservado para o item de range com a identidade agora
+        conhecida. Devolve o ``uuid5`` promovido, ou ``None`` em falha."""
+        range_id = range_item_identifier(ente, fonte, tipo, numero)
+        try:
+            uuid5, index_csv = _resolve_uuid5_and_index(
+                range_id,
+                content,
+                tipo=tipo,
+                numero=numero,
+                rendicao=row.get("rendicao", ""),
+                formato=row.get("formato", "pdf"),
+                source=row.get("source", ""),
+            )
+        except IndexFetchError as e:
+            logger.warning("reconcile: índice do range ilegível (%s): %s", range_id, e)
+            return None
+        suffix = _FORMATO_SUFFIX.get(row.get("formato", "pdf"), ".pdf")
+        with tempfile.TemporaryDirectory() as tmp:
+            fdst = Path(tmp) / raw_filename(uuid5, suffix)
+            fdst.write_bytes(content)
+            index_path = Path(tmp) / INDEX_FILENAME
+            index_path.write_text(index_csv, encoding="utf-8")
+            try:
+                subprocess.run(
+                    [
+                        "ia",
+                        "upload",
+                        range_id,
+                        str(fdst),
+                        str(index_path),
+                        "--metadata",
+                        f"title:{_range_title(ente, fonte, tipo, numero)}",
+                        "--metadata",
+                        "mediatype:texts",
+                        "--metadata",
+                        f"subject:leis;leizilla;{ente};{fonte}",
+                        "--metadata",
+                        "language:pt",
+                        "--metadata",
+                        f"coverage:{_entity_coverage(ente)}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                )
+            except subprocess.CalledProcessError as e:
+                logger.warning(
+                    "reconcile: upload ao range falhou (%s): %s", range_id, e
+                )
+                return None
+        return uuid5
+
+    def _upload_index_only(self, item_id: str, index_csv: str) -> bool:
+        """Reescreve o index.csv de um item (usado para tirar do índice de espera o
+        que foi promovido)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            index_path = Path(tmp) / INDEX_FILENAME
+            index_path.write_text(index_csv, encoding="utf-8")
+            try:
+                subprocess.run(
+                    [
+                        "ia",
+                        "upload",
+                        item_id,
+                        str(index_path),
+                        "--metadata",
+                        "mediatype:texts",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                )
+            except subprocess.CalledProcessError as e:
+                logger.warning("reconcile: reescrita do índice de espera falhou: %s", e)
+                return False
+        return True
+
+    def reconcile_unidentified(
+        self,
+        ente: str,
+        fonte: str,
+        identity_by_source: Dict[str, tuple[str, int]],
+    ) -> Dict[str, Any]:
+        """Promove arquivos da área de espera ``_unidentified`` para o item de range
+        cuja identidade ``(tipo, número)`` foi (re-)derivada do contexto da fonte.
+
+        ``identity_by_source`` mapeia URL de origem → ``(tipo, número)`` — montado
+        pela CLI a partir de uma passada de descoberta com os extratores atuais. Os
+        bytes vêm do **IA** (item de espera), nunca do portal frágil (ADR-0004).
+        """
+        if not self.access_key or not self.secret_key:
+            return {"success": False, "error": "IA credentials not configured"}
+        holding_id = unidentified_item_identifier(ente, fonte)
+        try:
+            holding_index = _fetch_existing_index(holding_id)
+        except IndexFetchError as e:
+            return {
+                "success": False,
+                "error": f"could not read holding index: {e}",
+                "item_id": holding_id,
+            }
+        if not holding_index:
+            return {
+                "success": True,
+                "promoted": 0,
+                "remaining": 0,
+                "item_id": holding_id,
+            }
+
+        rows = [
+            {c: r.get(c, "") or "" for c in INDEX_COLUMNS}
+            for r in csv.DictReader(io.StringIO(holding_index))
+        ]
+        promoted_uuid5s: Set[str] = set()
+        for row in rows:
+            if row["numero"]:  # já identificado nesta área (não deveria ocorrer)
+                continue
+            ident = identity_by_source.get(row["source"])
+            if ident is None:
+                continue
+            suffix = _FORMATO_SUFFIX.get(row["formato"], ".pdf")
+            try:
+                content = _fetch_item_file_bytes(
+                    holding_id, raw_filename(row["uuid5"], suffix)
+                )
+            except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
+                logger.warning("reconcile: download de %s falhou: %s", row["uuid5"], e)
+                continue
+            tipo, numero = ident
+            promoted = self._promote_to_range(ente, fonte, tipo, numero, content, row)
+            if promoted is not None:
+                promoted_uuid5s.add(row["uuid5"])
+
+        if promoted_uuid5s:
+            new_index = remove_index_rows(holding_index, promoted_uuid5s)
+            self._upload_index_only(holding_id, new_index)
+
+        remaining = sum(
+            1 for r in rows if not r["numero"] and r["uuid5"] not in promoted_uuid5s
+        )
+        return {
+            "success": True,
+            "promoted": len(promoted_uuid5s),
+            "remaining": remaining,
+            "item_id": holding_id,
         }
 
     def upload_parsed(

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -1,7 +1,10 @@
 """Publicação no Internet Archive e exportação de datasets."""
 
+import atexit
+import configparser
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -451,11 +454,49 @@ def update_raw_index(
                 capture_output=True,
                 text=True,
                 check=True,
+                env=_ia_subprocess_env(config.IA_ACCESS_KEY, config.IA_SECRET_KEY),
             )
             return {"success": True, "index_id": index_id}
         except (subprocess.CalledProcessError, FileNotFoundError) as e:
             err = getattr(e, "stderr", str(e))
             return {"success": False, "error": err, "index_id": index_id}
+
+
+_ia_config_cache: Dict[tuple[str, str], str] = {}
+
+
+def _ia_subprocess_env(
+    access_key: Optional[str], secret_key: Optional[str]
+) -> Optional[Dict[str, str]]:
+    """Devolve um env que autentica o CLI ``ia``, ou ``None`` se sem credenciais.
+
+    O CLI ``ia`` ignora ``IA_ACCESS_KEY``/``IA_SECRET_KEY`` e não tem flags de
+    chave: ele só lê credenciais de um arquivo de config, cujo caminho pode ser
+    sobrescrito via a env var ``IA_CONFIG_FILE``. Escrevemos um ``ia.ini`` mínimo
+    (uma vez por par de credenciais) e apontamos o subprocess para ele, para que
+    o upload funcione sem um ``~/.config/internetarchive/ia.ini`` pré-existente.
+    """
+    if not access_key or not secret_key:
+        return None
+    key = (access_key, secret_key)
+    cfg_path = _ia_config_cache.get(key)
+    if cfg_path is None:
+        cfg = configparser.ConfigParser()
+        cfg["s3"] = {"access": access_key, "secret": secret_key}
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ini", delete=False, encoding="utf-8"
+        )
+        cfg.write(tmp)
+        tmp.close()
+        cfg_path = tmp.name
+        _ia_config_cache[key] = cfg_path
+        _final_path = cfg_path
+
+        def _cleanup() -> None:
+            Path(_final_path).unlink(missing_ok=True)
+
+        atexit.register(_cleanup)
+    return {**os.environ, "IA_CONFIG_FILE": cfg_path}
 
 
 class InternetArchivePublisher:
@@ -537,6 +578,7 @@ class InternetArchivePublisher:
                     capture_output=True,
                     text=True,
                     check=True,
+                    env=_ia_subprocess_env(self.access_key, self.secret_key),
                 )
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
@@ -637,6 +679,7 @@ class InternetArchivePublisher:
                     capture_output=True,
                     text=True,
                     check=True,
+                    env=_ia_subprocess_env(self.access_key, self.secret_key),
                 )
             except FileNotFoundError:
                 return {
@@ -725,6 +768,7 @@ class InternetArchivePublisher:
                     capture_output=True,
                     text=True,
                     check=True,
+                    env=_ia_subprocess_env(self.access_key, self.secret_key),
                 )
                 return {
                     "success": True,
@@ -806,6 +850,7 @@ class InternetArchivePublisher:
                     capture_output=True,
                     text=True,
                     check=True,
+                    env=_ia_subprocess_env(self.access_key, self.secret_key),
                 )
                 return {
                     "success": True,
@@ -874,6 +919,7 @@ class InternetArchivePublisher:
                     capture_output=True,
                     text=True,
                     check=True,
+                    env=_ia_subprocess_env(self.access_key, self.secret_key),
                 )
                 return {"success": True}
             except FileNotFoundError:

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -22,11 +22,14 @@ from leizilla.ia_utils import (
     INDEX_FILENAME,
     compute_hash,
     download_url,
-    list_source_keys,
+    list_identities,
     merge_index_row,
+    parse_identity,
+    range_bounds,
+    range_item_identifier,
     raw_filename,
-    raw_index_identifier,
-    raw_range_identifier,
+    uuid5_collision,
+    uuid5_name,
 )
 
 _DATASET_IDENTIFIER_RE = (
@@ -218,31 +221,68 @@ def count_ia_items(identifier_prefix: str) -> Optional[int]:
     return total
 
 
+def _scrape_identifiers(identifier_prefix: str) -> Optional[list[str]]:
+    """Lista os identifiers de itens IA que começam com o prefixo (scrape API).
+
+    ``None`` em erro de rede. Pagina via cursor até esgotar.
+    """
+    q = f"identifier:{identifier_prefix}*"
+    base_url = (
+        f"{_IA_SCRAPE_URL}?q={urllib.parse.quote(q)}&count=10000&fields=identifier"
+    )
+    ids: list[str] = []
+    cursor: Optional[str] = None
+    while True:
+        url = base_url
+        if cursor:
+            url += f"&cursor={urllib.parse.quote(cursor)}"
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = json.loads(resp.read())
+            ids.extend(
+                item["identifier"]
+                for item in data.get("items", [])
+                if item.get("identifier")
+            )
+            cursor = data.get("cursor")
+            if not cursor:
+                break
+        except Exception:
+            return None
+    return ids
+
+
 def list_raw_ids(ente: str, fonte: str) -> Set[str]:
     """Return set of legacy raw IDs already captured to IA for this ente/fonte.
 
-    Under the content-addressed layer (ADR-0010), raw bytes live in hash-prefix
-    range items whose identifiers carry no source_key — only the per-(ente,fonte)
-    ``index.csv`` maps source_keys to content. So discovery reads the index and
-    reconstructs the legacy raw IDs (``leizilla-raw-{ente}-{fonte}-{source_key}``)
-    that the parser knows how to resolve.
+    Under ADR-0011 the raw bytes live in identity range items
+    (``leizilla_{ente}_{fonte}_{tipo}_{start}-{end}``), each carrying its own
+    ``index.csv``. So we enumerate those items via the scrape API, read each
+    index, and reconstruct the legacy raw IDs
+    (``leizilla-raw-{ente}-{fonte}-{tipo}-{numero}``) the parser knows how to
+    resolve.
 
-    Fail-open: returns the empty set when the index doesn't exist yet or on any
-    network error, so the caller falls back to the sequential range — never skips
-    due to connectivity.
+    Fail-open: returns the empty set when nothing exists yet or on any network
+    error, so the caller falls back to the sequential range — never skips due to
+    connectivity.
     """
-    index_url = download_url(raw_index_identifier(ente, fonte), INDEX_FILENAME)
-    req = urllib.request.Request(index_url, headers={"User-Agent": _USER_AGENT})
-    try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            index_csv = resp.read().decode("utf-8", errors="replace")
-    except (urllib.error.URLError, OSError, ValueError):
+    prefix = f"leizilla_{ente.lower()}_{fonte.lower()}_"
+    item_ids = _scrape_identifiers(prefix)
+    if not item_ids:
         return set()
-
-    return {
-        _raw_identifier(ente, fonte, source_key)
-        for source_key in list_source_keys(index_csv)
-    }
+    out: Set[str] = set()
+    for item_id in item_ids:
+        index_url = download_url(item_id, INDEX_FILENAME)
+        req = urllib.request.Request(index_url, headers={"User-Agent": _USER_AGENT})
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                index_csv = resp.read().decode("utf-8", errors="replace")
+        except (urllib.error.URLError, OSError, ValueError):
+            continue
+        for identity in list_identities(index_csv):
+            out.add(_raw_identifier(ente, fonte, identity))
+    return out
 
 
 def list_parsed_raw_ids(ente: str, fonte: str) -> Set[str]:
@@ -371,15 +411,15 @@ class IndexFetchError(Exception):
     """
 
 
-def _fetch_existing_index(ente: str, fonte: str) -> Optional[str]:
-    """Baixa o index.csv corrente do (ente, fonte) do IA.
+def _fetch_existing_index(item_id: str) -> Optional[str]:
+    """Baixa o index.csv corrente de um item de range do IA.
 
-    Retorna o CSV se existir, ``None`` se for um 404 confirmado (índice ainda não
-    publicado — seguro começar vazio), e levanta ``IndexFetchError`` em falhas
+    Retorna o CSV se existir, ``None`` se for um 404 confirmado (item/índice ainda
+    não publicado — seguro começar vazio), e levanta ``IndexFetchError`` em falhas
     transitórias (timeout, 5xx, rede) para que o chamador não sobrescreva o
     histórico existente com um índice vazio.
     """
-    url = download_url(raw_index_identifier(ente, fonte), INDEX_FILENAME)
+    url = download_url(item_id, INDEX_FILENAME)
     req = urllib.request.Request(url)
     req.add_header("User-Agent", _USER_AGENT)
     try:
@@ -395,71 +435,46 @@ def _fetch_existing_index(ente: str, fonte: str) -> Optional[str]:
         raise IndexFetchError(str(e)) from e
 
 
-def update_raw_index(
-    ente: str,
-    fonte: str,
+def _resolve_uuid5_and_index(
+    item_id: str,
+    content_bytes: bytes,
     *,
-    source_key: str,
-    content_hash: str,
-    content_type: str,
-    source_url: str,
-) -> Dict[str, Any]:
-    """Anexa uma captura ao index.csv do (ente, fonte) e re-publica o item índice.
+    tipo: str,
+    numero: int,
+    rendicao: str,
+    formato: str,
+) -> tuple[str, str]:
+    """Resolve o nome de arquivo (UUIDv5) e o index.csv mesclado do item (ADR-0011).
 
-    O índice (``leizilla-raw-{ente}-{fonte}-index``) é a ponte source_key →
-    content_hash da camada raw (ADR-0010). Append-only e idempotente em
-    (source_key, content_hash). Item separado do range que guarda os bytes, para
-    que a resolução de leitura precise de um único fetch por (ente, fonte).
-
-    WARNING: download+upload incremental por captura é O(n²) em ingestão massiva.
-    Para backfill offline, acumular o index.csv localmente e publicar uma vez.
+    Busca o index.csv corrente do item, detecta colisão de UUIDv5 truncado (estende
+    para o UUID completo se necessário), e mescla a captura (append-only,
+    newest-wins). Levanta ``IndexFetchError`` em falha transitória de leitura — o
+    chamador aborta em vez de sobrescrever o histórico do item.
     """
-    try:
-        existing = _fetch_existing_index(ente, fonte)
-    except IndexFetchError as e:
-        # Falha transitória ao ler o índice atual: abortar em vez de sobrescrever
-        # o histórico com uma única linha (perderia mapeamentos prévios).
-        return {
-            "success": False,
-            "error": f"could not read existing index (aborting to avoid data loss): {e}",
-            "index_id": raw_index_identifier(ente, fonte),
-        }
-    updated = merge_index_row(
+    sha256 = compute_hash(content_bytes)
+    uuid5 = uuid5_name(content_bytes)
+    existing = _fetch_existing_index(item_id)
+    if existing and uuid5_collision(existing, uuid5=uuid5, sha256=sha256):
+        uuid5 = uuid5_name(content_bytes, length=32)  # estende: garante unicidade
+    merged = merge_index_row(
         existing,
-        source_key=source_key,
-        content_hash=content_hash,
-        content_type=content_type,
-        source_url=source_url,
+        tipo=tipo,
+        numero=numero,
+        rendicao=rendicao,
+        formato=formato,
+        uuid5=uuid5,
+        sha256=sha256,
     )
-    index_id = raw_index_identifier(ente, fonte)
-    with tempfile.TemporaryDirectory() as tmp:
-        index_path = Path(tmp) / INDEX_FILENAME
-        index_path.write_text(updated, encoding="utf-8")
-        try:
-            subprocess.run(
-                [
-                    "ia",
-                    "upload",
-                    index_id,
-                    str(index_path),
-                    "--metadata",
-                    f"title:Leizilla Raw Index {ente.upper()} {fonte.upper()}",
-                    "--metadata",
-                    "mediatype:data",
-                    "--metadata",
-                    f"subject:leizilla;index;{ente};{fonte}",
-                    "--metadata",
-                    "creator:leizilla-crawler",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-                env=_ia_subprocess_env(config.IA_ACCESS_KEY, config.IA_SECRET_KEY),
-            )
-            return {"success": True, "index_id": index_id}
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            err = getattr(e, "stderr", str(e))
-            return {"success": False, "error": err, "index_id": index_id}
+    return uuid5, merged
+
+
+def _range_title(ente: str, fonte: str, tipo: str, numero: int) -> str:
+    """Título legível do item de range (ex.: 'Leizilla Raw RO CASACIVIL LEI 5001-6000')."""
+    start, end = range_bounds(numero)
+    return (
+        f"Leizilla Raw {ente.upper()} {fonte.upper()} "
+        f"{tipo.upper()} {start:04d}-{end:04d}"
+    )
 
 
 _ia_config_cache: Dict[tuple[str, str], str] = {}
@@ -527,24 +542,47 @@ class InternetArchivePublisher:
         chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
         ia_id = _raw_identifier(ente, fonte, chave)
 
-        # Endereço de conteúdo (ADR-0010): o arquivo raw é nomeado pelo SHA-256
-        # dos seus bytes e bucketizado por prefixo de hash. A chave de colheita
-        # (chave) é metadado no índice, nunca path nem fronteira de range.
-        content_hash = compute_hash(pdf_bytes)
-        range_ia_id = raw_range_identifier(ente, fonte, content_hash)
-        title = f"Leizilla Raw {ente.upper()} {fonte.upper()} {content_hash[:2]}"
+        # Reject-until-identified (ADR-0011): só entram na coleção normas com
+        # (tipo, número) conhecidos. coddoc/seq/fallback não identificam.
+        identity = parse_identity(chave)
+        if identity is None:
+            return {
+                "success": False,
+                "error": f"unidentified resource (no tipo+número): {chave}",
+                "ia_id": ia_id,
+            }
+        tipo, numero = identity
+        item_id = range_item_identifier(ente, fonte, tipo, numero)
+        rendicao = str(lei_data.get("rendicao", ""))
 
         raw_meta = build_raw_meta(lei_data, pdf_bytes, fetched_from, wayback_url)
-        url_original = str(lei_data.get("url_original") or fetched_from)
+
+        # Nome content-addressed (UUIDv5) + index.csv do item. Aborta se não
+        # conseguir ler o índice atual (não sobrescreve histórico do item).
+        try:
+            uuid5, index_csv = _resolve_uuid5_and_index(
+                item_id,
+                pdf_bytes,
+                tipo=tipo,
+                numero=numero,
+                rendicao=rendicao,
+                formato="pdf",
+            )
+        except IndexFetchError as e:
+            return {
+                "success": False,
+                "error": f"could not read existing index (aborting to avoid data loss): {e}",
+                "ia_id": ia_id,
+            }
 
         with tempfile.TemporaryDirectory() as tmp:
-            pdf_name = raw_filename(content_hash, ".pdf")
-            meta_name = raw_filename(content_hash, "_meta.json")
-            pdf_dst = Path(tmp) / pdf_name
-            meta_path = Path(tmp) / meta_name
+            pdf_dst = Path(tmp) / raw_filename(uuid5, ".pdf")
+            meta_path = Path(tmp) / raw_filename(uuid5, "_meta.json")
+            index_path = Path(tmp) / INDEX_FILENAME
 
             shutil.copy2(str(pdf_path), str(pdf_dst))
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
+            index_path.write_text(index_csv, encoding="utf-8")
 
             coverage = _entity_coverage(ente)
             desc = (
@@ -557,11 +595,12 @@ class InternetArchivePublisher:
                     [
                         "ia",
                         "upload",
-                        range_ia_id,
+                        item_id,
                         str(pdf_dst),
                         str(meta_path),
+                        str(index_path),
                         "--metadata",
-                        f"title:{title}",
+                        f"title:{_range_title(ente, fonte, tipo, numero)}",
                         "--metadata",
                         "mediatype:texts",
                         "--metadata",
@@ -583,28 +622,11 @@ class InternetArchivePublisher:
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
 
-        # Anexa a captura ao índice source_key → content_hash do (ente, fonte).
-        # A leitura (fetch_ocr) resolve exclusivamente via índice; se este upload
-        # falhar, a captura existe nos bytes mas o parser nunca a localiza —
-        # então propagamos a falha em vez de reportar sucesso.
-        index_result = update_raw_index(
-            ente,
-            fonte,
-            source_key=chave,
-            content_hash=content_hash,
-            content_type="application/pdf",
-            source_url=url_original,
-        )
-        if not index_result.get("success"):
-            return {
-                "success": False,
-                "error": f"index update failed: {index_result.get('error')}",
-                "ia_id": ia_id,
-            }
         return {
             "success": True,
             "ia_id": ia_id,
-            "ia_url": f"https://archive.org/details/{range_ia_id}",
+            "ia_url": f"https://archive.org/details/{item_id}",
+            "uuid5": uuid5,
         }
 
     def upload_raw_html(
@@ -628,24 +650,47 @@ class InternetArchivePublisher:
         chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
         ia_id = _raw_identifier(ente, fonte, chave)
 
-        html_bytes = html_content.encode("utf-8")
-        content_hash = compute_hash(html_bytes)
-        range_ia_id = raw_range_identifier(ente, fonte, content_hash)
-        title = f"Leizilla Raw {ente.upper()} {fonte.upper()} {content_hash[:2]}"
+        # Reject-until-identified (ADR-0011).
+        identity = parse_identity(chave)
+        if identity is None:
+            return {
+                "success": False,
+                "error": f"unidentified resource (no tipo+número): {chave}",
+                "ia_id": ia_id,
+            }
+        tipo, numero = identity
+        item_id = range_item_identifier(ente, fonte, tipo, numero)
+        rendicao = str(lei_data.get("rendicao", ""))
 
+        html_bytes = html_content.encode("utf-8")
         raw_meta = build_raw_meta_html(
             html_content, lei_data, fetched_from, wayback_url
         )
-        url_original = str(lei_data.get("url_original") or fetched_from)
+
+        try:
+            uuid5, index_csv = _resolve_uuid5_and_index(
+                item_id,
+                html_bytes,
+                tipo=tipo,
+                numero=numero,
+                rendicao=rendicao,
+                formato="html",
+            )
+        except IndexFetchError as e:
+            return {
+                "success": False,
+                "error": f"could not read existing index (aborting to avoid data loss): {e}",
+                "ia_id": ia_id,
+            }
 
         with tempfile.TemporaryDirectory() as tmp:
-            html_name = raw_filename(content_hash, ".html")
-            meta_name = raw_filename(content_hash, "_meta.json")
-            html_dst = Path(tmp) / html_name
-            meta_path = Path(tmp) / meta_name
+            html_dst = Path(tmp) / raw_filename(uuid5, ".html")
+            meta_path = Path(tmp) / raw_filename(uuid5, "_meta.json")
+            index_path = Path(tmp) / INDEX_FILENAME
 
             html_dst.write_text(html_content, encoding="utf-8")
             meta_path.write_text(json.dumps(raw_meta, indent=2, ensure_ascii=False))
+            index_path.write_text(index_csv, encoding="utf-8")
 
             coverage = _entity_coverage(ente)
             desc = (
@@ -658,11 +703,12 @@ class InternetArchivePublisher:
                     [
                         "ia",
                         "upload",
-                        range_ia_id,
+                        item_id,
                         str(html_dst),
                         str(meta_path),
+                        str(index_path),
                         "--metadata",
-                        f"title:{title}",
+                        f"title:{_range_title(ente, fonte, tipo, numero)}",
                         "--metadata",
                         "mediatype:texts",
                         "--metadata",
@@ -690,24 +736,11 @@ class InternetArchivePublisher:
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
 
-        index_result = update_raw_index(
-            ente,
-            fonte,
-            source_key=chave,
-            content_hash=content_hash,
-            content_type="text/html",
-            source_url=url_original,
-        )
-        if not index_result.get("success"):
-            return {
-                "success": False,
-                "error": f"index update failed: {index_result.get('error')}",
-                "ia_id": ia_id,
-            }
         return {
             "success": True,
             "ia_id": ia_id,
-            "ia_url": f"https://archive.org/details/{range_ia_id}",
+            "ia_url": f"https://archive.org/details/{item_id}",
+            "uuid5": uuid5,
         }
 
     def upload_parsed(

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -28,6 +28,7 @@ from leizilla.ia_utils import (
     range_bounds,
     range_item_identifier,
     raw_filename,
+    unidentified_item_identifier,
     uuid5_collision,
     uuid5_name,
 )
@@ -440,7 +441,7 @@ def _resolve_uuid5_and_index(
     content_bytes: bytes,
     *,
     tipo: str,
-    numero: int,
+    numero: Optional[int],
     rendicao: str,
     formato: str,
     source: str = "",
@@ -477,6 +478,11 @@ def _range_title(ente: str, fonte: str, tipo: str, numero: int) -> str:
         f"Leizilla Raw {ente.upper()} {fonte.upper()} "
         f"{tipo.upper()} {start:04d}-{end:04d}"
     )
+
+
+def _unidentified_title(ente: str, fonte: str) -> str:
+    """Título do item de espera (ex.: 'Leizilla Raw RO ASSEMBLEIA UNIDENTIFIED')."""
+    return f"Leizilla Raw {ente.upper()} {fonte.upper()} UNIDENTIFIED"
 
 
 _ia_config_cache: Dict[tuple[str, str], str] = {}
@@ -544,17 +550,19 @@ class InternetArchivePublisher:
         chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
         ia_id = _raw_identifier(ente, fonte, chave)
 
-        # Reject-until-identified (ADR-0011): só entram na coleção normas com
-        # (tipo, número) conhecidos. coddoc/seq/fallback não identificam.
+        # Identidade é evidência, não catraca (ADR-0011 §1): capturamos sempre. Se
+        # o contexto rendeu (tipo, número), o item é o range navegável; senão, os
+        # bytes ficam **preservados** na área de espera _unidentified (o IA faz OCR)
+        # até a reconciliação — nunca há descarte.
         identity = parse_identity(chave)
         if identity is None:
-            return {
-                "success": False,
-                "error": f"unidentified resource (no tipo+número): {chave}",
-                "ia_id": ia_id,
-            }
-        tipo, numero = identity
-        item_id = range_item_identifier(ente, fonte, tipo, numero)
+            tipo, numero = "", None
+            item_id = unidentified_item_identifier(ente, fonte)
+            title = _unidentified_title(ente, fonte)
+        else:
+            tipo, numero = identity
+            item_id = range_item_identifier(ente, fonte, tipo, numero)
+            title = _range_title(ente, fonte, tipo, numero)
         rendicao = str(lei_data.get("rendicao", ""))
         # Proveniência (ADR-0010): mapeia o arquivo de volta à sua origem de
         # colheita (URL original; coddoc/path embutido). É como descartamos o
@@ -609,7 +617,7 @@ class InternetArchivePublisher:
                         str(meta_path),
                         str(index_path),
                         "--metadata",
-                        f"title:{_range_title(ente, fonte, tipo, numero)}",
+                        f"title:{title}",
                         "--metadata",
                         "mediatype:texts",
                         "--metadata",
@@ -636,6 +644,8 @@ class InternetArchivePublisher:
             "ia_id": ia_id,
             "ia_url": f"https://archive.org/details/{item_id}",
             "uuid5": uuid5,
+            "item_id": item_id,
+            "identified": identity is not None,
         }
 
     def upload_raw_html(
@@ -659,16 +669,17 @@ class InternetArchivePublisher:
         chave = str(lei_data.get("chave") or lei_data.get("id", "unknown"))
         ia_id = _raw_identifier(ente, fonte, chave)
 
-        # Reject-until-identified (ADR-0011).
+        # Identidade é evidência, não catraca (ADR-0011 §1): identificados vão ao
+        # range navegável; o resíduo fica preservado na área de espera _unidentified.
         identity = parse_identity(chave)
         if identity is None:
-            return {
-                "success": False,
-                "error": f"unidentified resource (no tipo+número): {chave}",
-                "ia_id": ia_id,
-            }
-        tipo, numero = identity
-        item_id = range_item_identifier(ente, fonte, tipo, numero)
+            tipo, numero = "", None
+            item_id = unidentified_item_identifier(ente, fonte)
+            title = _unidentified_title(ente, fonte)
+        else:
+            tipo, numero = identity
+            item_id = range_item_identifier(ente, fonte, tipo, numero)
+            title = _range_title(ente, fonte, tipo, numero)
         rendicao = str(lei_data.get("rendicao", ""))
         source = str(
             lei_data.get("url_original") or lei_data.get("url_pdf_original") or ""
@@ -721,7 +732,7 @@ class InternetArchivePublisher:
                         str(meta_path),
                         str(index_path),
                         "--metadata",
-                        f"title:{_range_title(ente, fonte, tipo, numero)}",
+                        f"title:{title}",
                         "--metadata",
                         "mediatype:texts",
                         "--metadata",
@@ -754,6 +765,8 @@ class InternetArchivePublisher:
             "ia_id": ia_id,
             "ia_url": f"https://archive.org/details/{item_id}",
             "uuid5": uuid5,
+            "item_id": item_id,
+            "identified": identity is not None,
         }
 
     def upload_parsed(

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -271,9 +271,13 @@ def list_raw_ids(ente: str, fonte: str) -> Set[str]:
     (``leizilla-raw-{ente}-{fonte}-{tipo}-{numero}``) the parser knows how to
     resolve.
 
-    Fail-open: returns the empty set when nothing exists yet or on any network
-    error, so the caller falls back to the sequential range — never skips due to
-    connectivity.
+    Fail-open **all-or-nothing**: returns the empty set when nothing exists yet or
+    on any network error, so the caller falls back to the sequential range — never
+    skips due to connectivity. Crucially, a transient failure reading *any single*
+    range index also returns empty (not a partial set): a partial non-empty result
+    would be treated as authoritative by ``cmd_parse_all`` and silently drop the
+    ranges whose index couldn't be read. A confirmed 404 (item without an index) is
+    not transient — that item simply contributes nothing.
     """
     prefix = f"leizilla_{ente.lower()}_{fonte.lower()}_"
     item_ids = _scrape_identifiers(prefix)
@@ -281,12 +285,14 @@ def list_raw_ids(ente: str, fonte: str) -> Set[str]:
         return set()
     out: Set[str] = set()
     for item_id in item_ids:
-        index_url = download_url(item_id, INDEX_FILENAME)
-        req = urllib.request.Request(index_url, headers={"User-Agent": _USER_AGENT})
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                index_csv = resp.read().decode("utf-8", errors="replace")
-        except (urllib.error.URLError, OSError, ValueError):
+            index_csv = _fetch_existing_index(item_id)
+        except IndexFetchError:
+            # Transitório (timeout/5xx): não sabemos os IDs deste range. All-or-
+            # nothing → devolve vazio para o caller cair no fallback sequencial,
+            # em vez de omitir ranges silenciosamente.
+            return set()
+        if index_csv is None:  # 404 confirmado: item sem index, nada a contribuir
             continue
         for identity in list_identities(index_csv):
             out.add(_raw_identifier(ente, fonte, identity))

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -922,7 +922,9 @@ class InternetArchivePublisher:
             {c: r.get(c, "") or "" for c in INDEX_COLUMNS}
             for r in csv.DictReader(io.StringIO(holding_index))
         ]
-        promoted_uuid5s: Set[str] = set()
+        # Chaveamos por (uuid5, source): bytes idênticos de origens distintas
+        # compartilham o uuid5, mas só a origem identificável deve sair da espera.
+        promoted_keys: Set[tuple[str, str]] = set()
         for row in rows:
             if row["numero"]:  # já identificado nesta área (não deveria ocorrer)
                 continue
@@ -940,24 +942,26 @@ class InternetArchivePublisher:
             tipo, numero = ident
             promoted = self._promote_to_range(ente, fonte, tipo, numero, content, row)
             if promoted is not None:
-                promoted_uuid5s.add(row["uuid5"])
+                promoted_keys.add((row["uuid5"], row["source"]))
 
         # As promoções ao range já aconteceram; só falta tirar essas linhas do
         # índice de espera. Se essa reescrita falhar, os arquivos seguem listados
         # na espera — reportamos erro (e contamos como remaining), senão o operador
         # acha que a limpeza terminou e a próxima reconciliação re-promove à toa.
         index_rewrite_ok = True
-        if promoted_uuid5s:
-            new_index = remove_index_rows(holding_index, promoted_uuid5s)
+        if promoted_keys:
+            new_index = remove_index_rows(holding_index, promoted_keys)
             index_rewrite_ok = self._upload_index_only(holding_id, new_index)
 
-        cleaned = promoted_uuid5s if index_rewrite_ok else set()
+        cleaned = promoted_keys if index_rewrite_ok else set()
         remaining = sum(
-            1 for r in rows if not r["numero"] and r["uuid5"] not in cleaned
+            1
+            for r in rows
+            if not r["numero"] and (r["uuid5"], r["source"]) not in cleaned
         )
         result: Dict[str, Any] = {
             "success": index_rewrite_ok,
-            "promoted": len(promoted_uuid5s),
+            "promoted": len(promoted_keys),
             "remaining": remaining,
             "item_id": holding_id,
         }

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -942,19 +942,31 @@ class InternetArchivePublisher:
             if promoted is not None:
                 promoted_uuid5s.add(row["uuid5"])
 
+        # As promoções ao range já aconteceram; só falta tirar essas linhas do
+        # índice de espera. Se essa reescrita falhar, os arquivos seguem listados
+        # na espera — reportamos erro (e contamos como remaining), senão o operador
+        # acha que a limpeza terminou e a próxima reconciliação re-promove à toa.
+        index_rewrite_ok = True
         if promoted_uuid5s:
             new_index = remove_index_rows(holding_index, promoted_uuid5s)
-            self._upload_index_only(holding_id, new_index)
+            index_rewrite_ok = self._upload_index_only(holding_id, new_index)
 
+        cleaned = promoted_uuid5s if index_rewrite_ok else set()
         remaining = sum(
-            1 for r in rows if not r["numero"] and r["uuid5"] not in promoted_uuid5s
+            1 for r in rows if not r["numero"] and r["uuid5"] not in cleaned
         )
-        return {
-            "success": True,
+        result: Dict[str, Any] = {
+            "success": index_rewrite_ok,
             "promoted": len(promoted_uuid5s),
             "remaining": remaining,
             "item_id": holding_id,
         }
+        if not index_rewrite_ok:
+            result["error"] = (
+                "arquivos promovidos ao range, mas a reescrita do índice de espera "
+                "falhou — linhas promovidas ainda constam em _unidentified"
+            )
+        return result
 
     def upload_parsed(
         self,

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -443,6 +443,7 @@ def _resolve_uuid5_and_index(
     numero: int,
     rendicao: str,
     formato: str,
+    source: str = "",
 ) -> tuple[str, str]:
     """Resolve o nome de arquivo (UUIDv5) e o index.csv mesclado do item (ADR-0011).
 
@@ -464,6 +465,7 @@ def _resolve_uuid5_and_index(
         formato=formato,
         uuid5=uuid5,
         sha256=sha256,
+        source=source,
     )
     return uuid5, merged
 
@@ -554,6 +556,12 @@ class InternetArchivePublisher:
         tipo, numero = identity
         item_id = range_item_identifier(ente, fonte, tipo, numero)
         rendicao = str(lei_data.get("rendicao", ""))
+        # Proveniência (ADR-0010): mapeia o arquivo de volta à sua origem de
+        # colheita (URL original; coddoc/path embutido). É como descartamos o
+        # coddoc da identidade sem perder a rastreabilidade.
+        source = str(
+            lei_data.get("url_original") or lei_data.get("url_pdf_original") or ""
+        )
 
         raw_meta = build_raw_meta(lei_data, pdf_bytes, fetched_from, wayback_url)
 
@@ -567,6 +575,7 @@ class InternetArchivePublisher:
                 numero=numero,
                 rendicao=rendicao,
                 formato="pdf",
+                source=source,
             )
         except IndexFetchError as e:
             return {
@@ -661,6 +670,9 @@ class InternetArchivePublisher:
         tipo, numero = identity
         item_id = range_item_identifier(ente, fonte, tipo, numero)
         rendicao = str(lei_data.get("rendicao", ""))
+        source = str(
+            lei_data.get("url_original") or lei_data.get("url_pdf_original") or ""
+        )
 
         html_bytes = html_content.encode("utf-8")
         raw_meta = build_raw_meta_html(
@@ -675,6 +687,7 @@ class InternetArchivePublisher:
                 numero=numero,
                 rendicao=rendicao,
                 formato="html",
+                source=source,
             )
         except IndexFetchError as e:
             return {

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -662,6 +662,12 @@ class InternetArchivePublisher:
                     check=True,
                     env=_ia_subprocess_env(self.access_key, self.secret_key),
                 )
+            except FileNotFoundError:
+                return {
+                    "success": False,
+                    "error": "ia CLI não encontrado — instale 'internetarchive'",
+                    "ia_id": ia_id,
+                }
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
 

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -820,24 +820,32 @@ class InternetArchivePublisher:
         fonte: str,
         tipo: str,
         numero: int,
+        meta: Optional[tuple[str, bytes]] = None,
     ) -> bool:
         """Escreve o arquivo + o ``index.csv`` (já mesclado pelo chamador) e sobe ao
-        item de range. O index vem pronto para que promoções ao MESMO range numa
-        execução acumulem num único índice — evita o lost-update de releituras
-        sucessivas contra o IA eventualmente-consistente."""
+        item de range. ``meta`` é o sidecar ``(_meta.json nome, bytes)`` de
+        proveniência preservado da espera, para o item de range não ficar sem o
+        ``raw_meta`` que a captura direta publica. O index vem pronto para que
+        promoções ao MESMO range numa execução acumulem num único índice — evita o
+        lost-update de releituras sucessivas contra o IA eventualmente-consistente."""
         with tempfile.TemporaryDirectory() as tmp:
             fdst = Path(tmp) / filename
             fdst.write_bytes(content)
             index_path = Path(tmp) / INDEX_FILENAME
             index_path.write_text(index_csv, encoding="utf-8")
+            files = [str(fdst)]
+            if meta is not None:
+                meta_dst = Path(tmp) / meta[0]
+                meta_dst.write_bytes(meta[1])
+                files.append(str(meta_dst))
+            files.append(str(index_path))
             try:
                 subprocess.run(
                     [
                         "ia",
                         "upload",
                         range_id,
-                        str(fdst),
-                        str(index_path),
+                        *files,
                         "--metadata",
                         f"title:{_range_title(ente, fonte, tipo, numero)}",
                         "--metadata",
@@ -954,6 +962,14 @@ class InternetArchivePublisher:
             except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
                 logger.warning("reconcile: download de %s falhou: %s", row["uuid5"], e)
                 continue
+            # Sidecar de proveniência (_meta.json) — best-effort: preserva a
+            # proveniência Wayback/fonte no item de range (paridade com upload_raw).
+            try:
+                meta_bytes: Optional[bytes] = _fetch_item_file_bytes(
+                    holding_id, raw_filename(row["uuid5"], "_meta.json")
+                )
+            except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+                meta_bytes = None
             range_id = range_item_identifier(ente, fonte, tipo, numero)
             if range_id in failed_ranges:
                 continue
@@ -981,6 +997,11 @@ class InternetArchivePublisher:
                 sha256=sha256,
                 source=row["source"],
             )
+            meta = (
+                (raw_filename(uuid5, "_meta.json"), meta_bytes)
+                if meta_bytes is not None
+                else None
+            )
             if self._upload_to_range(
                 range_id,
                 content,
@@ -990,6 +1011,7 @@ class InternetArchivePublisher:
                 fonte,
                 tipo,
                 numero,
+                meta,
             ):
                 range_index_cache[range_id] = merged  # acumula só em sucesso
                 promoted_keys.add((row["uuid5"], row["source"]))

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -474,6 +474,7 @@ def _resolve_uuid5_and_index(
     rendicao: str,
     formato: str,
     source: str = "",
+    index_cache: Optional[Dict[str, str]] = None,
 ) -> tuple[str, str]:
     """Resolve o nome de arquivo (UUIDv5) e o index.csv mesclado do item (ADR-0011).
 
@@ -481,10 +482,20 @@ def _resolve_uuid5_and_index(
     para o UUID completo se necessário), e mescla a captura (append-only,
     newest-wins). Levanta ``IndexFetchError`` em falha transitória de leitura — o
     chamador aborta em vez de sobrescrever o histórico do item.
+
+    ``index_cache`` (opcional) é o índice acumulado por item DENTRO de um lote: se
+    presente e já tiver o item, usamos a versão local em vez de reler do IA. Isso
+    evita o lost-update quando uploads sucessivos do MESMO lote caem no mesmo item
+    de range — o IA não garante read-after-write, então uma releitura veria um
+    índice sem a linha do upload anterior e a sobrescreveria. O chamador grava o
+    índice mesclado de volta no cache **só após o upload bem-sucedido**.
     """
     sha256 = compute_hash(content_bytes)
     uuid5 = uuid5_name(content_bytes)
-    existing = _fetch_existing_index(item_id)
+    if index_cache is not None and item_id in index_cache:
+        existing: Optional[str] = index_cache[item_id]
+    else:
+        existing = _fetch_existing_index(item_id)
     if existing and uuid5_collision(existing, uuid5=uuid5, sha256=sha256):
         uuid5 = uuid5_name(content_bytes, length=32)  # estende: garante unicidade
     merged = merge_index_row(
@@ -565,11 +576,16 @@ class InternetArchivePublisher:
         pdf_bytes: bytes,
         fetched_from: str = "source-fallback",
         wayback_url: Optional[str] = None,
+        index_cache: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Upload raw PDF + raw_meta.json sidecar para IA.
 
         Identifier: leizilla-raw-{ente}-{fonte}-{chave} (SCHEMA.md §1.2).
         Retorna dict com 'success', 'ia_id', 'ia_url'.
+
+        ``index_cache`` acumula o ``index.csv`` por item dentro de um lote para que
+        uploads sucessivos ao mesmo item de range não se sobrescrevam (ver
+        ``_resolve_uuid5_and_index``).
         """
         if not self.access_key or not self.secret_key:
             return {"success": False, "error": "IA credentials not configured"}
@@ -616,6 +632,7 @@ class InternetArchivePublisher:
                 rendicao=rendicao,
                 formato="pdf",
                 source=source,
+                index_cache=index_cache,
             )
         except IndexFetchError as e:
             return {
@@ -677,6 +694,11 @@ class InternetArchivePublisher:
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
 
+        # Upload OK: acumula o índice mesclado para o próximo upload do MESMO lote
+        # ao mesmo item ver esta linha em vez de reler um índice obsoleto do IA.
+        if index_cache is not None:
+            index_cache[item_id] = index_csv
+
         return {
             "success": True,
             "ia_id": ia_id,
@@ -692,12 +714,15 @@ class InternetArchivePublisher:
         lei_data: Dict[str, Any],
         fetched_from: str = "source-fallback",
         wayback_url: Optional[str] = None,
+        index_cache: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Upload raw HTML + raw_meta.json sidecar para IA.
 
         Identifier: leizilla-raw-{ente}-{fonte}-{chave} (SCHEMA.md §1.2).
         Análogo a upload_raw mas para fontes que servem HTML (ex: Planalto).
         IA não faz OCR em HTML — Etapa 2 usa fetch_html direto da fonte_url.
+        ``index_cache`` acumula o ``index.csv`` por item dentro de um lote
+        (ver ``_resolve_uuid5_and_index``).
         """
         if not self.access_key or not self.secret_key:
             return {"success": False, "error": "IA credentials not configured"}
@@ -740,6 +765,7 @@ class InternetArchivePublisher:
                 rendicao=rendicao,
                 formato="html",
                 source=source,
+                index_cache=index_cache,
             )
         except IndexFetchError as e:
             return {
@@ -800,6 +826,10 @@ class InternetArchivePublisher:
                 }
             except subprocess.CalledProcessError as e:
                 return {"success": False, "error": e.stderr, "ia_id": ia_id}
+
+        # Upload OK: acumula o índice mesclado para o próximo upload do mesmo lote.
+        if index_cache is not None:
+            index_cache[item_id] = index_csv
 
         return {
             "success": True,

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -25,12 +25,15 @@ def scrape_one(
     lei_data: Dict[str, Any],
     publisher: InternetArchivePublisher,
     rate_limiter: Optional[Callable[[str], None]] = None,
+    index_cache: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Scrape um PDF: robots check → wayback save → fetch → upload_raw.
 
     Retorna dict com 'success' + ('ia_id', 'ia_url') ou ('reason') em falha.
     Robots bloqueado é permanente — caller NÃO deve re-tentar a mesma URL.
     rate_limiter recebe a URL do fallback para tracking por host.
+    ``index_cache`` (acumulador por item do lote) repassa-se ao ``upload_raw``
+    para evitar lost-update do index.csv entre uploads ao mesmo item de range.
     """
     if not robots.is_allowed(fonte_url):
         return {"success": False, "reason": "robots-blocked", "url": fonte_url}
@@ -80,6 +83,7 @@ def scrape_one(
             pdf_bytes,
             fetched_from=fetched_from,
             wayback_url=wb_url,
+            index_cache=index_cache,
         )
     except Exception as exc:
         return {"success": False, "reason": "upload-failed", "error": str(exc)}
@@ -92,12 +96,14 @@ def scrape_one_html(
     lei_data: dict,
     publisher: InternetArchivePublisher,
     rate_limiter: Optional[Callable[[str], None]] = None,
+    index_cache: Optional[Dict[str, str]] = None,
 ) -> dict:
     """Scrape de uma página HTML: robots → wayback save → fetch → upload_raw_html.
 
     Para fontes sem PDF (ex: Planalto federal) que servem HTML compilado vigente.
     Retorna dict com 'success' + ('ia_id', 'ia_url') ou ('reason') em falha.
     Robots bloqueado é permanente — caller NÃO deve re-tentar a mesma URL.
+    ``index_cache`` (acumulador por item do lote) repassa-se ao ``upload_raw_html``.
     """
     if not robots.is_allowed(fonte_url):
         return {"success": False, "reason": "robots-blocked", "url": fonte_url}
@@ -136,6 +142,7 @@ def scrape_one_html(
             lei_data,
             fetched_from=fetched_from,
             wayback_url=wb_url,
+            index_cache=index_cache,
         )
     except Exception as exc:
         return {"success": False, "reason": "upload-failed", "error": str(exc)}
@@ -181,6 +188,10 @@ def harvest_pending_resources(
     pending = storage.get_pending_resources(limit=limit, ente=ente)
     stats = {"success": 0, "failed": 0, "robots-blocked": 0}
     rate_limiter = make_rate_limiter()
+    # Índice acumulado por item de range neste lote: vários recursos do mesmo
+    # (ente, fonte, tipo) caem no mesmo item; sem isto cada upload releria do IA
+    # (sem read-after-write) e sobrescreveria a linha do upload anterior.
+    index_cache: Dict[str, str] = {}
 
     for res in pending:
         url = res["url"]
@@ -243,6 +254,7 @@ def harvest_pending_resources(
                 pdf_bytes,
                 fetched_from=fetched_from,
                 wayback_url=wb_url,
+                index_cache=index_cache,
             )
             if result.get("success"):
                 storage.update_resource_status(

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -12,7 +12,6 @@ from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 from leizilla import robots, wayback
-from leizilla.ia_utils import parse_identity
 from leizilla.parser import fetch_html
 from leizilla.publisher import InternetArchivePublisher
 from leizilla.storage import DuckDBStorage
@@ -180,7 +179,7 @@ def harvest_pending_resources(
     Se `ente` for fornecido, processa apenas recursos desse ente.
     """
     pending = storage.get_pending_resources(limit=limit, ente=ente)
-    stats = {"success": 0, "failed": 0, "robots-blocked": 0, "deferred": 0}
+    stats = {"success": 0, "failed": 0, "robots-blocked": 0}
     rate_limiter = make_rate_limiter()
 
     for res in pending:
@@ -190,14 +189,6 @@ def harvest_pending_resources(
         tipo = res["tipo_documento"]
         chave = res["chave"]
         wb_url = res["wayback_snapshot"]
-
-        # Reject-until-identified (ADR-0011): recursos sem (tipo, número)
-        # normativo — ex. coddoc puro da ALRO — são adiados, não baixados nem
-        # enviados (evita uploads que o gate de upload_raw recusaria).
-        if parse_identity(chave) is None:
-            storage.update_resource_status(url, "deferred")
-            stats["deferred"] += 1
-            continue
 
         # Robots check
         if not robots.is_allowed(url):

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -151,9 +151,16 @@ def make_rate_limiter(min_interval: float = _RATE_LIMIT_S) -> Callable[[str], No
 
     def limiter(url: str) -> None:
         host = urlparse(url).hostname or ""
-        elapsed = time.monotonic() - last.get(host, 0.0)
-        if elapsed < min_interval:
-            time.sleep(min_interval - elapsed)
+        # Primeira batida em um host nunca espera. Usamos um sentinela explícito
+        # (host ausente no dict) em vez de 0.0: o epoch de time.monotonic() é
+        # arbitrário, então `monotonic() - 0.0` pode ser < min_interval logo após
+        # o boot e provocar um sleep espúrio na primeira chamada (hosts distintos
+        # devem permanecer independentes).
+        previous = last.get(host)
+        if previous is not None:
+            elapsed = time.monotonic() - previous
+            if elapsed < min_interval:
+                time.sleep(min_interval - elapsed)
         last[host] = time.monotonic()
 
     return limiter

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 from leizilla import robots, wayback
+from leizilla.ia_utils import parse_identity
 from leizilla.parser import fetch_html
 from leizilla.publisher import InternetArchivePublisher
 from leizilla.storage import DuckDBStorage
@@ -179,7 +180,7 @@ def harvest_pending_resources(
     Se `ente` for fornecido, processa apenas recursos desse ente.
     """
     pending = storage.get_pending_resources(limit=limit, ente=ente)
-    stats = {"success": 0, "failed": 0, "robots-blocked": 0}
+    stats = {"success": 0, "failed": 0, "robots-blocked": 0, "deferred": 0}
     rate_limiter = make_rate_limiter()
 
     for res in pending:
@@ -189,6 +190,14 @@ def harvest_pending_resources(
         tipo = res["tipo_documento"]
         chave = res["chave"]
         wb_url = res["wayback_snapshot"]
+
+        # Reject-until-identified (ADR-0011): recursos sem (tipo, número)
+        # normativo — ex. coddoc puro da ALRO — são adiados, não baixados nem
+        # enviados (evita uploads que o gate de upload_raw recusaria).
+        if parse_identity(chave) is None:
+            storage.update_resource_status(url, "deferred")
+            stats["deferred"] += 1
+            continue
 
         # Robots check
         if not robots.is_allowed(url):

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -233,6 +233,7 @@ def harvest_pending_resources(
             "fonte": fonte,
             "chave": chave,
             "titulo": f"{tipo.upper()} {chave} ({ente.upper()})",
+            "url_original": url,  # proveniência: mapeia o arquivo → fonte (ADR-0010)
         }
 
         try:

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -506,8 +506,10 @@ class TestCmdParseAll:
             "leizilla-raw-federal-planalto-lcp-00002",
         ]
 
-    def test_non_planalto_uses_coddoc_chave(self):
-        """Assembleia usa coddoc-NNNNN (identificador de coddoc sequencial da ALRO)."""
+    def test_assembleia_uses_tipo_chave_like_other_fontes(self):
+        """ADR-0011: assembleia é identity-keyed (tipo+número extraído do título na
+        descoberta), então parse-all sequencial usa {tipo}-NNNNN como qualquer
+        fonte — não mais coddoc."""
         fetched_ids: list[str] = []
 
         def track_ocr(raw_id: str) -> str:
@@ -531,6 +533,8 @@ class TestCmdParseAll:
                     "ro",
                     "--fonte",
                     "assembleia",
+                    "--tipo",
+                    "lei",
                     "--start-coddoc",
                     "5",
                     "--end-coddoc",
@@ -539,8 +543,8 @@ class TestCmdParseAll:
                 ],
             )
         assert fetched_ids == [
-            "leizilla-raw-ro-assembleia-coddoc-00005",
-            "leizilla-raw-ro-assembleia-coddoc-00006",
+            "leizilla-raw-ro-assembleia-lei-00005",
+            "leizilla-raw-ro-assembleia-lei-00006",
         ]
 
     def test_casacivil_uses_tipo_chave(self):
@@ -704,7 +708,7 @@ class TestCmdParseAllSkipExisting:
 
     def test_skip_existing_skips_already_parsed_items(self):
         """Items cujo raw_id está em already_parsed são pulados sem fetch/parse."""
-        raw_id = "leizilla-raw-ro-assembleia-coddoc-00001"
+        raw_id = "leizilla-raw-ro-assembleia-lei-00001"
         with (
             patch(
                 "leizilla.publisher.list_parsed_raw_ids",
@@ -732,8 +736,8 @@ class TestCmdParseAllSkipExisting:
 
     def test_skip_existing_reports_skipped_count_in_summary(self):
         raw_ids = {
-            "leizilla-raw-ro-assembleia-coddoc-00001",
-            "leizilla-raw-ro-assembleia-coddoc-00002",
+            "leizilla-raw-ro-assembleia-lei-00001",
+            "leizilla-raw-ro-assembleia-lei-00002",
         }
         with (
             patch("leizilla.publisher.list_parsed_raw_ids", return_value=raw_ids),
@@ -811,9 +815,9 @@ class TestCmdParseAllSkipExisting:
         to stall after first run (all items in limit window already parsed, 51+ never reached).
         """
         already_parsed = {
-            "leizilla-raw-ro-assembleia-coddoc-00001",
-            "leizilla-raw-ro-assembleia-coddoc-00002",
-            "leizilla-raw-ro-assembleia-coddoc-00003",
+            "leizilla-raw-ro-assembleia-lei-00001",
+            "leizilla-raw-ro-assembleia-lei-00002",
+            "leizilla-raw-ro-assembleia-lei-00003",
         }
         fetched: list[str] = []
 
@@ -844,8 +848,8 @@ class TestCmdParseAllSkipExisting:
         assert result.exit_code == 0
         # items 1-3 skipped; items 4 and 5 are the first 2 non-skipped → fetched
         assert fetched == [
-            "leizilla-raw-ro-assembleia-coddoc-00004",
-            "leizilla-raw-ro-assembleia-coddoc-00005",
+            "leizilla-raw-ro-assembleia-lei-00004",
+            "leizilla-raw-ro-assembleia-lei-00005",
         ]
 
 

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -986,7 +986,7 @@ class TestCmdStats:
         # parsed shown directly, not raw-count subtracted from it
         assert "42" in result.output
         prefixes = [c[0][0] for c in mock_count.call_args_list]
-        assert "leizilla-raw-ro-" in prefixes
+        assert "leizilla_ro_" in prefixes  # raw range items (ADR-0011, underscores)
         assert "leizilla-ro-" in prefixes
         assert "leizilla-dataset-ro-" in prefixes
 
@@ -1008,4 +1008,4 @@ class TestCmdStats:
             result = runner.invoke(app, ["stats"])
         assert result.exit_code == 0
         first_call_prefix = mock_count.call_args_list[0][0][0]
-        assert "leizilla-raw-ro-" == first_call_prefix
+        assert "leizilla_ro_" == first_call_prefix

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -578,6 +578,41 @@ class TestCmdParseAll:
             "leizilla-raw-ro-casacivil-lc-00002",
         ]
 
+    def test_hyphenated_tipo_from_ia_listing_not_skipped(self):
+        """Regression (ADR-0011): list_raw_ids may return a hyphenated tipo such
+        as lei-complementar. cmd_parse_all must preserve the full tipo (not read
+        it as 'complementar' via split('-')[-2]) or it skips every such law.
+        """
+        raw_id = "leizilla-raw-ro-casacivil-lei-complementar-00042"
+        fetched: list[str] = []
+
+        def track_ocr(rid: str) -> str:
+            fetched.append(rid)
+            return None  # type: ignore[return-value]
+
+        with (
+            patch("leizilla.publisher.list_raw_ids", return_value={raw_id}),
+            patch("leizilla.parser.fetch_ocr", side_effect=track_ocr),
+        ):
+            runner.invoke(
+                app,
+                [
+                    "parse-all",
+                    "--ente",
+                    "ro",
+                    "--fonte",
+                    "casacivil",
+                    "--tipo",
+                    "lei-complementar",
+                    "--start-coddoc",
+                    "1",
+                    "--end-coddoc",
+                    "100",
+                    "--no-upload",
+                ],
+            )
+        assert fetched == [raw_id]
+
     def test_invalid_input_type_exits_1(self):
         """Valor inválido para --input-type retorna exit 1 antes de processar qualquer item."""
         with patch("leizilla.parser.fetch_ocr") as mock_ocr:

--- a/tests/test_cli_reconcile.py
+++ b/tests/test_cli_reconcile.py
@@ -44,3 +44,25 @@ def test_reconcile_builds_identity_map_and_calls_publisher():
     identity_map = args[2]
     assert identity_map == {"http://alro/leis/99": ("lei", 99)}
     assert "1 promovidos" in result.output
+
+
+def test_reconcile_exits_nonzero_when_a_fonte_fails():
+    # A failed reconcile (e.g. holding-index rewrite error) must exit nonzero so
+    # automation detects the partial cleanup.
+    resources = [
+        {"url": "http://alro/leis/99", "fonte": "assembleia", "chave": "lei-00099"},
+    ]
+    pub = MagicMock()
+    pub.reconcile_unidentified.return_value = {
+        "success": False,
+        "error": "holding index rewrite failed",
+        "item_id": "leizilla_ro_assembleia_unidentified",
+    }
+    with (
+        patch("leizilla.discovery.discover_resources", return_value=resources),
+        patch("leizilla.publisher.InternetArchivePublisher", return_value=pub),
+    ):
+        result = runner.invoke(app, ["reconcile", "--ente", "ro"])
+
+    assert result.exit_code == 1
+    assert "erro" in result.output.lower()

--- a/tests/test_cli_reconcile.py
+++ b/tests/test_cli_reconcile.py
@@ -1,0 +1,46 @@
+"""CLI wiring for `reconcile`: discovery re-derives identities → publisher promotes."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from leizilla.cli import app
+
+runner = CliRunner()
+
+
+def test_reconcile_builds_identity_map_and_calls_publisher():
+    # Fresh discovery yields one identified (lei-99) and one still-unidentified row.
+    resources = [
+        {
+            "url": "http://alro/leis/99",
+            "fonte": "assembleia",
+            "chave": "lei-00099",
+        },
+        {
+            "url": "http://alro/leis/77",
+            "fonte": "assembleia",
+            "chave": "coddoc-00077",  # non-identifying → not in the map
+        },
+    ]
+    pub = MagicMock()
+    pub.reconcile_unidentified.return_value = {
+        "success": True,
+        "promoted": 1,
+        "remaining": 1,
+        "item_id": "leizilla_ro_assembleia_unidentified",
+    }
+    with (
+        patch("leizilla.discovery.discover_resources", return_value=resources),
+        patch("leizilla.publisher.InternetArchivePublisher", return_value=pub),
+    ):
+        result = runner.invoke(app, ["reconcile", "--ente", "ro"])
+
+    assert result.exit_code == 0
+    # Publisher called once for the assembleia fonte with only the identified URL.
+    pub.reconcile_unidentified.assert_called_once()
+    args = pub.reconcile_unidentified.call_args.args
+    assert args[0] == "ro" and args[1] == "assembleia"
+    identity_map = args[2]
+    assert identity_map == {"http://alro/leis/99": ("lei", 99)}
+    assert "1 promovidos" in result.output

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -39,6 +39,14 @@ class TestParseTituloIdentity:
     def test_no_number_returns_none(self):
         assert parse_titulo_identity("Lei sem número identificável") is None
 
+    def test_year_word_is_not_mistaken_for_number(self):
+        # The "n" in "ano"/"no" before a year must NOT anchor a número — these
+        # titles lack a real ordinal marker, so they're unidentified (preserved),
+        # not catalogued under a fabricated number equal to the year.
+        assert parse_titulo_identity("RESOLUÇÃO ADMINISTRATIVA - ANO 2020") is None
+        assert parse_titulo_identity("LEI QUE DISPÕE NO ÂMBITO, DE 2021") is None
+        assert parse_titulo_identity("Portaria do ano 2019 sobre x") is None
+
     def test_no_tipo_returns_none(self):
         assert parse_titulo_identity("Documento avulso nº 123") is None
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,36 @@
+"""Tests for crawler pure helpers (no network/Playwright)."""
+
+from leizilla.crawler import parse_titulo_identity
+
+
+class TestParseTituloIdentity:
+    def test_lei_ordinaria(self):
+        assert parse_titulo_identity("LEI Nº 5.120, DE 22 DE JUNHO DE 1999") == (
+            "lei",
+            5120,
+        )
+
+    def test_lei_complementar_before_lei(self):
+        assert parse_titulo_identity("LEI COMPLEMENTAR Nº 42, DE 2001") == ("lc", 42)
+
+    def test_decreto(self):
+        assert parse_titulo_identity("DECRETO Nº 1.234, DE 2010") == ("decreto", 1234)
+
+    def test_decreto_lei_before_decreto(self):
+        assert parse_titulo_identity("DECRETO-LEI Nº 99") == ("decreto-lei", 99)
+
+    def test_resolucao_accented(self):
+        assert parse_titulo_identity("Resolução nº 7, de 2020") == ("resolucao", 7)
+
+    def test_number_anchored_to_n_not_year(self):
+        # The year (1999) must not be mistaken for the law number.
+        assert parse_titulo_identity("Lei nº 5120, de 1999") == ("lei", 5120)
+
+    def test_no_number_returns_none(self):
+        assert parse_titulo_identity("Lei sem número identificável") is None
+
+    def test_no_tipo_returns_none(self):
+        assert parse_titulo_identity("Documento avulso nº 123") is None
+
+    def test_empty_returns_none(self):
+        assert parse_titulo_identity("") is None

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -22,6 +22,16 @@ class TestParseTituloIdentity:
     def test_resolucao_accented(self):
         assert parse_titulo_identity("Resolução nº 7, de 2020") == ("resolucao", 7)
 
+    def test_n_dot_ordinal_abbreviation(self):
+        # "N.º" (dot + ordinal marker) is common on ALRO; must not fall back.
+        assert parse_titulo_identity("LEI N.º 6.084, DE 12 DE JANEIRO DE 2000") == (
+            "lei",
+            6084,
+        )
+
+    def test_n_dot_only(self):
+        assert parse_titulo_identity("Decreto n. 1.234") == ("decreto", 1234)
+
     def test_number_anchored_to_n_not_year(self):
         # The year (1999) must not be mistaken for the law number.
         assert parse_titulo_identity("Lei nº 5120, de 1999") == ("lei", 5120)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -110,6 +110,41 @@ def test_wayback_cdx_discovery():
     )
 
 
+def test_sequential_discovery_skips_unidentifiable():
+    # ADR-0011: filenames that don't yield (tipo, número) are not enqueued, so a
+    # later pass that can identify them re-evaluates fresh (no stuck rows).
+    config = {
+        "strategy": "sequential",
+        "templates": ["http://example.com/page{num}.pdf"],
+        "start": 1,
+        "end": 3,
+    }
+    resources = SequentialDiscovery(config, "ro", "casacivil").run()
+    assert resources == []
+
+
+def test_wayback_cdx_skips_unidentifiable_filenames():
+    config = {"strategy": "wayback-cdx", "prefix": "http://example.com/Files/"}
+    cdx_response = [
+        ["urlkey", "timestamp", "original", "mimetype", "statuscode", "digest", "len"],
+        [
+            "com,example)/files/relatorio.pdf",
+            "20220824115429",
+            "http://example.com/Files/relatorio_anual.pdf",
+            "application/pdf",
+            "200",
+            "DIGEST",
+            "1234",
+        ],
+    ]
+    mock_resp = MagicMock()
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.read.return_value = json.dumps(cdx_response).encode("utf-8")
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        resources = WaybackCdxDiscovery(config, "ro", "casacivil").run()
+    assert resources == []
+
+
 @pytest.fixture
 def temp_db(tmp_path):
     db_path = tmp_path / "test.duckdb"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -110,9 +110,10 @@ def test_wayback_cdx_discovery():
     )
 
 
-def test_sequential_discovery_skips_unidentifiable():
-    # ADR-0011: filenames that don't yield (tipo, número) are not enqueued, so a
-    # later pass that can identify them re-evaluates fresh (no stuck rows).
+def test_sequential_discovery_captures_unidentifiable():
+    # ADR-0011 §1: filenames that don't yield (tipo, número) are still CAPTURED
+    # (preserved, not discarded) — tipo unknown (""), chave = harvest key — so the
+    # upload routes them to the _unidentified holding area.
     config = {
         "strategy": "sequential",
         "templates": ["http://example.com/page{num}.pdf"],
@@ -120,10 +121,12 @@ def test_sequential_discovery_skips_unidentifiable():
         "end": 3,
     }
     resources = SequentialDiscovery(config, "ro", "casacivil").run()
-    assert resources == []
+    assert len(resources) == 3
+    assert resources[0]["tipo_documento"] == ""
+    assert resources[0]["chave"] == "page1"  # harvest key, non-identifying
 
 
-def test_wayback_cdx_skips_unidentifiable_filenames():
+def test_wayback_cdx_captures_unidentifiable_filenames():
     config = {"strategy": "wayback-cdx", "prefix": "http://example.com/Files/"}
     cdx_response = [
         ["urlkey", "timestamp", "original", "mimetype", "statuscode", "digest", "len"],
@@ -142,7 +145,9 @@ def test_wayback_cdx_skips_unidentifiable_filenames():
     mock_resp.read.return_value = json.dumps(cdx_response).encode("utf-8")
     with patch("urllib.request.urlopen", return_value=mock_resp):
         resources = WaybackCdxDiscovery(config, "ro", "casacivil").run()
-    assert resources == []
+    assert len(resources) == 1
+    assert resources[0]["tipo_documento"] == ""
+    assert resources[0]["chave"] == "relatorio_anual"  # harvest key, preserved
 
 
 @pytest.fixture

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -13,6 +13,7 @@ from leizilla.discovery import (
     parse_filename,
     run_discovery,
 )
+from leizilla.ia_utils import parse_identity
 
 
 def test_parse_filename():
@@ -123,7 +124,10 @@ def test_sequential_discovery_captures_unidentifiable():
     resources = SequentialDiscovery(config, "ro", "casacivil").run()
     assert len(resources) == 3
     assert resources[0]["tipo_documento"] == ""
-    assert resources[0]["chave"] == "page1"  # harvest key, non-identifying
+    # harvest key preserved under a non-identifying prefix so it can never be
+    # mis-promoted to a navigable range (parse_identity must return None).
+    assert resources[0]["chave"] == "documento-page1"
+    assert parse_identity(resources[0]["chave"]) is None
 
 
 def test_wayback_cdx_captures_unidentifiable_filenames():
@@ -147,7 +151,34 @@ def test_wayback_cdx_captures_unidentifiable_filenames():
         resources = WaybackCdxDiscovery(config, "ro", "casacivil").run()
     assert len(resources) == 1
     assert resources[0]["tipo_documento"] == ""
-    assert resources[0]["chave"] == "relatorio_anual"  # harvest key, preserved
+    assert resources[0]["chave"] == "documento-relatorio_anual"
+    assert parse_identity(resources[0]["chave"]) is None
+
+
+def test_wayback_cdx_word_digit_stem_stays_unidentified():
+    # Regression: a fallback stem shaped "{letters}-{digits}" (e.g. oficio-123)
+    # must NOT satisfy parse_identity — otherwise it would be promoted to a bogus
+    # navigable range (oficio_0001-1000) instead of the _unidentified holding.
+    config = {"strategy": "wayback-cdx", "prefix": "http://example.com/Files/"}
+    cdx_response = [
+        ["urlkey", "timestamp", "original", "mimetype", "statuscode", "digest", "len"],
+        [
+            "com,example)/files/oficio-123.pdf",
+            "20220824115429",
+            "http://example.com/Files/oficio-123.pdf",
+            "application/pdf",
+            "200",
+            "DIGEST",
+            "1234",
+        ],
+    ]
+    mock_resp = MagicMock()
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.read.return_value = json.dumps(cdx_response).encode("utf-8")
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        resources = WaybackCdxDiscovery(config, "ro", "casacivil").run()
+    assert resources[0]["chave"] == "documento-oficio-123"
+    assert parse_identity(resources[0]["chave"]) is None
 
 
 @pytest.fixture

--- a/tests/test_harvest_pipeline.py
+++ b/tests/test_harvest_pipeline.py
@@ -277,24 +277,6 @@ class TestHarvestPendingResources:
         assert stats["success"] == 1
         pub.upload_raw.assert_called_once()
 
-    def test_unidentified_resource_is_deferred(self, temp_db: DuckDBStorage) -> None:
-        # ADR-0011: a resource without a normative (tipo, número) — e.g. ALRO's
-        # bare coddoc — is deferred, never downloaded or uploaded.
-        from leizilla.scraper import harvest_pending_resources
-
-        temp_db.insert_resource(
-            _make_resource(
-                url="http://x/coddoc.pdf", fonte="assembleia", chave="coddoc-00007"
-            )
-        )
-        pub = MagicMock()
-        with patch("leizilla.scraper.robots.is_allowed", return_value=True):
-            stats = harvest_pending_resources(temp_db, pub, limit=10)
-
-        assert stats["deferred"] == 1
-        assert stats["success"] == 0
-        pub.upload_raw.assert_not_called()
-
     def test_limit_respected(self, temp_db: DuckDBStorage) -> None:
         from leizilla.scraper import harvest_pending_resources
 

--- a/tests/test_harvest_pipeline.py
+++ b/tests/test_harvest_pipeline.py
@@ -277,6 +277,24 @@ class TestHarvestPendingResources:
         assert stats["success"] == 1
         pub.upload_raw.assert_called_once()
 
+    def test_unidentified_resource_is_deferred(self, temp_db: DuckDBStorage) -> None:
+        # ADR-0011: a resource without a normative (tipo, número) — e.g. ALRO's
+        # bare coddoc — is deferred, never downloaded or uploaded.
+        from leizilla.scraper import harvest_pending_resources
+
+        temp_db.insert_resource(
+            _make_resource(
+                url="http://x/coddoc.pdf", fonte="assembleia", chave="coddoc-00007"
+            )
+        )
+        pub = MagicMock()
+        with patch("leizilla.scraper.robots.is_allowed", return_value=True):
+            stats = harvest_pending_resources(temp_db, pub, limit=10)
+
+        assert stats["deferred"] == 1
+        assert stats["success"] == 0
+        pub.upload_raw.assert_not_called()
+
     def test_limit_respected(self, temp_db: DuckDBStorage) -> None:
         from leizilla.scraper import harvest_pending_resources
 

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -159,6 +159,17 @@ class TestMergeIndexRow:
         assert second == first  # truly no-op: unchanged bytes → unchanged CSV
         assert "2026-05-31" not in second
 
+    def test_records_source_provenance(self):
+        # ADR-0010: the manifest maps each file back to its harvest source — this
+        # is what lets identity drop coddoc without losing traceability.
+        csv_out = self._row(None, source="http://alro.ro.gov.br/legislacao/leis/7")
+        assert "source" in INDEX_COLUMNS
+        assert (
+            csv_out.strip()
+            .splitlines()[1]
+            .endswith(",http://alro.ro.gov.br/legislacao/leis/7")
+        )
+
 
 class TestUuid5Collision:
     def test_detects_same_name_different_bytes(self):

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -210,7 +210,7 @@ class TestMergeIndexRow:
 
 
 class TestRemoveIndexRows:
-    def test_drops_named_uuid5_keeps_others(self):
+    def test_drops_named_key_keeps_others(self):
         from leizilla.ia_utils import remove_index_rows
 
         idx = merge_index_row(
@@ -221,6 +221,7 @@ class TestRemoveIndexRows:
             formato="pdf",
             uuid5="keep1",
             sha256="h1",
+            source="srcA",
         )
         idx = merge_index_row(
             idx,
@@ -230,11 +231,42 @@ class TestRemoveIndexRows:
             formato="pdf",
             uuid5="drop1",
             sha256="h2",
+            source="srcB",
         )
-        out = remove_index_rows(idx, {"drop1"})
+        out = remove_index_rows(idx, {("drop1", "srcB")})
         assert "drop1" not in out
         assert "keep1" in out
         assert out.splitlines()[0] == ",".join(INDEX_COLUMNS)  # header intact
+        assert len(out.strip().splitlines()) == 2  # header + 1 kept row
+
+    def test_same_uuid5_different_source_only_drops_matched(self):
+        # Aliased rows (same bytes/uuid5, different source): removing one (uuid5,
+        # source) must NOT delete the other alias.
+        from leizilla.ia_utils import remove_index_rows
+
+        idx = merge_index_row(
+            None,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="u1",
+            sha256="hsame",
+            source="srcA",
+        )
+        idx = merge_index_row(
+            idx,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="u1",
+            sha256="hsame",
+            source="srcB",
+        )
+        out = remove_index_rows(idx, {("u1", "srcA")})
+        assert "srcA" not in out
+        assert "srcB" in out  # the still-unidentified alias survives
         assert len(out.strip().splitlines()) == 2  # header + 1 kept row
 
 

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -58,6 +58,15 @@ class TestParseIdentity:
         assert parse_identity("seq-00042") is None
         assert parse_identity("fallback-foo") is None
 
+    def test_non_identifying_first_segment_rejected(self):
+        # A fallback chave keeps the harvest stem after a non-identifying prefix;
+        # the leading segment must veto identity even though the regex tipo group
+        # greedily spans hyphens (else "documento-oficio-123" → bogus tipo).
+        assert parse_identity("documento-oficio-123") is None
+        assert parse_identity("documento-page1") is None
+        # ...but a genuine hyphenated tipo whose first segment is identifying stays.
+        assert parse_identity("lei-complementar-00042") == ("lei-complementar", 42)
+
     def test_non_numeric_returns_none(self):
         assert parse_identity("documento") is None
         assert parse_identity("lei-abc") is None

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -1,4 +1,4 @@
-"""Tests for the content-addressed raw layer utilities (ADR-0010)."""
+"""Tests for the identity-keyed raw layer utilities (ADR-0011)."""
 
 from unittest.mock import patch
 
@@ -6,13 +6,17 @@ from leizilla.ia_utils import (
     INDEX_COLUMNS,
     compute_hash,
     download_url,
-    lookup_current_hash,
+    list_identities,
+    lookup_current,
     merge_index_row,
+    parse_identity,
     parse_raw_id,
+    range_bounds,
+    range_item_identifier,
     raw_filename,
-    raw_index_identifier,
-    raw_range_identifier,
     resolve_raw_url,
+    uuid5_collision,
+    uuid5_name,
 )
 
 
@@ -27,33 +31,56 @@ class TestComputeHash:
         assert compute_hash(b"a") != compute_hash(b"b")
 
 
+class TestUuid5Name:
+    def test_deterministic_and_truncated(self):
+        name = uuid5_name(b"PDF bytes")
+        assert name == uuid5_name(b"PDF bytes")
+        assert len(name) == 8
+
+    def test_distinct_bytes_distinct_name(self):
+        assert uuid5_name(b"a") != uuid5_name(b"b")
+
+    def test_custom_length(self):
+        assert len(uuid5_name(b"x", length=32)) == 32
+
+
+class TestParseIdentity:
+    def test_extracts_tipo_and_numero(self):
+        assert parse_identity("lei-05120") == ("lei", 5120)
+
+    def test_hyphenated_tipo(self):
+        assert parse_identity("lei-complementar-00042") == ("lei-complementar", 42)
+
+    def test_coddoc_is_not_identifying(self):
+        assert parse_identity("coddoc-00099") is None
+
+    def test_seq_and_fallback_not_identifying(self):
+        assert parse_identity("seq-00042") is None
+        assert parse_identity("fallback-foo") is None
+
+    def test_non_numeric_returns_none(self):
+        assert parse_identity("documento") is None
+        assert parse_identity("lei-abc") is None
+
+
 class TestParseRawId:
     def test_simple_ente(self):
-        assert parse_raw_id("leizilla-raw-ro-casacivil-coddoc-05120") == (
+        assert parse_raw_id("leizilla-raw-ro-casacivil-lei-05120") == (
             "ro",
             "casacivil",
-            "coddoc-05120",
+            "lei-05120",
         )
 
     def test_hyphenated_ente_longest_match(self):
-        # When a hyphenated municipal slug is in the catalog, longest-match must
-        # pick it over the bare state slug (ro-porto-velho before ro).
         with patch(
             "leizilla.ia_utils.list_slugs",
             return_value=["ro", "ro-porto-velho", "federal"],
         ):
-            assert parse_raw_id("leizilla-raw-ro-porto-velho-camara-doc-7") == (
+            assert parse_raw_id("leizilla-raw-ro-porto-velho-camara-lei-7") == (
                 "ro-porto-velho",
                 "camara",
-                "doc-7",
+                "lei-7",
             )
-
-    def test_source_key_may_contain_hyphens(self):
-        assert parse_raw_id("leizilla-raw-federal-planalto-lei-complementar-42") == (
-            "federal",
-            "planalto",
-            "lei-complementar-42",
-        )
 
     def test_non_raw_id_returns_none(self):
         assert parse_raw_id("external-archive-item") is None
@@ -61,32 +88,32 @@ class TestParseRawId:
     def test_unknown_ente_returns_none(self):
         assert parse_raw_id("leizilla-raw-xx-fonte-key") is None
 
-    def test_missing_source_key_returns_none(self):
+    def test_missing_chave_returns_none(self):
         assert parse_raw_id("leizilla-raw-ro-casacivil") is None
 
 
-class TestIdentifiers:
-    def test_index_identifier(self):
+class TestRanges:
+    def test_range_bounds(self):
+        assert range_bounds(5120) == (5001, 6000)
+        assert range_bounds(1) == (1, 1000)
+        assert range_bounds(1000) == (1, 1000)
+        assert range_bounds(1001) == (1001, 2000)
+
+    def test_range_item_identifier(self):
         assert (
-            raw_index_identifier("ro", "casacivil") == "leizilla-raw-ro-casacivil-index"
+            range_item_identifier("ro", "casacivil", "lei", 5120)
+            == "leizilla_ro_casacivil_lei_5001-6000"
         )
 
-    def test_range_identifier_buckets_by_hash_prefix(self):
-        h = "3f8a" + "0" * 60
+    def test_range_item_identifier_lowercases_and_keeps_hyphen_in_tipo(self):
         assert (
-            raw_range_identifier("ro", "casacivil", h) == "leizilla-raw-ro-casacivil-3f"
+            range_item_identifier("RO", "CasaCivil", "lei-complementar", 42)
+            == "leizilla_ro_casacivil_lei-complementar_0001-1000"
         )
 
-    def test_range_identifier_lowercases(self):
-        h = "AB" + "0" * 62
-        assert (
-            raw_range_identifier("RO", "CasaCivil", h) == "leizilla-raw-ro-casacivil-ab"
-        )
-
-    def test_raw_filename_is_content_addressed(self):
-        h = "3f8a" + "0" * 60
-        assert raw_filename(h, ".pdf") == f"{h}.pdf"
-        assert raw_filename(h, "_djvu.txt") == f"{h}_djvu.txt"
+    def test_raw_filename(self):
+        assert raw_filename("a1b2c3d4", ".pdf") == "a1b2c3d4.pdf"
+        assert raw_filename("a1b2c3d4", "_djvu.txt") == "a1b2c3d4_djvu.txt"
 
     def test_download_url(self):
         assert (
@@ -96,154 +123,132 @@ class TestIdentifiers:
 
 
 class TestMergeIndexRow:
-    def test_creates_header_and_row(self):
-        csv_out = merge_index_row(
-            None,
-            source_key="coddoc-05120",
-            content_hash="abc",
-            content_type="application/pdf",
-            source_url="http://src/1",
+    def _row(self, existing, **kw):
+        defaults = dict(
+            tipo="lei",
+            numero=5120,
+            rendicao="",
+            formato="pdf",
+            uuid5="aaaa1111",
+            sha256="h1",
             captured_at="2026-05-30T00:00:00+00:00",
         )
+        defaults.update(kw)
+        return merge_index_row(existing, **defaults)
+
+    def test_creates_header_and_row(self):
+        csv_out = self._row(None)
         lines = csv_out.strip().splitlines()
         assert lines[0] == ",".join(INDEX_COLUMNS)
-        assert lines[1].startswith("coddoc-05120,abc,application/pdf,http://src/1,")
+        assert lines[1].startswith("lei,5120,,pdf,aaaa1111,h1,")
 
     def test_append_only_keeps_history(self):
-        first = merge_index_row(
-            None,
-            source_key="coddoc-1",
-            content_hash="h1",
-            content_type="application/pdf",
-            source_url="http://src/1",
-            captured_at="2026-05-30T00:00:00+00:00",
-        )
-        second = merge_index_row(
+        first = self._row(None)
+        second = self._row(
             first,
-            source_key="coddoc-1",
-            content_hash="h2",
-            content_type="application/pdf",
-            source_url="http://src/1",
+            uuid5="bbbb2222",
+            sha256="h2",
             captured_at="2026-05-31T00:00:00+00:00",
         )
-        rows = [ln for ln in second.strip().splitlines()[1:]]
-        assert len(rows) == 2  # both captures retained
+        rows = second.strip().splitlines()[1:]
+        assert len(rows) == 2
 
-    def test_idempotent_same_key_and_hash(self):
-        first = merge_index_row(
-            None,
-            source_key="coddoc-1",
-            content_hash="h1",
-            content_type="application/pdf",
-            source_url="http://src/1",
-            captured_at="2026-05-30T00:00:00+00:00",
-        )
-        second = merge_index_row(
-            first,
-            source_key="coddoc-1",
-            content_hash="h1",
-            content_type="application/pdf",
-            source_url="http://src/1",
-            captured_at="2026-05-31T00:00:00+00:00",
-        )
-        rows = [ln for ln in second.strip().splitlines()[1:]]
-        assert len(rows) == 1  # re-crawl, identical bytes → no duplicate
-
-    def test_idempotent_preserves_original_captured_at(self):
-        # A re-crawl of unchanged bytes must NOT rewrite the provenance timestamp.
-        # Re-appending with a newer captured_at would also push the row to the end,
-        # making lookup_current_hash see it as "newer" and silently rolling back any
-        # capture that was added between the two crawls.
-        first = merge_index_row(
-            None,
-            source_key="coddoc-1",
-            content_hash="h1",
-            content_type="application/pdf",
-            source_url="http://src/1",
-            captured_at="2026-05-30T00:00:00+00:00",
-        )
-        second = merge_index_row(
-            first,
-            source_key="coddoc-1",
-            content_hash="h1",
-            content_type="application/pdf",
-            source_url="http://src/1",
-            captured_at="2026-05-31T00:00:00+00:00",  # newer timestamp must be ignored
-        )
-        assert second == first  # truly no-op: CSV unchanged
-        assert "2026-05-30T00:00:00+00:00" in second
-        assert "2026-05-31T00:00:00+00:00" not in second
+    def test_idempotent_same_identity_and_bytes(self):
+        first = self._row(None)
+        second = self._row(first, captured_at="2026-05-31T00:00:00+00:00")
+        assert second == first  # truly no-op: unchanged bytes → unchanged CSV
+        assert "2026-05-31" not in second
 
 
-class TestLookupCurrentHash:
-    def _two_version_index(self) -> str:
+class TestUuid5Collision:
+    def test_detects_same_name_different_bytes(self):
         idx = merge_index_row(
             None,
-            source_key="coddoc-1",
-            content_hash="h1",
-            content_type="application/pdf",
-            source_url="http://src/1",
+            tipo="lei",
+            numero=5120,
+            rendicao="",
+            formato="pdf",
+            uuid5="dup",
+            sha256="h1",
+        )
+        assert uuid5_collision(idx, uuid5="dup", sha256="h2") is True
+        assert uuid5_collision(idx, uuid5="dup", sha256="h1") is False
+        assert uuid5_collision(idx, uuid5="other", sha256="h2") is False
+
+
+class TestLookupCurrent:
+    def _mixed_index(self) -> str:
+        idx = merge_index_row(
+            None,
+            tipo="lc",
+            numero=42,
+            rendicao="original",
+            formato="pdf",
+            uuid5="pdf1",
+            sha256="hpdf",
             captured_at="2026-05-30T00:00:00+00:00",
         )
         return merge_index_row(
             idx,
-            source_key="coddoc-1",
-            content_hash="h2",
-            content_type="application/pdf",
-            source_url="http://src/1",
-            captured_at="2026-05-31T00:00:00+00:00",
+            tipo="lc",
+            numero=42,
+            rendicao="atual",
+            formato="html",
+            uuid5="html1",
+            sha256="hhtml",
+            captured_at="2026-05-30T01:00:00+00:00",
         )
 
-    def test_returns_latest_capture(self):
-        idx = self._two_version_index()
-        assert lookup_current_hash(idx, "coddoc-1") == ("h2", "application/pdf")
+    def test_returns_latest_for_identity(self):
+        idx = self._mixed_index()
+        # No filter → last-appended matching row (html).
+        assert lookup_current(idx, "lc", 42)["uuid5"] == "html1"
 
-    def test_missing_key_returns_none(self):
-        idx = self._two_version_index()
-        assert lookup_current_hash(idx, "coddoc-999") is None
+    def test_formato_filter(self):
+        idx = self._mixed_index()
+        assert lookup_current(idx, "lc", 42, formato="pdf")["uuid5"] == "pdf1"
+        assert lookup_current(idx, "lc", 42, formato="html")["uuid5"] == "html1"
 
-    def test_content_type_filter_picks_correct_component(self):
-        # Same source_key has a PDF row and an HTML row.
-        pdf_hash = "pdf_hash"
-        html_hash = "html_hash"
+    def test_rendicao_filter(self):
+        idx = self._mixed_index()
+        assert lookup_current(idx, "lc", 42, rendicao="original")["uuid5"] == "pdf1"
+
+    def test_missing_returns_none(self):
+        idx = self._mixed_index()
+        assert lookup_current(idx, "lc", 999) is None
+        assert lookup_current(idx, "lc", 42, formato="docx") is None
+
+
+class TestListIdentities:
+    def test_distinct_tipo_numero_keys(self):
         idx = merge_index_row(
             None,
-            source_key="lc-00042",
-            content_hash=pdf_hash,
-            content_type="application/pdf",
-            source_url="http://src/pdf",
-            captured_at="2026-05-30T00:00:00+00:00",
+            tipo="lei",
+            numero=5120,
+            rendicao="",
+            formato="pdf",
+            uuid5="a",
+            sha256="h1",
         )
         idx = merge_index_row(
             idx,
-            source_key="lc-00042",
-            content_hash=html_hash,
-            content_type="text/html",
-            source_url="http://src/html",
-            captured_at="2026-05-30T01:00:00+00:00",
+            tipo="lei",
+            numero=5120,
+            rendicao="atual",
+            formato="html",
+            uuid5="b",
+            sha256="h2",
         )
-        # Without filter, returns last-appended row (HTML).
-        assert lookup_current_hash(idx, "lc-00042") == (html_hash, "text/html")
-        # With filter, each component resolves independently.
-        assert lookup_current_hash(idx, "lc-00042", "application/pdf") == (
-            pdf_hash,
-            "application/pdf",
-        )
-        assert lookup_current_hash(idx, "lc-00042", "text/html") == (
-            html_hash,
-            "text/html",
-        )
-
-    def test_content_type_filter_returns_none_when_type_absent(self):
         idx = merge_index_row(
-            None,
-            source_key="lc-00042",
-            content_hash="h1",
-            content_type="application/pdf",
-            source_url="http://src/1",
+            idx,
+            tipo="lc",
+            numero=42,
+            rendicao="",
+            formato="pdf",
+            uuid5="c",
+            sha256="h3",
         )
-        # Requesting HTML for a source that only has a PDF entry → None.
-        assert lookup_current_hash(idx, "lc-00042", "text/html") is None
+        assert list_identities(idx) == {"lei-05120", "lc-00042"}
 
 
 class TestResolveRawUrl:
@@ -253,62 +258,69 @@ class TestResolveRawUrl:
             == "https://archive.org/download/external-archive-item/external-archive-item_djvu.txt"
         )
 
-    def test_resolves_via_index_to_content_addressed_url(self):
-        content_hash = "3f8a" + "0" * 60
-        index_csv = merge_index_row(
-            None,
-            source_key="coddoc-05120",
-            content_hash=content_hash,
-            content_type="application/pdf",
-            source_url="http://src/1",
+    def test_unidentified_chave_returns_none(self):
+        # coddoc is not an identity → not in the collection, regardless of index.
+        assert (
+            resolve_raw_url("leizilla-raw-ro-assembleia-coddoc-00099", ".pdf") is None
         )
-        with patch("leizilla.ia_utils._fetch_text", return_value=index_csv):
-            url = resolve_raw_url("leizilla-raw-ro-casacivil-coddoc-05120", "_djvu.txt")
+
+    def test_resolves_via_index_to_uuid5_url(self):
+        idx = merge_index_row(
+            None,
+            tipo="lei",
+            numero=5120,
+            rendicao="",
+            formato="pdf",
+            uuid5="a1b2c3d4",
+            sha256="h1",
+        )
+        with patch("leizilla.ia_utils._fetch_text", return_value=idx):
+            url = resolve_raw_url("leizilla-raw-ro-casacivil-lei-05120", "_djvu.txt")
         assert url == (
             "https://archive.org/download/"
-            "leizilla-raw-ro-casacivil-3f/"
-            f"{content_hash}_djvu.txt"
+            "leizilla_ro_casacivil_lei_5001-6000/a1b2c3d4_djvu.txt"
         )
 
     def test_no_index_yet_returns_none(self):
         with patch("leizilla.ia_utils._fetch_text", return_value=None):
-            assert resolve_raw_url("leizilla-raw-ro-casacivil-coddoc-1", ".pdf") is None
+            assert resolve_raw_url("leizilla-raw-ro-casacivil-lei-1", ".pdf") is None
 
-    def test_source_key_not_in_index_returns_none(self):
-        index_csv = merge_index_row(
-            None,
-            source_key="coddoc-OTHER",
-            content_hash="h1",
-            content_type="application/pdf",
-            source_url="http://src/1",
-        )
-        with patch("leizilla.ia_utils._fetch_text", return_value=index_csv):
-            assert resolve_raw_url("leizilla-raw-ro-casacivil-coddoc-1", ".pdf") is None
-
-    def test_suffix_content_type_filters_mixed_components(self):
-        # source_key has both PDF and HTML components; suffix drives which hash is used.
-        pdf_hash = "aa" + "0" * 62
-        html_hash = "bb" + "0" * 62
+    def test_identity_not_in_index_returns_none(self):
         idx = merge_index_row(
             None,
-            source_key="lc-00042",
-            content_hash=pdf_hash,
-            content_type="application/pdf",
-            source_url="http://src/pdf",
+            tipo="lei",
+            numero=999,
+            rendicao="",
+            formato="pdf",
+            uuid5="x",
+            sha256="h1",
+        )
+        with patch("leizilla.ia_utils._fetch_text", return_value=idx):
+            assert resolve_raw_url("leizilla-raw-ro-casacivil-lei-1", ".pdf") is None
+
+    def test_suffix_formato_filters_mixed_components(self):
+        idx = merge_index_row(
+            None,
+            tipo="lc",
+            numero=42,
+            rendicao="original",
+            formato="pdf",
+            uuid5="pdf1",
+            sha256="hpdf",
         )
         idx = merge_index_row(
             idx,
-            source_key="lc-00042",
-            content_hash=html_hash,
-            content_type="text/html",
-            source_url="http://src/html",
+            tipo="lc",
+            numero=42,
+            rendicao="atual",
+            formato="html",
+            uuid5="html1",
+            sha256="hhtml",
         )
         ia_id = "leizilla-raw-ro-casacivil-lc-00042"
         with patch("leizilla.ia_utils._fetch_text", return_value=idx):
-            # OCR suffix → PDF hash (IA derives djvu.txt from the PDF)
             ocr_url = resolve_raw_url(ia_id, "_djvu.txt")
-            assert ocr_url and f"{pdf_hash}_djvu.txt" in ocr_url
+            assert ocr_url and "pdf1_djvu.txt" in ocr_url
         with patch("leizilla.ia_utils._fetch_text", return_value=idx):
-            # .html suffix → HTML hash
             html_url = resolve_raw_url(ia_id, ".html")
-            assert html_url and f"{html_hash}.html" in html_url
+            assert html_url and "html1.html" in html_url

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -171,6 +171,35 @@ class TestMergeIndexRow:
         )
 
 
+class TestRemoveIndexRows:
+    def test_drops_named_uuid5_keeps_others(self):
+        from leizilla.ia_utils import remove_index_rows
+
+        idx = merge_index_row(
+            None,
+            tipo="lei",
+            numero=5120,
+            rendicao="",
+            formato="pdf",
+            uuid5="keep1",
+            sha256="h1",
+        )
+        idx = merge_index_row(
+            idx,
+            tipo="lei",
+            numero=5121,
+            rendicao="",
+            formato="pdf",
+            uuid5="drop1",
+            sha256="h2",
+        )
+        out = remove_index_rows(idx, {"drop1"})
+        assert "drop1" not in out
+        assert "keep1" in out
+        assert out.splitlines()[0] == ",".join(INDEX_COLUMNS)  # header intact
+        assert len(out.strip().splitlines()) == 2  # header + 1 kept row
+
+
 class TestUuid5Collision:
     def test_detects_same_name_different_bytes(self):
         idx = merge_index_row(

--- a/tests/test_ia_utils.py
+++ b/tests/test_ia_utils.py
@@ -170,6 +170,44 @@ class TestMergeIndexRow:
             .endswith(",http://alro.ro.gov.br/legislacao/leis/7")
         )
 
+    def test_unidentified_same_bytes_different_source_coexist(self):
+        # Holding area: identical bytes from two different source URLs must yield
+        # two rows (reconcile keys by source) — not deduped to one.
+        idx = merge_index_row(
+            None,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="u1",
+            sha256="hsame",
+            source="http://alro/leis/7",
+        )
+        idx = merge_index_row(
+            idx,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="u1",
+            sha256="hsame",
+            source="http://alro/leis/8",  # same bytes, different source
+        )
+        rows = idx.strip().splitlines()[1:]
+        assert len(rows) == 2
+        # But re-appending the *same* source+bytes is still a no-op.
+        idx2 = merge_index_row(
+            idx,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="u1",
+            sha256="hsame",
+            source="http://alro/leis/8",
+        )
+        assert idx2 == idx
+
 
 class TestRemoveIndexRows:
     def test_drops_named_uuid5_keeps_others(self):

--- a/tests/test_planalto_pipeline.py
+++ b/tests/test_planalto_pipeline.py
@@ -331,10 +331,7 @@ class TestUploadRawHtml:
         mock_result = MagicMock(returncode=0, stdout="", stderr="")
         with (
             patch("subprocess.run", return_value=mock_result),
-            patch(
-                "leizilla.publisher.update_raw_index",
-                return_value={"success": True},
-            ),
+            patch("leizilla.publisher._fetch_existing_index", return_value=None),
         ):
             result = pub.upload_raw_html("<html>lei</html>", _lei_data_html())
         assert result["success"] is True
@@ -352,14 +349,20 @@ class TestUploadRawHtml:
     def test_subprocess_failure_returns_error(self) -> None:
         pub = _publisher()
         err = subprocess.CalledProcessError(1, "ia", stderr="quota exceeded")
-        with patch("subprocess.run", side_effect=err):
+        with (
+            patch("leizilla.publisher._fetch_existing_index", return_value=None),
+            patch("subprocess.run", side_effect=err),
+        ):
             result = pub.upload_raw_html("<html/>", _lei_data_html())
         assert result["success"] is False
         assert "quota exceeded" in result["error"]
 
     def test_missing_ia_cli_returns_error(self) -> None:
         pub = _publisher()
-        with patch("subprocess.run", side_effect=FileNotFoundError):
+        with (
+            patch("leizilla.publisher._fetch_existing_index", return_value=None),
+            patch("subprocess.run", side_effect=FileNotFoundError),
+        ):
             result = pub.upload_raw_html("<html/>", _lei_data_html())
         assert result["success"] is False
         assert "ia CLI" in result["error"]
@@ -367,7 +370,10 @@ class TestUploadRawHtml:
     def test_ia_called_with_html_extension(self) -> None:
         pub = _publisher()
         mock_result = MagicMock(returncode=0, stdout="", stderr="")
-        with patch("subprocess.run", return_value=mock_result) as mock_run:
+        with (
+            patch("leizilla.publisher._fetch_existing_index", return_value=None),
+            patch("subprocess.run", return_value=mock_result) as mock_run,
+        ):
             pub.upload_raw_html("<html>lei</html>", _lei_data_html())
         call_args = mock_run.call_args_list[0][0][0]
         html_files = [
@@ -378,7 +384,10 @@ class TestUploadRawHtml:
     def test_mediatype_is_texts(self) -> None:
         pub = _publisher()
         mock_result = MagicMock(returncode=0, stdout="", stderr="")
-        with patch("subprocess.run", return_value=mock_result) as mock_run:
+        with (
+            patch("leizilla.publisher._fetch_existing_index", return_value=None),
+            patch("subprocess.run", return_value=mock_result) as mock_run,
+        ):
             pub.upload_raw_html("<html/>", _lei_data_html())
         call_args = mock_run.call_args_list[0][0][0]
         assert "mediatype:texts" in call_args
@@ -428,10 +437,7 @@ class TestScrapeOneHtml:
             patch("leizilla.wayback.check_available", return_value=wb_url),
             patch("leizilla.scraper.fetch_html", return_value="<html>lei</html>"),
             patch("subprocess.run", return_value=mock_run),
-            patch(
-                "leizilla.publisher.update_raw_index",
-                return_value={"success": True},
-            ),
+            patch("leizilla.publisher._fetch_existing_index", return_value=None),
         ):
             result = scrape_one_html(self._url(), _lei_data_html(), pub)
         assert result["success"] is True
@@ -453,10 +459,7 @@ class TestScrapeOneHtml:
             patch("leizilla.wayback.check_available", return_value=None),
             patch("leizilla.scraper.fetch_html", side_effect=fake_fetch),
             patch("subprocess.run", return_value=mock_run) as _mock,
-            patch(
-                "leizilla.publisher.update_raw_index",
-                return_value={"success": True},
-            ),
+            patch("leizilla.publisher._fetch_existing_index", return_value=None),
         ):
             result = scrape_one_html(self._url(), _lei_data_html(), pub)
         assert result["success"] is True, result

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -10,12 +10,37 @@ from unittest.mock import patch, MagicMock
 from leizilla.publisher import (
     _raw_identifier,
     _bundle_identifier,
+    _ia_subprocess_env,
     build_raw_meta,
     count_ia_items,
     list_parsed_raw_ids,
     list_raw_ids,
     InternetArchivePublisher,
 )
+
+
+class TestIASubprocessEnv:
+    """O CLI `ia` só lê credenciais de um config file; injetamos via IA_CONFIG_FILE."""
+
+    def test_returns_none_without_credentials(self):
+        assert _ia_subprocess_env(None, None) is None
+        assert _ia_subprocess_env("", "secret") is None
+        assert _ia_subprocess_env("access", "") is None
+
+    def test_points_ia_config_file_at_temp_ini_with_keys(self):
+        env = _ia_subprocess_env("AKIA-test", "shh-secret")
+        assert env is not None
+        cfg_path = env["IA_CONFIG_FILE"]
+        content = Path(cfg_path).read_text(encoding="utf-8")
+        assert "[s3]" in content
+        assert "AKIA-test" in content
+        assert "shh-secret" in content
+
+    def test_caches_config_per_credential_pair(self):
+        first = _ia_subprocess_env("dup-key", "dup-secret")
+        second = _ia_subprocess_env("dup-key", "dup-secret")
+        assert first is not None and second is not None
+        assert first["IA_CONFIG_FILE"] == second["IA_CONFIG_FILE"]
 
 
 class TestRawIdentifier:

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -556,6 +556,55 @@ class TestListRawIds:
             list_raw_ids("ro", "casacivil")
         m.assert_called_once_with("leizilla_ro_casacivil_")
 
+    def test_transient_index_failure_returns_empty_all_or_nothing(self):
+        # A transient failure reading ANY range index must return empty (not a
+        # partial set), so cmd_parse_all falls back to the sequential range instead
+        # of treating a partial result as authoritative and dropping ranges.
+        from leizilla.publisher import IndexFetchError
+
+        good = (
+            "tipo,numero,rendicao,formato,uuid5,sha256,captured_at\n"
+            "lei,1,,pdf,u1,h1,2026-05-30T00:00:00+00:00\n"
+        )
+        with (
+            patch(
+                "leizilla.publisher._scrape_identifiers",
+                return_value=[
+                    "leizilla_ro_casacivil_lei_0001-1000",
+                    "leizilla_ro_casacivil_lei_1001-2000",
+                ],
+            ),
+            patch(
+                "leizilla.publisher._fetch_existing_index",
+                side_effect=[good, IndexFetchError("HTTP 503")],
+            ),
+        ):
+            assert list_raw_ids("ro", "casacivil") == set()
+
+    def test_confirmed_404_index_skips_only_that_item(self):
+        # A confirmed 404 (item without an index) is not transient: that item
+        # contributes nothing, but the others are still returned.
+        good = (
+            "tipo,numero,rendicao,formato,uuid5,sha256,captured_at\n"
+            "lei,5,,pdf,u5,h5,2026-05-30T00:00:00+00:00\n"
+        )
+        with (
+            patch(
+                "leizilla.publisher._scrape_identifiers",
+                return_value=[
+                    "leizilla_ro_casacivil_lei_0001-1000",
+                    "leizilla_ro_casacivil_lei_5001-6000",
+                ],
+            ),
+            patch(
+                "leizilla.publisher._fetch_existing_index",
+                side_effect=[None, good],  # first item has no index (404)
+            ),
+        ):
+            assert list_raw_ids("ro", "casacivil") == {
+                "leizilla-raw-ro-casacivil-lei-00005"
+            }
+
 
 class TestUploadToArchive:
     @patch("subprocess.run")

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -490,12 +490,8 @@ class TestCountIaItems:
 
 
 class TestListRawIds:
-    """Testes para list_raw_ids — reconstrói raw_ids legados a partir do index.csv.
-
-    Sob a camada content-addressed (ADR-0010), os itens IA são buckets de hash
-    sem source_key; a descoberta lê o index.csv do (ente, fonte) e reconstrói os
-    raw_ids que o parser sabe resolver.
-    """
+    """Testes para list_raw_ids (ADR-0011): enumera os itens de range via scrape
+    API e reconstrói os raw_ids legados a partir do index.csv de cada item."""
 
     def _csv_resp(self, csv_text: str) -> object:
         payload = csv_text.encode()
@@ -512,48 +508,53 @@ class TestListRawIds:
 
         return _R()
 
-    def test_returns_empty_set_on_network_error(self):
-        # No index published yet (404) → empty set → caller uses sequential range.
-        with patch("urllib.request.urlopen", side_effect=OSError("network")):
+    def test_returns_empty_set_on_scrape_error(self):
+        with patch("leizilla.publisher._scrape_identifiers", return_value=None):
             assert list_raw_ids("ro", "assembleia") == set()
 
-    def test_returns_empty_set_when_index_has_no_rows(self):
-        header = "source_key,content_hash,content_type,source_url,captured_at\n"
-        with patch("urllib.request.urlopen", return_value=self._csv_resp(header)):
+    def test_returns_empty_set_when_no_items(self):
+        with patch("leizilla.publisher._scrape_identifiers", return_value=[]):
             assert list_raw_ids("ro", "assembleia") == set()
 
-    def test_reconstructs_legacy_raw_ids_from_index(self):
+    def test_reconstructs_legacy_raw_ids_from_item_indexes(self):
         index_csv = (
-            "source_key,content_hash,content_type,source_url,captured_at\n"
-            "coddoc-00001,h1,application/pdf,http://s/1,2026-05-30T00:00:00+00:00\n"
-            "coddoc-00002,h2,application/pdf,http://s/2,2026-05-30T00:00:00+00:00\n"
+            "tipo,numero,rendicao,formato,uuid5,sha256,captured_at\n"
+            "lei,1,,pdf,u1,h1,2026-05-30T00:00:00+00:00\n"
+            "lei,2,,pdf,u2,h2,2026-05-30T00:00:00+00:00\n"
         )
-        with patch("urllib.request.urlopen", return_value=self._csv_resp(index_csv)):
-            result = list_raw_ids("ro", "assembleia")
+        with patch(
+            "leizilla.publisher._scrape_identifiers",
+            return_value=["leizilla_ro_assembleia_lei_0001-1000"],
+        ):
+            with patch(
+                "urllib.request.urlopen", return_value=self._csv_resp(index_csv)
+            ):
+                result = list_raw_ids("ro", "assembleia")
         assert result == {
-            "leizilla-raw-ro-assembleia-coddoc-00001",
-            "leizilla-raw-ro-assembleia-coddoc-00002",
+            "leizilla-raw-ro-assembleia-lei-00001",
+            "leizilla-raw-ro-assembleia-lei-00002",
         }
 
-    def test_deduplicates_source_keys_across_versions(self):
-        # Same source_key captured twice (two versions) → one raw_id.
+    def test_deduplicates_identities_across_versions(self):
         index_csv = (
-            "source_key,content_hash,content_type,source_url,captured_at\n"
-            "lei-00001,h1,application/pdf,http://s/1,2026-05-30T00:00:00+00:00\n"
-            "lei-00001,h2,application/pdf,http://s/1,2026-05-31T00:00:00+00:00\n"
+            "tipo,numero,rendicao,formato,uuid5,sha256,captured_at\n"
+            "lei,1,,pdf,u1,h1,2026-05-30T00:00:00+00:00\n"
+            "lei,1,atual,html,u2,h2,2026-05-31T00:00:00+00:00\n"
         )
-        with patch("urllib.request.urlopen", return_value=self._csv_resp(index_csv)):
-            result = list_raw_ids("ro", "casacivil")
+        with patch(
+            "leizilla.publisher._scrape_identifiers",
+            return_value=["leizilla_ro_casacivil_lei_0001-1000"],
+        ):
+            with patch(
+                "urllib.request.urlopen", return_value=self._csv_resp(index_csv)
+            ):
+                result = list_raw_ids("ro", "casacivil")
         assert result == {"leizilla-raw-ro-casacivil-lei-00001"}
 
-    def test_queries_the_index_item(self):
-        index_csv = "source_key,content_hash,content_type,source_url,captured_at\n"
-        with patch(
-            "urllib.request.urlopen", return_value=self._csv_resp(index_csv)
-        ) as m:
+    def test_enumerates_range_items_by_prefix(self):
+        with patch("leizilla.publisher._scrape_identifiers", return_value=[]) as m:
             list_raw_ids("ro", "casacivil")
-        url = m.call_args_list[0][0][0].full_url
-        assert "leizilla-raw-ro-casacivil-index/index.csv" in url
+        m.assert_called_once_with("leizilla_ro_casacivil_")
 
 
 class TestUploadToArchive:
@@ -599,9 +600,9 @@ class TestUploadToArchive:
         assert "credentials" in res["error"]
 
 
-class TestUpdateRawIndex:
-    """update_raw_index deve preservar o histórico: nunca sobrescrever o índice
-    com uma versão de uma linha por causa de falha transitória de leitura."""
+class TestFetchExistingIndex:
+    """_fetch_existing_index distingue 404 (ausente → None) de falha transitória
+    (5xx/timeout → IndexFetchError), para o chamador nunca sobrescrever histórico."""
 
     def _http_error(self, code: int) -> Exception:
         import urllib.error
@@ -610,97 +611,87 @@ class TestUpdateRawIndex:
             url="http://ia/index.csv", code=code, msg="x", hdrs=None, fp=None
         )
 
-    def _csv_resp(self, text: str) -> object:
-        payload = text.encode()
-
-        class _R:
-            def read(self):
-                return payload
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *a):
-                pass
-
-        return _R()
-
-    def test_404_starts_fresh_and_uploads(self):
-        from leizilla.publisher import update_raw_index
+    def test_404_returns_none(self):
+        from leizilla.publisher import _fetch_existing_index
 
         with patch("urllib.request.urlopen", side_effect=self._http_error(404)):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0)) as run:
-                res = update_raw_index(
-                    "ro",
-                    "casacivil",
-                    source_key="coddoc-1",
-                    content_hash="h1",
-                    content_type="application/pdf",
-                    source_url="http://s/1",
-                )
-        assert res["success"] is True
-        run.assert_called_once()
+            assert _fetch_existing_index("leizilla_ro_casacivil_lei_1-1000") is None
 
-    def test_transient_error_aborts_without_upload(self):
-        """5xx/timeout while an index may already exist → abort, do NOT overwrite."""
-        from leizilla.publisher import update_raw_index
+    def test_transient_error_raises(self):
+        from leizilla.publisher import _fetch_existing_index, IndexFetchError
+
+        import pytest
 
         with patch("urllib.request.urlopen", side_effect=self._http_error(503)):
-            with patch("subprocess.run") as run:
-                res = update_raw_index(
-                    "ro",
-                    "casacivil",
-                    source_key="coddoc-2",
-                    content_hash="h2",
-                    content_type="application/pdf",
-                    source_url="http://s/2",
-                )
-        assert res["success"] is False
-        assert "data loss" in res["error"]
-        run.assert_not_called()  # crucial: no upload that would wipe history
+            with pytest.raises(IndexFetchError):
+                _fetch_existing_index("leizilla_ro_casacivil_lei_1-1000")
 
-    def test_timeout_aborts_without_upload(self):
-        from leizilla.publisher import update_raw_index
+    def test_timeout_raises(self):
+        from leizilla.publisher import _fetch_existing_index, IndexFetchError
+
+        import pytest
 
         with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
-            with patch("subprocess.run") as run:
-                res = update_raw_index(
-                    "ro",
-                    "casacivil",
-                    source_key="coddoc-3",
-                    content_hash="h3",
-                    content_type="application/pdf",
-                    source_url="http://s/3",
-                )
-        assert res["success"] is False
-        run.assert_not_called()
+            with pytest.raises(IndexFetchError):
+                _fetch_existing_index("leizilla_ro_casacivil_lei_1-1000")
 
-    def test_existing_index_is_appended_not_replaced(self):
-        from leizilla.publisher import update_raw_index
 
-        existing = (
-            "source_key,content_hash,content_type,source_url,captured_at\n"
-            "coddoc-1,h1,application/pdf,http://s/1,2026-05-30T00:00:00+00:00\n"
+class TestResolveUuid5AndIndex:
+    """_resolve_uuid5_and_index mescla o index.csv do item (append-only) e estende
+    o UUIDv5 em caso de colisão (mesmo nome curto, bytes diferentes)."""
+
+    def test_appends_to_existing_index(self):
+        from leizilla.publisher import _resolve_uuid5_and_index
+        from leizilla.ia_utils import merge_index_row, uuid5_name
+
+        existing = merge_index_row(
+            None,
+            tipo="lei",
+            numero=1,
+            rendicao="",
+            formato="pdf",
+            uuid5="old",
+            sha256="hold",
+            captured_at="2026-05-30T00:00:00+00:00",
         )
-        written: dict = {}
+        with patch("leizilla.publisher._fetch_existing_index", return_value=existing):
+            uuid5, merged = _resolve_uuid5_and_index(
+                "leizilla_ro_casacivil_lei_1-1000",
+                b"new bytes",
+                tipo="lei",
+                numero=2,
+                rendicao="",
+                formato="pdf",
+            )
+        assert uuid5 == uuid5_name(b"new bytes")
+        # Prior row preserved; new row appended.
+        assert "lei,1," in merged and "lei,2," in merged
 
-        def fake_run(args, **kw):
-            # args = ["ia","upload",index_id,index_path,...] — capture uploaded CSV
-            path = args[3]
-            written["csv"] = open(path, encoding="utf-8").read()
-            return MagicMock(returncode=0)
+    def test_extends_uuid5_on_collision(self):
+        from leizilla.publisher import _resolve_uuid5_and_index
+        from leizilla.ia_utils import merge_index_row, uuid5_name
 
-        with patch("urllib.request.urlopen", return_value=self._csv_resp(existing)):
-            with patch("subprocess.run", side_effect=fake_run):
-                res = update_raw_index(
-                    "ro",
-                    "casacivil",
-                    source_key="coddoc-2",
-                    content_hash="h2",
-                    content_type="application/pdf",
-                    source_url="http://s/2",
-                )
-        assert res["success"] is True
-        # Both the prior and the new mapping survive.
-        assert "coddoc-1,h1" in written["csv"]
-        assert "coddoc-2,h2" in written["csv"]
+        short = uuid5_name(b"new bytes")
+        # Pre-seed the index with the same short name bound to DIFFERENT bytes.
+        existing = merge_index_row(
+            None,
+            tipo="lei",
+            numero=1,
+            rendicao="",
+            formato="pdf",
+            uuid5=short,
+            sha256="different-sha",
+            captured_at="2026-05-30T00:00:00+00:00",
+        )
+        with patch("leizilla.publisher._fetch_existing_index", return_value=existing):
+            uuid5, _merged = _resolve_uuid5_and_index(
+                "leizilla_ro_casacivil_lei_1-1000",
+                b"new bytes",
+                tipo="lei",
+                numero=2,
+                rendicao="",
+                formato="pdf",
+            )
+        # Extended to the full UUIDv5 to avoid clobbering the colliding entry.
+        assert uuid5 == uuid5_name(b"new bytes", length=32)
+        assert uuid5 != short

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -84,3 +84,34 @@ class TestReconcileUnidentified:
         pub.secret_key = None
         res = pub.reconcile_unidentified("ro", "assembleia", {})
         assert res["success"] is False
+
+
+class TestSourceMatchesDiscoveryURL:
+    """Regression: the index `source` must equal discovery's res['url'] (the PDF
+    URL) so reconcile can match — not the ALRO listing-page url_original."""
+
+    @patch("leizilla.publisher._ia_subprocess_env", return_value={})
+    @patch("subprocess.run")
+    def test_upload_raw_records_pdf_url_as_source(self, _run, _env, tmp_path):
+        from pathlib import Path
+
+        captured = {}
+
+        def _capture(item_id, content, **kw):
+            captured.update(kw)
+            return "uuid5x", "tipo,numero\n"
+
+        pdf = Path(tmp_path) / "doc.pdf"
+        pdf.write_bytes(b"x")
+        lei_data = {
+            "ente": "ro",
+            "fonte": "assembleia",
+            "chave": "lei-00099",
+            "url_original": "http://alro/legislacao/leis/77",  # listing page
+            "url_pdf_original": "http://alro/files/L99.pdf",  # the PDF (res['url'])
+        }
+        with patch(
+            "leizilla.publisher._resolve_uuid5_and_index", side_effect=_capture
+        ):
+            _pub().upload_raw(pdf, lei_data, b"x")
+        assert captured["source"] == "http://alro/files/L99.pdf"

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -110,8 +110,6 @@ class TestSourceMatchesDiscoveryURL:
             "url_original": "http://alro/legislacao/leis/77",  # listing page
             "url_pdf_original": "http://alro/files/L99.pdf",  # the PDF (res['url'])
         }
-        with patch(
-            "leizilla.publisher._resolve_uuid5_and_index", side_effect=_capture
-        ):
+        with patch("leizilla.publisher._resolve_uuid5_and_index", side_effect=_capture):
             _pub().upload_raw(pdf, lei_data, b"x")
         assert captured["source"] == "http://alro/files/L99.pdf"

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -92,6 +92,42 @@ class TestReconcileUnidentified:
         assert res["promoted"] == 1
         assert res["remaining"] == 1  # still listed in holding → not cleaned
 
+    @patch("leizilla.publisher._ia_subprocess_env", return_value={})
+    @patch("subprocess.run")
+    @patch("leizilla.publisher._fetch_item_file_bytes", return_value=b"PDF-bytes")
+    @patch("leizilla.publisher._fetch_existing_index")
+    def test_aliased_sources_only_promotes_identified(
+        self, mock_idx, _mock_bytes, _run, _env
+    ):
+        # Two holding rows: same bytes/uuid5, different source URLs. Only srcA is
+        # identifiable → promote it, but srcB (still unidentified) must remain.
+        holding = merge_index_row(
+            None,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="u1",
+            sha256="hsame",
+            source="http://alro/leis/7",
+        )
+        holding = merge_index_row(
+            holding,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="u1",
+            sha256="hsame",
+            source="http://alro/leis/8",
+        )
+        # holding fetched once; range index fetched once (for the single promotion).
+        mock_idx.side_effect = [holding, None]
+        identity = {"http://alro/leis/7": ("lei", 7)}  # only src 7 is mappable
+        res = _pub().reconcile_unidentified("ro", "assembleia", identity)
+        assert res["promoted"] == 1
+        assert res["remaining"] == 1  # src 8 alias still preserved
+
     @patch("leizilla.publisher._fetch_existing_index", return_value=None)
     def test_empty_holding_is_noop(self, _mock_idx):
         res = _pub().reconcile_unidentified("ro", "assembleia", {"x": ("lei", 1)})

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -128,6 +128,63 @@ class TestReconcileUnidentified:
         assert res["promoted"] == 1
         assert res["remaining"] == 1  # src 8 alias still preserved
 
+    def test_same_range_promotions_accumulate_index_no_lost_update(self):
+        # Two held files (different bytes → different uuid5, different sources) both
+        # resolve into the SAME range bucket (lei 7 & 8 → lei_0001-1000). The range
+        # index must be fetched once and accumulate BOTH rows; without the per-call
+        # cache, each upload would re-read a stale index and clobber the prior row.
+        import csv as _csv
+        import io as _io
+
+        holding = merge_index_row(
+            None,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="ua",
+            sha256="ha",
+            source="http://x/7",
+        )
+        holding = merge_index_row(
+            holding,
+            tipo="",
+            numero=None,
+            rendicao="",
+            formato="pdf",
+            uuid5="ub",
+            sha256="hb",
+            source="http://x/8",
+        )
+        identity = {"http://x/7": ("lei", 7), "http://x/8": ("lei", 8)}
+
+        captured: list[tuple[str, str]] = []
+
+        def fake_upload(range_id, content, filename, index_csv, *a):
+            captured.append((range_id, index_csv))
+            return True
+
+        def fake_bytes(item_id, filename):
+            return b"A" if filename.startswith("ua") else b"B"
+
+        pub = _pub()
+        with (
+            patch("leizilla.publisher._fetch_item_file_bytes", side_effect=fake_bytes),
+            patch("leizilla.publisher._fetch_existing_index") as mock_idx,
+            patch.object(pub, "_upload_to_range", side_effect=fake_upload),
+            patch.object(pub, "_upload_index_only", return_value=True),
+        ):
+            mock_idx.side_effect = [holding, None]  # holding, then range ONCE
+            res = pub.reconcile_unidentified("ro", "casacivil", identity)
+
+        assert res["promoted"] == 2
+        # holding (1) + range index (1) — the range is NOT re-fetched per file.
+        assert mock_idx.call_count == 2
+        # Final index uploaded for the range carries BOTH números (no lost update).
+        last_index = captured[-1][1]
+        numeros = {r["numero"] for r in _csv.DictReader(_io.StringIO(last_index))}
+        assert numeros == {"7", "8"}
+
     @patch("leizilla.publisher._fetch_existing_index", return_value=None)
     def test_empty_holding_is_noop(self, _mock_idx):
         res = _pub().reconcile_unidentified("ro", "assembleia", {"x": ("lei", 1)})

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -56,6 +56,13 @@ class TestReconcileUnidentified:
         assert "leizilla_ro_assembleia_lei_0001-1000" in uploaded_items
         # ... and the holding index was rewritten (promoted row removed).
         assert "leizilla_ro_assembleia_unidentified" in uploaded_items
+        # ... carrying the provenance _meta.json sidecar (parity with upload_raw).
+        range_call = next(
+            c
+            for c in mock_run.call_args_list
+            if c.args[0][2] == "leizilla_ro_assembleia_lei_0001-1000"
+        )
+        assert any(str(a).endswith("_meta.json") for a in range_call.args[0])
 
     @patch("leizilla.publisher._ia_subprocess_env", return_value={})
     @patch("subprocess.run")

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -35,6 +35,24 @@ def _pub() -> InternetArchivePublisher:
 
 class TestReconcileUnidentified:
     @patch("leizilla.publisher._ia_subprocess_env", return_value={})
+    @patch("leizilla.publisher._fetch_item_file_bytes", return_value=b"PDF-bytes")
+    @patch("leizilla.publisher._fetch_existing_index")
+    def test_range_upload_failure_is_surfaced(self, mock_idx, _mock_bytes, _env):
+        # Identity is known but the range upload fails (IA/network/CLI). The row
+        # stays in _unidentified; reconcile must report success=False with an error
+        # so automation doesn't read exit 0 and miss the failed promotion (the row
+        # alone is indistinguishable from a still-unidentified one).
+        mock_idx.side_effect = [_holding_index_one_unidentified(), None]
+        identity = {"http://alro.ro.gov.br/legislacao/leis/99": ("lei", 99)}
+        pub = _pub()
+        with patch.object(pub, "_upload_to_range", return_value=False):
+            res = pub.reconcile_unidentified("ro", "assembleia", identity)
+        assert res["success"] is False
+        assert res["promoted"] == 0
+        assert res["remaining"] == 1
+        assert "range" in res["error"].lower()
+
+    @patch("leizilla.publisher._ia_subprocess_env", return_value={})
     @patch("subprocess.run")
     @patch("leizilla.publisher._fetch_item_file_bytes", return_value=b"PDF-bytes")
     @patch("leizilla.publisher._fetch_existing_index")

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -72,6 +72,26 @@ class TestReconcileUnidentified:
         assert res["remaining"] == 1
         mock_run.assert_not_called()  # nothing uploaded, holding untouched
 
+    @patch("leizilla.publisher._ia_subprocess_env", return_value={})
+    @patch("subprocess.run")
+    @patch("leizilla.publisher._fetch_item_file_bytes", return_value=b"PDF-bytes")
+    @patch("leizilla.publisher._fetch_existing_index")
+    def test_holding_index_rewrite_failure_is_surfaced(
+        self, mock_idx, _mock_bytes, _run, _env
+    ):
+        # Range upload succeeds, but rewriting the holding index fails → report the
+        # failure (success False) and keep the promoted row counted as remaining,
+        # so the operator sees cleanup didn't finish.
+        mock_idx.side_effect = [_holding_index_one_unidentified(), None]
+        identity = {"http://alro.ro.gov.br/legislacao/leis/99": ("lei", 99)}
+        pub = _pub()
+        with patch.object(pub, "_upload_index_only", return_value=False):
+            res = pub.reconcile_unidentified("ro", "assembleia", identity)
+        assert res["success"] is False
+        assert "error" in res
+        assert res["promoted"] == 1
+        assert res["remaining"] == 1  # still listed in holding → not cleaned
+
     @patch("leizilla.publisher._fetch_existing_index", return_value=None)
     def test_empty_holding_is_noop(self, _mock_idx):
         res = _pub().reconcile_unidentified("ro", "assembleia", {"x": ("lei", 1)})

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,86 @@
+"""Tests for the reconcile step: promote held _unidentified files into range items.
+
+ADR-0011 §1 (revised): identity is evidence, not an ingestion gate. Un-numbered
+captures are preserved in `leizilla_{ente}_{fonte}_unidentified`; reconcile re-derives
+identity from discovery context and promotes them — pulling bytes from IA, never the
+fragile source.
+"""
+
+from unittest.mock import patch
+
+from leizilla.ia_utils import merge_index_row
+from leizilla.publisher import InternetArchivePublisher
+
+
+def _holding_index_one_unidentified() -> str:
+    # One preserved row with no número and a source URL (the reconcile target).
+    return merge_index_row(
+        None,
+        tipo="",
+        numero=None,
+        rendicao="",
+        formato="pdf",
+        uuid5="abcd1234",
+        sha256="h1",
+        source="http://alro.ro.gov.br/legislacao/leis/99",
+    )
+
+
+def _pub() -> InternetArchivePublisher:
+    pub = InternetArchivePublisher()
+    pub.access_key = "fake-key"
+    pub.secret_key = "fake-secret"
+    return pub
+
+
+class TestReconcileUnidentified:
+    @patch("leizilla.publisher._ia_subprocess_env", return_value={})
+    @patch("subprocess.run")
+    @patch("leizilla.publisher._fetch_item_file_bytes", return_value=b"PDF-bytes")
+    @patch("leizilla.publisher._fetch_existing_index")
+    def test_promotes_now_identified_resource(
+        self, mock_idx, _mock_bytes, mock_run, _env
+    ):
+        # _fetch_existing_index: first the holding index, then the (new) range index.
+        mock_idx.side_effect = [_holding_index_one_unidentified(), None]
+        identity = {"http://alro.ro.gov.br/legislacao/leis/99": ("lei", 99)}
+
+        res = _pub().reconcile_unidentified("ro", "assembleia", identity)
+
+        assert res["success"] is True
+        assert res["promoted"] == 1
+        assert res["remaining"] == 0
+
+        uploaded_items = [call.args[0][2] for call in mock_run.call_args_list]
+        # Promoted into the navigable range item ...
+        assert "leizilla_ro_assembleia_lei_0001-1000" in uploaded_items
+        # ... and the holding index was rewritten (promoted row removed).
+        assert "leizilla_ro_assembleia_unidentified" in uploaded_items
+
+    @patch("leizilla.publisher._ia_subprocess_env", return_value={})
+    @patch("subprocess.run")
+    @patch("leizilla.publisher._fetch_item_file_bytes", return_value=b"PDF-bytes")
+    @patch("leizilla.publisher._fetch_existing_index")
+    def test_leaves_still_unidentified_in_holding(
+        self, mock_idx, _mock_bytes, mock_run, _env
+    ):
+        mock_idx.return_value = _holding_index_one_unidentified()
+        # The held resource's source is NOT in the identity map → not promotable.
+        res = _pub().reconcile_unidentified("ro", "assembleia", {})
+
+        assert res["promoted"] == 0
+        assert res["remaining"] == 1
+        mock_run.assert_not_called()  # nothing uploaded, holding untouched
+
+    @patch("leizilla.publisher._fetch_existing_index", return_value=None)
+    def test_empty_holding_is_noop(self, _mock_idx):
+        res = _pub().reconcile_unidentified("ro", "assembleia", {"x": ("lei", 1)})
+        assert res["promoted"] == 0
+        assert res["remaining"] == 0
+
+    def test_no_credentials_returns_error(self):
+        pub = InternetArchivePublisher()
+        pub.access_key = None
+        pub.secret_key = None
+        res = pub.reconcile_unidentified("ro", "assembleia", {})
+        assert res["success"] is False

--- a/tests/test_rondonia_lc_manifest.py
+++ b/tests/test_rondonia_lc_manifest.py
@@ -6,6 +6,7 @@ Rondônia Lei Complementar example: ingestion is gated on a known identity
 (truncated UUIDv5); and the item's ``index.csv`` maps the identity to the file.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from leizilla.publisher import InternetArchivePublisher, IndexFetchError
@@ -120,6 +121,70 @@ class TestRondoniaLCIdentityKeyed:
         args = mock_run.call_args[0][0]
         assert "leizilla_ro_assembleia_unidentified" in args
         assert any(a.endswith("index.csv") for a in args)
+
+    @patch("leizilla.publisher._fetch_existing_index", return_value=None)
+    @patch("subprocess.run")
+    def test_batch_index_cache_accumulates_same_range(
+        self, mock_run, mock_idx, tmp_path
+    ):
+        # Two uploads into the SAME range bucket within one batch must accumulate
+        # the index.csv via the shared cache: the IA index is read once (the 2nd
+        # upload reuses the cached merge), and the 2nd index.csv carries BOTH rows.
+        # Without the cache, the 2nd upload re-reads a stale (None) index and
+        # publishes an index with only its own row — clobbering the first.
+        import csv as _csv
+        import io as _io
+
+        captured: list[str] = []
+
+        def fake_run(cmd, *a, **kw):
+            for arg in cmd:
+                if str(arg).endswith("index.csv"):
+                    captured.append(Path(str(arg)).read_text(encoding="utf-8"))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = fake_run
+
+        pub = InternetArchivePublisher()
+        pub.access_key = "fake-key"
+        pub.secret_key = "fake-secret"
+
+        cache: dict[str, str] = {}
+        pdf1 = tmp_path / "L1.pdf"
+        pdf1.write_bytes(b"AAA")
+        pdf2 = tmp_path / "L2.pdf"
+        pdf2.write_bytes(b"BBB")
+
+        r1 = pub.upload_raw(
+            pdf1,
+            {
+                "ente": "ro",
+                "fonte": "casacivil",
+                "chave": "lei-00001",
+                "url_original": "u1",
+            },
+            b"AAA",
+            index_cache=cache,
+        )
+        r2 = pub.upload_raw(
+            pdf2,
+            {
+                "ente": "ro",
+                "fonte": "casacivil",
+                "chave": "lei-00002",
+                "url_original": "u2",
+            },
+            b"BBB",
+            index_cache=cache,
+        )
+
+        assert r1["success"] and r2["success"]
+        assert r1["item_id"] == r2["item_id"]  # same 0001-1000 range bucket
+        # IA index read exactly once — the 2nd upload was served from the cache.
+        assert mock_idx.call_count == 1
+        # The 2nd upload's index.csv carries BOTH captures (no lost update).
+        rows = list(_csv.DictReader(_io.StringIO(captured[-1])))
+        assert {r["numero"] for r in rows} == {"1", "2"}
 
     @patch(
         "leizilla.publisher._fetch_existing_index",

--- a/tests/test_rondonia_lc_manifest.py
+++ b/tests/test_rondonia_lc_manifest.py
@@ -1,57 +1,62 @@
-"""Pipeline validation for the content-addressed raw layer (ADR-0010).
+"""Pipeline validation for the identity-keyed raw layer (ADR-0011).
 
-Rondônia Lei Complementar example: upload names the file by content hash, the
-range item buckets by hash prefix, and the (ente, fonte) index records the
-source_key → content_hash mapping. The source's harvest key (coddoc/lc number)
-is metadata, never a path.
+Rondônia Lei Complementar example: ingestion is gated on a known identity
+(tipo, número); the IA item is an identity range bucket
+(``leizilla_ro_casacivil_lc_0001-1000``); the file inside is content-addressed
+(truncated UUIDv5); and the item's ``index.csv`` maps the identity to the file.
 """
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-from leizilla.publisher import InternetArchivePublisher
+from leizilla.publisher import InternetArchivePublisher, IndexFetchError
 from leizilla.ia_utils import (
-    compute_hash,
-    lookup_current_hash,
+    lookup_current,
+    merge_index_row,
+    range_item_identifier,
     raw_filename,
-    raw_range_identifier,
     resolve_raw_url,
+    uuid5_name,
 )
 
 
-class TestRondoniaLCContentAddressed:
-    def test_filename_and_range_are_content_addressed(self):
+class TestRondoniaLCIdentityKeyed:
+    def test_item_and_filename_are_identity_keyed(self):
         pdf_bytes = b"PDF content for LC 42"
-        h = compute_hash(pdf_bytes)
-
-        # Range item buckets by hash prefix — no coddoc, no lc number in the path.
-        assert raw_range_identifier("ro", "casacivil", h) == (
-            f"leizilla-raw-ro-casacivil-{h[:2]}"
+        u = uuid5_name(pdf_bytes)
+        # Item is the identity range bucket — tipo + número range, no hash, no coddoc.
+        assert (
+            range_item_identifier("ro", "casacivil", "lc", 42)
+            == "leizilla_ro_casacivil_lc_0001-1000"
         )
-        # File is named purely by the content hash.
-        assert raw_filename(h, ".pdf") == f"{h}.pdf"
+        # File inside the item is content-addressed (truncated UUIDv5).
+        assert raw_filename(u, ".pdf") == f"{u}.pdf"
 
     def test_resolve_via_index_roundtrip(self):
         pdf_bytes = b"PDF content for LC 42"
-        h = compute_hash(pdf_bytes)
-        # Index maps the legacy source_key (lc-00042) to the content hash.
-        index_csv = (
-            "source_key,content_hash,content_type,source_url,captured_at\n"
-            f"lc-00042,{h},application/pdf,http://ditel/LC42.pdf,2026-05-30T00:00:00+00:00\n"
+        u = uuid5_name(pdf_bytes)
+        index_csv = merge_index_row(
+            None,
+            tipo="lc",
+            numero=42,
+            rendicao="",
+            formato="pdf",
+            uuid5=u,
+            sha256="hpdf",
+            captured_at="2026-05-30T00:00:00+00:00",
         )
-        assert lookup_current_hash(index_csv, "lc-00042") == (h, "application/pdf")
+        assert lookup_current(index_csv, "lc", 42, formato="pdf")["uuid5"] == u
 
         with patch("leizilla.ia_utils._fetch_text", return_value=index_csv):
             url = resolve_raw_url("leizilla-raw-ro-casacivil-lc-00042", "_djvu.txt")
         assert url == (
-            f"https://archive.org/download/leizilla-raw-ro-casacivil-{h[:2]}/"
-            f"{h}_djvu.txt"
+            "https://archive.org/download/leizilla_ro_casacivil_lc_0001-1000/"
+            f"{u}_djvu.txt"
         )
 
-    @patch("leizilla.publisher.update_raw_index")
+    @patch("leizilla.publisher._fetch_existing_index", return_value=None)
     @patch("subprocess.run")
-    def test_complete_upload_raw_lc_rondonia(self, mock_run, mock_index, tmp_path):
+    def test_complete_upload_raw_lc_rondonia(self, mock_run, _mock_idx, tmp_path):
         mock_run.return_value = MagicMock(returncode=0)
-        mock_index.return_value = {"success": True}
 
         pub = InternetArchivePublisher()
         pub.access_key = "fake-key"
@@ -60,7 +65,7 @@ class TestRondoniaLCContentAddressed:
         pdf_path = tmp_path / "LC42.pdf"
         pdf_bytes = b"PDF content for LC 42"
         pdf_path.write_bytes(pdf_bytes)
-        h = compute_hash(pdf_bytes)
+        u = uuid5_name(pdf_bytes)
 
         lei_data = {
             "ente": "ro",
@@ -72,49 +77,51 @@ class TestRondoniaLCContentAddressed:
         res = pub.upload_raw(pdf_path, lei_data, pdf_bytes, fetched_from="wayback")
 
         assert res["success"] is True
+        assert res["uuid5"] == u
         assert (
             res["ia_url"]
-            == f"https://archive.org/details/leizilla-raw-ro-casacivil-{h[:2]}"
+            == "https://archive.org/details/leizilla_ro_casacivil_lc_0001-1000"
         )
 
-        # Upload targeted the hash-prefix range item with the hash-named file.
+        # Upload targeted the identity range item with the uuid5-named file + index.
         args = mock_run.call_args[0][0]
         assert "ia" in args and "upload" in args
-        assert f"leizilla-raw-ro-casacivil-{h[:2]}" in args
-        assert any(a.endswith(f"{h}.pdf") for a in args)
+        assert "leizilla_ro_casacivil_lc_0001-1000" in args
+        assert any(a.endswith(f"{u}.pdf") for a in args)
+        assert any(a.endswith("index.csv") for a in args)
 
-        # The index was updated with source_key → content_hash (coddoc/lc as metadata).
-        _, kwargs = mock_index.call_args
-        assert kwargs["source_key"] == "lc-00042"
-        assert kwargs["content_hash"] == h
-        assert kwargs["content_type"] == "application/pdf"
-
-    @patch("leizilla.publisher.update_raw_index")
     @patch("subprocess.run")
-    def test_index_failure_propagates_as_upload_failure(
-        self, mock_run, mock_index, tmp_path
-    ):
-        # Reads resolve exclusively through the index; if the index write fails,
-        # the capture would be unreachable. upload_raw must NOT report success.
-        mock_run.return_value = MagicMock(returncode=0)
-        mock_index.return_value = {"success": False, "error": "IA 503"}
+    def test_unidentified_chave_is_rejected(self, mock_run, tmp_path):
+        # coddoc is a harvest key, not an identity → reject-until-identified.
+        pub = InternetArchivePublisher()
+        pub.access_key = "fake-key"
+        pub.secret_key = "fake-secret"
 
+        pdf_path = tmp_path / "doc.pdf"
+        pdf_path.write_bytes(b"x")
+        lei_data = {"ente": "ro", "fonte": "assembleia", "chave": "coddoc-00099"}
+
+        res = pub.upload_raw(pdf_path, lei_data, b"x")
+        assert res["success"] is False
+        assert "unidentified" in res["error"]
+        mock_run.assert_not_called()
+
+    @patch(
+        "leizilla.publisher._fetch_existing_index",
+        side_effect=IndexFetchError("IA 503"),
+    )
+    @patch("subprocess.run")
+    def test_index_fetch_error_aborts(self, mock_run, _mock_idx, tmp_path):
+        # A transient failure reading the item's index must abort, not overwrite.
         pub = InternetArchivePublisher()
         pub.access_key = "fake-key"
         pub.secret_key = "fake-secret"
 
         pdf_path = tmp_path / "LC42.pdf"
-        pdf_bytes = b"PDF content for LC 42"
-        pdf_path.write_bytes(pdf_bytes)
+        pdf_path.write_bytes(b"PDF content for LC 42")
+        lei_data = {"ente": "ro", "fonte": "casacivil", "chave": "lc-00042"}
 
-        lei_data = {
-            "ente": "ro",
-            "fonte": "casacivil",
-            "chave": "lc-00042",
-            "url_original": "http://ditel/LC42.pdf",
-        }
-
-        res = pub.upload_raw(pdf_path, lei_data, pdf_bytes, fetched_from="wayback")
-
+        res = pub.upload_raw(pdf_path, lei_data, b"PDF content for LC 42")
         assert res["success"] is False
-        assert "index update failed" in res["error"]
+        assert "could not read existing index" in res["error"]
+        mock_run.assert_not_called()

--- a/tests/test_rondonia_lc_manifest.py
+++ b/tests/test_rondonia_lc_manifest.py
@@ -140,3 +140,20 @@ class TestRondoniaLCIdentityKeyed:
         assert res["success"] is False
         assert "could not read existing index" in res["error"]
         mock_run.assert_not_called()
+
+    @patch("leizilla.publisher._fetch_existing_index", return_value=None)
+    @patch("subprocess.run", side_effect=FileNotFoundError())
+    def test_missing_ia_cli_returns_structured_error(self, _run, _idx, tmp_path):
+        # When the `ia` executable is absent, the PDF path must return the same
+        # structured error as the HTML/parsed/dataset paths — not crash.
+        pub = InternetArchivePublisher()
+        pub.access_key = "fake-key"
+        pub.secret_key = "fake-secret"
+
+        pdf_path = tmp_path / "LC42.pdf"
+        pdf_path.write_bytes(b"PDF")
+        lei_data = {"ente": "ro", "fonte": "casacivil", "chave": "lc-00042"}
+
+        res = pub.upload_raw(pdf_path, lei_data, b"PDF")
+        assert res["success"] is False
+        assert "ia CLI não encontrado" in res["error"]

--- a/tests/test_rondonia_lc_manifest.py
+++ b/tests/test_rondonia_lc_manifest.py
@@ -90,21 +90,36 @@ class TestRondoniaLCIdentityKeyed:
         assert any(a.endswith(f"{u}.pdf") for a in args)
         assert any(a.endswith("index.csv") for a in args)
 
+    @patch("leizilla.publisher._fetch_existing_index", return_value=None)
     @patch("subprocess.run")
-    def test_unidentified_chave_is_rejected(self, mock_run, tmp_path):
-        # coddoc is a harvest key, not an identity → reject-until-identified.
+    def test_unidentified_chave_is_preserved_in_holding(
+        self, mock_run, _mock_idx, tmp_path
+    ):
+        # ADR-0011 §1: coddoc has no resolved (tipo, número), but we PRESERVE it —
+        # the bytes go to the _unidentified holding item (IA still OCRs them), never
+        # discarded. Reconciliation promotes it later.
         pub = InternetArchivePublisher()
         pub.access_key = "fake-key"
         pub.secret_key = "fake-secret"
 
         pdf_path = tmp_path / "doc.pdf"
         pdf_path.write_bytes(b"x")
-        lei_data = {"ente": "ro", "fonte": "assembleia", "chave": "coddoc-00099"}
+        lei_data = {
+            "ente": "ro",
+            "fonte": "assembleia",
+            "chave": "coddoc-00099",
+            "url_original": "http://alro.ro.gov.br/legislacao/leis/99",
+        }
 
         res = pub.upload_raw(pdf_path, lei_data, b"x")
-        assert res["success"] is False
-        assert "unidentified" in res["error"]
-        mock_run.assert_not_called()
+        assert res["success"] is True
+        assert res["identified"] is False
+        assert res["item_id"] == "leizilla_ro_assembleia_unidentified"
+
+        # Uploaded to the holding item (not discarded); index.csv carries source.
+        args = mock_run.call_args[0][0]
+        assert "leizilla_ro_assembleia_unidentified" in args
+        assert any(a.endswith("index.csv") for a in args)
 
     @patch(
         "leizilla.publisher._fetch_existing_index",

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,5 +1,13 @@
 import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const svelteClient = path.resolve(__dirname, 'node_modules/svelte/src/index-client.js');
+const svelteLegacy = path.resolve(__dirname, 'node_modules/svelte/src/legacy/legacy-client.js');
+const svelteReactivity = path.resolve(__dirname, 'node_modules/svelte/src/reactivity/index-client.js');
+const svelteStore = path.resolve(__dirname, 'node_modules/svelte/src/store/index-client.js');
 
 export default defineConfig({
   integrations: [svelte()],
@@ -7,8 +15,22 @@ export default defineConfig({
   site: 'https://franklinbaldo.github.io',
   base: '/leizilla',
   vite: {
+    resolve: {
+      alias: [
+        { find: /^svelte$/, replacement: svelteClient },
+        { find: /^svelte\/legacy$/, replacement: svelteLegacy },
+        { find: /^svelte\/reactivity$/, replacement: svelteReactivity },
+        { find: /^svelte\/store$/, replacement: svelteStore },
+      ],
+    },
     optimizeDeps: {
-      exclude: ['@duckdb/duckdb-wasm'],
+      exclude: [
+        '@duckdb/duckdb-wasm',
+        'svelte',
+        'svelte/legacy',
+        'svelte/reactivity',
+        'svelte/store',
+      ],
     },
   },
 });

--- a/web/src/components/LeiSearchUI.svelte
+++ b/web/src/components/LeiSearchUI.svelte
@@ -7,19 +7,18 @@
     PAGE_SIZE,
     type LeiRow,
   } from '../lib/db.ts';
-  import LeiCard from './LeiCard.svelte';
 
   // --- Svelte 5 state for UI ---
   let rawTerm = $state('');
   let debouncedTerm = $state('');
-  let ente = $state('');
+  let ente = $state(''); // Padrão: Todos os entes
+  let tipoLei = $state(''); // Padrão: Todos os tipos de norma
   let year = $state<number | null>(null);
   let page = $state(0);
 
   // Debounce: update debouncedTerm 400ms after last keystroke.
-  // $effect cleanup cancels the pending timer on rawTerm change or unmount.
   $effect(() => {
-    const _raw = rawTerm; // captured for closure
+    const _raw = rawTerm;
     const timer = setTimeout(() => {
       debouncedTerm = _raw;
       page = 0;
@@ -34,30 +33,63 @@
     ente = (e.target as HTMLSelectElement).value;
     page = 0;
   }
+  function onTipoLeiChange(e: Event) {
+    tipoLei = (e.target as HTMLSelectElement).value;
+    page = 0;
+  }
   function onYearInput(e: Event) {
     const v = parseInt((e.target as HTMLInputElement).value, 10);
     year = Number.isFinite(v) && v >= 1900 && v <= 2099 ? v : null;
     page = 0;
   }
 
+  // --- Helpers de Formatação ---
+  function formatTipoLei(tipo: string): string {
+    if (!tipo) return 'Norma';
+    const clean = tipo.toLowerCase();
+    if (clean === 'lei') return 'Lei Ordinária';
+    if (clean === 'lei-complementar') return 'Lei Complementar';
+    if (clean === 'decreto') return 'Decreto';
+    if (clean === 'resolucao') return 'Resolução';
+    if (clean === 'portaria') return 'Portaria';
+    return tipo.charAt(0).toUpperCase() + tipo.slice(1);
+  }
+
+  function formatEnte(enteCode: string): string {
+    if (!enteCode) return '-';
+    const clean = enteCode.toLowerCase();
+    if (clean === 'ro') return 'Rondônia';
+    if (clean === 'sp') return 'São Paulo';
+    if (clean === 'federal') return 'Federal';
+    return enteCode.toUpperCase();
+  }
+
+  function getIaUrl(row: LeiRow): string {
+    // Sob o esquema content-addressed (ADR-0010), o item raw é bucketizado por
+    // hash e não é derivável da norma no cliente — então linkamos para uma busca
+    // no Internet Archive pelo lei_id, que resolve para o(s) item(ns) relevantes.
+    return `https://archive.org/search?query=${encodeURIComponent(row.lei_id)}`;
+  }
+
   // --- Bridge: Svelte 5 state → Svelte 4 stores (TanStack Query interface) ---
   const resultsOpts = writable({
-    queryKey: ['leis', '', '', null, 0] as readonly unknown[],
+    queryKey: ['leis', '', '', '', null, 0] as readonly unknown[],
     queryFn: () => searchLeisFiltered('', {}),
     placeholderData: (prev: LeiRow[] | undefined) => prev,
   });
   const countOpts = writable({
-    queryKey: ['leis-count', '', '', null] as readonly unknown[],
+    queryKey: ['leis-count', '', '', '', null] as readonly unknown[],
     queryFn: () => countLeisFiltered('', {}),
     staleTime: 5 * 60 * 1000,
   });
 
   $effect(() => {
     resultsOpts.set({
-      queryKey: ['leis', debouncedTerm, ente, year, page] as readonly unknown[],
+      queryKey: ['leis', debouncedTerm, ente, tipoLei, year, page] as readonly unknown[],
       queryFn: () =>
         searchLeisFiltered(debouncedTerm, {
           ente: ente || undefined,
+          tipoLei: tipoLei || undefined,
           year: year ?? undefined,
           page,
           pageSize: PAGE_SIZE,
@@ -68,10 +100,11 @@
 
   $effect(() => {
     countOpts.set({
-      queryKey: ['leis-count', debouncedTerm, ente, year] as readonly unknown[],
+      queryKey: ['leis-count', debouncedTerm, ente, tipoLei, year] as readonly unknown[],
       queryFn: () =>
         countLeisFiltered(debouncedTerm, {
           ente: ente || undefined,
+          tipoLei: tipoLei || undefined,
           year: year ?? undefined,
         }),
       staleTime: 5 * 60 * 1000,
@@ -90,7 +123,7 @@
 <section>
   <input
     type="search"
-    placeholder="Buscar leis (ex: servidores públicos, IPTU, meio ambiente...)"
+    placeholder="Buscar no texto das leis (ex: servidores públicos, IPTU, cargos...)"
     value={rawTerm}
     oninput={onTermInput}
     aria-label="Buscar leis"
@@ -104,9 +137,16 @@
       <option value="sp">São Paulo</option>
     </select>
 
+    <select value={tipoLei} onchange={onTipoLeiChange} aria-label="Filtrar por tipo de norma">
+      <option value="">Todos os tipos de norma</option>
+      <option value="lei">Lei Ordinária</option>
+      <option value="lei-complementar">Lei Complementar</option>
+      <option value="decreto">Decreto</option>
+    </select>
+
     <input
       type="number"
-      placeholder="Ano (ex: 2020)"
+      placeholder="Ano"
       min="1900"
       max="2099"
       value={year ?? ''}
@@ -124,18 +164,69 @@
   {:else}
     <p class="stats">
       {$countQ.isPending ? '…' : ($countQ.data ?? 0)}
-      resultado{($countQ.data ?? 0) !== 1 ? 's' : ''}
+      norma{($countQ.data ?? 0) !== 1 ? 's' : ''}
+      encontrada{($countQ.data ?? 0) !== 1 ? 's' : ''}
       {#if debouncedTerm}para "<em>{debouncedTerm}</em>"{/if}
     </p>
 
-    <div class="results">
-      {#each $resultsQ.data ?? [] as row (row.lei_id + '|' + row.dispositivo_path + '|' + (row.em ?? ''))}
-        <LeiCard {row} />
-      {/each}
+    <div class="results-table-container">
+      <table class="striped responsive">
+        <thead>
+          <tr>
+            <th scope="col">Norma</th>
+            <th scope="col" style="width: 90px; text-align: center;">Ano</th>
+            <th scope="col">Ementa / Conteúdo</th>
+            <th scope="col" style="width: 130px; text-align: center;">Ente</th>
+            <th scope="col" style="width: 100px; text-align: center;">Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each $resultsQ.data ?? [] as row (row.lei_id + '|' + row.dispositivo_path + '|' + (row.em ?? ''))}
+            <tr>
+              <td>
+                <span class="norma-titulo">
+                  {formatTipoLei(row.tipo_lei)} nº {row.numero_lei || 'S/N'}
+                </span>
+              </td>
+              <td style="text-align: center;">
+                <span class="norma-ano">{row.ano_lei || '-'}</span>
+              </td>
+              <td>
+                <div class="text-excerpt">
+                  {#if row.texto}
+                    {row.texto}
+                  {:else}
+                    <span class="no-text">Sem texto disponível</span>
+                  {/if}
+                </div>
+              </td>
+              <td style="text-align: center;">
+                <span class="badge {row.ente}">
+                  {formatEnte(row.ente)}
+                </span>
+              </td>
+              <td style="text-align: center;">
+                <a
+                  href={getIaUrl(row)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="btn-link"
+                >
+                  Abrir IA
+                </a>
+              </td>
+            </tr>
+          {/each}
 
-      {#if ($resultsQ.data ?? []).length === 0 && !$resultsQ.isFetching}
-        <p>Nenhum resultado{debouncedTerm ? ` para "${debouncedTerm}"` : ''}.</p>
-      {/if}
+          {#if ($resultsQ.data ?? []).length === 0 && !$resultsQ.isFetching}
+            <tr>
+              <td colspan="5" class="empty-state">
+                Nenhum resultado encontrado{debouncedTerm ? ` para "${debouncedTerm}"` : ''}.
+              </td>
+            </tr>
+          {/if}
+        </tbody>
+      </table>
     </div>
 
     {#if totalPages() > 1}
@@ -174,10 +265,86 @@
     color: var(--pico-muted-color, #666);
     margin: 0 0 0.5rem;
   }
-  .results {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+  .results-table-container {
+    overflow-x: auto;
+    background: var(--pico-card-background-color, #fff);
+    border: 1px solid var(--pico-border-color, #e1e1e1);
+    border-radius: var(--pico-border-radius, 8px);
+    margin-bottom: 1.5rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  }
+  table {
+    margin-bottom: 0;
+    font-size: 0.925rem;
+    width: 100%;
+  }
+  th {
+    background: var(--pico-table-border-color, #f9f9f9);
+    font-weight: 600;
+  }
+  td, th {
+    padding: 0.75rem 1rem;
+    vertical-align: middle;
+  }
+  .norma-titulo {
+    font-weight: 600;
+    color: var(--pico-primary, #0056b3);
+  }
+  .norma-ano {
+    font-variant-numeric: tabular-nums;
+  }
+  .text-excerpt {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.4;
+    max-height: 2.8em;
+    word-break: break-word;
+  }
+  .no-text {
+    font-style: italic;
+    color: var(--pico-muted-color, #888);
+  }
+  .empty-state {
+    text-align: center;
+    padding: 2rem;
+    color: var(--pico-muted-color, #666);
+  }
+  .badge {
+    display: inline-block;
+    padding: 0.2rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 4px;
+    text-transform: uppercase;
+  }
+  .badge.ro {
+    background-color: #e3f2fd;
+    color: #0d47a1;
+  }
+  .badge.sp {
+    background-color: #efebe9;
+    color: #3e2723;
+  }
+  .badge.federal {
+    background-color: #e8f5e9;
+    color: #1b5e20;
+  }
+  .btn-link {
+    display: inline-block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    text-decoration: none;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid var(--pico-primary, #0056b3);
+    border-radius: 4px;
+    transition: all 0.2s ease;
+  }
+  .btn-link:hover {
+    background: var(--pico-primary, #0056b3);
+    color: #fff !important;
   }
   .pagination {
     display: flex;

--- a/web/src/components/LeiSearchUI.svelte
+++ b/web/src/components/LeiSearchUI.svelte
@@ -13,7 +13,7 @@
   let rawTerm = $state('');
   let debouncedTerm = $state('');
   let ente = $state(''); // Padrão: Todos os entes
-  let tipoLei = $state(''); // Padrão: Todos os tipos de norma
+  let tipoLei = $state(''); // Rótulo selecionado (agrupa aliases); '' = todos
   let tipoOptions = $state<string[]>([]); // valores reais de tipo_lei no dataset
   let year = $state<number | null>(null);
   let page = $state(0);
@@ -28,6 +28,28 @@
       })
       .catch(() => {});
   });
+
+  // Agrupa valores crus equivalentes sob o mesmo rótulo (lei.complementar e lc
+  // → "Lei Complementar"): o dropdown não exibe opções duplicadas e o filtro
+  // casa todos os aliases de um tipo de uma vez (tipo_lei IN (...)).
+  const tipoGroups = $derived.by(() => {
+    const byLabel = new Map<string, string[]>();
+    for (const raw of tipoOptions) {
+      const label = formatTipoLei(raw);
+      const arr = byLabel.get(label) ?? [];
+      arr.push(raw);
+      byLabel.set(label, arr);
+    }
+    return [...byLabel.entries()]
+      .map(([label, values]) => ({ label, values }))
+      .sort((a, b) => a.label.localeCompare(b.label, 'pt'));
+  });
+
+  // Rótulo selecionado → todos os valores crus daquele tipo (ou undefined).
+  function selectedTipoValues(): string[] | undefined {
+    if (!tipoLei) return undefined;
+    return tipoGroups.find((g) => g.label === tipoLei)?.values;
+  }
 
   // Debounce: update debouncedTerm 400ms after last keystroke.
   $effect(() => {
@@ -118,7 +140,7 @@
       queryFn: () =>
         searchLeisFiltered(debouncedTerm, {
           ente: ente || undefined,
-          tipoLei: tipoLei || undefined,
+          tipoLei: selectedTipoValues(),
           year: year ?? undefined,
           page,
           pageSize: PAGE_SIZE,
@@ -133,7 +155,7 @@
       queryFn: () =>
         countLeisFiltered(debouncedTerm, {
           ente: ente || undefined,
-          tipoLei: tipoLei || undefined,
+          tipoLei: selectedTipoValues(),
           year: year ?? undefined,
         }),
       staleTime: 5 * 60 * 1000,
@@ -168,8 +190,8 @@
 
     <select value={tipoLei} onchange={onTipoLeiChange} aria-label="Filtrar por tipo de norma">
       <option value="">Todos os tipos de norma</option>
-      {#each tipoOptions as t}
-        <option value={t}>{formatTipoLei(t)}</option>
+      {#each tipoGroups as g}
+        <option value={g.label}>{g.label}</option>
       {/each}
     </select>
 

--- a/web/src/components/LeiSearchUI.svelte
+++ b/web/src/components/LeiSearchUI.svelte
@@ -4,6 +4,7 @@
   import {
     searchLeisFiltered,
     countLeisFiltered,
+    listTiposLei,
     PAGE_SIZE,
     type LeiRow,
   } from '../lib/db.ts';
@@ -13,8 +14,20 @@
   let debouncedTerm = $state('');
   let ente = $state(''); // Padrão: Todos os entes
   let tipoLei = $state(''); // Padrão: Todos os tipos de norma
+  let tipoOptions = $state<string[]>([]); // valores reais de tipo_lei no dataset
   let year = $state<number | null>(null);
   let page = $state(0);
+
+  // Popula o filtro de tipo a partir dos valores realmente persistidos no
+  // dataset (lei.complementar, lc, decreto, ...), evitando slugs hardcoded que
+  // poderiam divergir do ETL e filtrar zero resultados. Roda uma vez.
+  $effect(() => {
+    listTiposLei()
+      .then((tipos) => {
+        tipoOptions = tipos;
+      })
+      .catch(() => {});
+  });
 
   // Debounce: update debouncedTerm 400ms after last keystroke.
   $effect(() => {
@@ -47,12 +60,28 @@
   function formatTipoLei(tipo: string): string {
     if (!tipo) return 'Norma';
     const clean = tipo.toLowerCase();
-    if (clean === 'lei') return 'Lei Ordinária';
-    if (clean === 'lei-complementar') return 'Lei Complementar';
-    if (clean === 'decreto') return 'Decreto';
-    if (clean === 'resolucao') return 'Resolução';
-    if (clean === 'portaria') return 'Portaria';
-    return tipo.charAt(0).toUpperCase() + tipo.slice(1);
+    // O tipo_lei persistido vem do URN-LEX (lei.complementar, pontuado) ou da
+    // heurística de fallback do lei_id (lc) — cobrimos ambas as formas.
+    const labels: Record<string, string> = {
+      lei: 'Lei Ordinária',
+      'lei.complementar': 'Lei Complementar',
+      'lei-complementar': 'Lei Complementar',
+      lc: 'Lei Complementar',
+      decreto: 'Decreto',
+      'decreto-lei': 'Decreto-Lei',
+      'decreto.lei': 'Decreto-Lei',
+      'medida.provisoria': 'Medida Provisória',
+      'emenda.constitucional': 'Emenda Constitucional',
+      constituicao: 'Constituição',
+      resolucao: 'Resolução',
+      portaria: 'Portaria',
+    };
+    if (labels[clean]) return labels[clean];
+    // Desconhecido: prettifica separando por '.'/'‑' e capitalizando.
+    return clean
+      .split(/[.\-]/)
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ');
   }
 
   function formatEnte(enteCode: string): string {
@@ -139,9 +168,9 @@
 
     <select value={tipoLei} onchange={onTipoLeiChange} aria-label="Filtrar por tipo de norma">
       <option value="">Todos os tipos de norma</option>
-      <option value="lei">Lei Ordinária</option>
-      <option value="lei-complementar">Lei Complementar</option>
-      <option value="decreto">Decreto</option>
+      {#each tipoOptions as t}
+        <option value={t}>{formatTipoLei(t)}</option>
+      {/each}
     </select>
 
     <input

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -86,7 +86,9 @@ export const PAGE_SIZE = 20;
 
 export interface SearchOptions {
   ente?: string;
-  tipoLei?: string;
+  // Um valor exato, ou vários aliases equivalentes (ex: ['lei.complementar','lc'])
+  // que o filtro casa via tipo_lei IN (...).
+  tipoLei?: string | string[];
   year?: number;
   page?: number;
   pageSize?: number;
@@ -111,8 +113,16 @@ function buildWhere(query: string, opts: SearchOptions = {}) {
     params.push(ente);
   }
   if (tipoLei) {
-    clauses.push('tipo_lei = ?');
-    params.push(tipoLei);
+    // tipoLei pode ser um valor único ou vários aliases do mesmo tipo de norma
+    // (lei.complementar / lc) — casamos todos de uma vez.
+    const vals = (Array.isArray(tipoLei) ? tipoLei : [tipoLei]).filter(Boolean);
+    if (vals.length === 1) {
+      clauses.push('tipo_lei = ?');
+      params.push(vals[0]);
+    } else if (vals.length > 1) {
+      clauses.push(`tipo_lei IN (${vals.map(() => '?').join(', ')})`);
+      params.push(...vals);
+    }
   }
   if (year != null && year > 0) {
     // em is a DATE column inferred by read_json_auto; YEAR(NULL) = NULL → safe

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -175,6 +175,23 @@ export async function countLeisFiltered(
   return Number(rows[0]?.cnt ?? 0);
 }
 
+/**
+ * Distinct `tipo_lei` values present in the dataset, for the type filter.
+ *
+ * Driven by the data so the dropdown always uses the persisted representation
+ * (the ETL stores e.g. `lei.complementar` or `lc`, never a hardcoded slug) —
+ * a hardcoded option list would silently filter to zero matches if it drifted.
+ */
+export async function listTiposLei(): Promise<string[]> {
+  const rows = await runSql<{ tipo_lei: string }>(
+    "SELECT DISTINCT tipo_lei FROM versoes " +
+      "WHERE tipo_lei IS NOT NULL AND tipo_lei <> 'desconhecido' ORDER BY tipo_lei",
+    [],
+    (r) => (r as { toJSON(): { tipo_lei: string } }).toJSON(),
+  );
+  return rows.map((r) => r.tipo_lei).filter(Boolean);
+}
+
 /** @deprecated Use searchLeisFiltered instead. Max 100 rows (capped by searchLeisFiltered). */
 export async function searchLeis(query: string, limit = 20): Promise<LeiRow[]> {
   return searchLeisFiltered(query, { pageSize: limit });

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -71,8 +71,12 @@ export function getDb(): Promise<duckdb.AsyncDuckDB> {
 export interface LeiRow {
   lei_id: string;
   ente: string;
+  tipo_lei: string;
+  numero_lei: string | null;
+  ano_lei: number;
   dispositivo_path: string;
   dispositivo_tipo: string;
+  texto: string | null;
   texto_normalizado: string | null;
   em: string | null;
   ate: Date | null;
@@ -82,6 +86,7 @@ export const PAGE_SIZE = 20;
 
 export interface SearchOptions {
   ente?: string;
+  tipoLei?: string;
   year?: number;
   page?: number;
   pageSize?: number;
@@ -90,16 +95,25 @@ export interface SearchOptions {
 type RowMapper<T> = (r: unknown) => T;
 const toJson: RowMapper<LeiRow> = (r) => (r as { toJSON(): LeiRow }).toJSON();
 
-function buildWhere(query: string, ente?: string, year?: number) {
+function buildWhere(query: string, opts: SearchOptions = {}) {
+  const { ente, tipoLei, year } = opts;
   const clauses = ['ate IS NULL'];
   const params: Array<string | number> = [];
   if (query.trim()) {
     clauses.push('texto_normalizado ILIKE ?');
     params.push(`%${query.trim()}%`);
+  } else {
+    // Sem busca textual, mostramos uma linha por norma (a ementa) em vez de
+    // uma linha por dispositivo — a tabela lista normas, não artigos.
+    clauses.push("dispositivo_path = 'ementa'");
   }
   if (ente) {
     clauses.push('ente = ?');
     params.push(ente);
+  }
+  if (tipoLei) {
+    clauses.push('tipo_lei = ?');
+    params.push(tipoLei);
   }
   if (year != null && year > 0) {
     // em is a DATE column inferred by read_json_auto; YEAR(NULL) = NULL → safe
@@ -135,14 +149,14 @@ async function runSql<T>(
 }
 
 export async function searchLeisFiltered(query: string, opts: SearchOptions = {}): Promise<LeiRow[]> {
-  const { ente, year, page = 0, pageSize = PAGE_SIZE } = opts;
+  const { page = 0, pageSize = PAGE_SIZE } = opts;
   // Math.trunc + bounds enforce integer values — LIMIT/OFFSET cannot be injected.
   // DuckDB prepared statements do not support ? placeholders in LIMIT/OFFSET clauses.
   // Number.isFinite guard prevents NaN from reaching the SQL string (e.g. if caller
   // passes NaN explicitly; normal path always receives valid integers from PAGE_SIZE).
   const safeSize = Math.min(100, Math.max(1, Math.trunc(Number.isFinite(pageSize) ? pageSize : PAGE_SIZE)));
   const offset = Math.max(0, Math.trunc(Number.isFinite(page) ? page : 0)) * safeSize;
-  const { where, params } = buildWhere(query, ente, year);
+  const { where, params } = buildWhere(query, opts);
   // ORDER BY (lei_id, dispositivo_path) is globally unique → stable pagination across pages.
   const sql = `SELECT * FROM versoes WHERE ${where} ORDER BY lei_id, dispositivo_path LIMIT ${safeSize} OFFSET ${offset}`;
   return runSql(sql, params, toJson);
@@ -150,9 +164,9 @@ export async function searchLeisFiltered(query: string, opts: SearchOptions = {}
 
 export async function countLeisFiltered(
   query: string,
-  opts: Pick<SearchOptions, 'ente' | 'year'> = {},
+  opts: Pick<SearchOptions, 'ente' | 'tipoLei' | 'year'> = {},
 ): Promise<number> {
-  const { where, params } = buildWhere(query, opts.ente, opts.year);
+  const { where, params } = buildWhere(query, opts);
   const rows = await runSql<{ cnt: bigint | number }>(
     `SELECT COUNT(*)::BIGINT AS cnt FROM versoes WHERE ${where}`,
     params,

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -102,11 +102,10 @@ function buildWhere(query: string, opts: SearchOptions = {}) {
   if (query.trim()) {
     clauses.push('texto_normalizado ILIKE ?');
     params.push(`%${query.trim()}%`);
-  } else {
-    // Sem busca textual, mostramos uma linha por norma (a ementa) em vez de
-    // uma linha por dispositivo — a tabela lista normas, não artigos.
-    clauses.push("dispositivo_path = 'ementa'");
   }
+  // Sem busca textual (modo navegação) NÃO filtramos por dispositivo aqui:
+  // colapsamos para uma linha representativa por norma em searchLeisFiltered,
+  // para não esconder leis publicadas sem ementa (SCHEMA.md §0.6).
   if (ente) {
     clauses.push('ente = ?');
     params.push(ente);
@@ -157,8 +156,24 @@ export async function searchLeisFiltered(query: string, opts: SearchOptions = {}
   const safeSize = Math.min(100, Math.max(1, Math.trunc(Number.isFinite(pageSize) ? pageSize : PAGE_SIZE)));
   const offset = Math.max(0, Math.trunc(Number.isFinite(page) ? page : 0)) * safeSize;
   const { where, params } = buildWhere(query, opts);
-  // ORDER BY (lei_id, dispositivo_path) is globally unique → stable pagination across pages.
-  const sql = `SELECT * FROM versoes WHERE ${where} ORDER BY lei_id, dispositivo_path LIMIT ${safeSize} OFFSET ${offset}`;
+  let sql: string;
+  if (query.trim()) {
+    // Busca textual: uma linha por dispositivo que casa (mostra os trechos).
+    // ORDER BY (lei_id, dispositivo_path) is globally unique → stable pagination.
+    sql = `SELECT * FROM versoes WHERE ${where} ORDER BY lei_id, dispositivo_path LIMIT ${safeSize} OFFSET ${offset}`;
+  } else {
+    // Navegação: uma linha representativa por norma. Preferimos a ementa, com
+    // fallback para o primeiro dispositivo (leis em estágio incremental podem
+    // não ter ementa; SCHEMA.md §0.6) — assim nenhuma norma publicada some.
+    sql = `SELECT * EXCLUDE (_rn) FROM (
+        SELECT *, ROW_NUMBER() OVER (
+          PARTITION BY lei_id
+          ORDER BY (dispositivo_path = 'ementa') DESC, dispositivo_ordem, dispositivo_path
+        ) AS _rn
+        FROM versoes WHERE ${where}
+      ) WHERE _rn = 1
+      ORDER BY lei_id LIMIT ${safeSize} OFFSET ${offset}`;
+  }
   return runSql(sql, params, toJson);
 }
 
@@ -167,8 +182,11 @@ export async function countLeisFiltered(
   opts: Pick<SearchOptions, 'ente' | 'tipoLei' | 'year'> = {},
 ): Promise<number> {
   const { where, params } = buildWhere(query, opts);
+  // Navegação conta normas distintas (1 linha representativa por lei_id); busca
+  // textual conta dispositivos que casam — coerente com searchLeisFiltered.
+  const countExpr = query.trim() ? 'COUNT(*)' : 'COUNT(DISTINCT lei_id)';
   const rows = await runSql<{ cnt: bigint | number }>(
-    `SELECT COUNT(*)::BIGINT AS cnt FROM versoes WHERE ${where}`,
+    `SELECT ${countExpr}::BIGINT AS cnt FROM versoes WHERE ${where}`,
     params,
     (r) => (r as { toJSON(): { cnt: bigint | number } }).toJSON(),
   );

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,5 +4,5 @@ import LeiSearch from '../components/LeiSearch.svelte';
 ---
 
 <Layout title="Buscar leis">
-  <LeiSearch client:load />
+  <LeiSearch client:only="svelte" />
 </Layout>


### PR DESCRIPTION
Started as a reconciliation of #79 onto `main`; grew into the **ADR-0011 raw-layer redesign** at the owner's direction. Themes:

## 1. ADR-0011 — identity-keyed raw layer (supersedes ADR-0010's raw layer)

Identity-keyed range items + content-addressed files + reject-until-identified:

- **Ingestion gate:** raw enters only with a known identity `(ente, fonte, tipo, número)`. `parse_identity` rejects non-identifying keys; unidentifiable resources are **skipped at discovery** (not enqueued/deferred), so they stay rediscoverable.
- **IA item = identity range bucket** `leizilla_{ente}_{fonte}_{tipo}_{start}-{end}` (browsable, per-source namespaced).
- **Files = content-addressed** truncated UUIDv5; collisions detected via full SHA-256 and resolved by extending the UUID.
- **`index.csv` per item:** `(tipo, número, rendição, formato) → {uuid5, sha256, captured_at}`, append-only/newest-wins. Renditions + re-captures coexist as distinct hashed files; no `-rN`.
- `list_raw_ids` enumerates range items via the scrape API + reads each in-item index; `resolve_raw_url` resolves identity → item → index → file. Parsed layer stays URN-keyed.

Docs: `docs/adr/0011-*.md`, ADR-0010 marked partially superseded, `SCHEMA.md §1.1` updated.

## 2. ALRO assembleia now admitted like casacivil

`crawler.parse_titulo_identity` extracts `(tipo, número)` from each ALRO page title (Nº-anchored, accent/case-insensitive), so discovery emits real `lei-NNNNN`/`lc-NNNNN`/… keys instead of the opaque `coddoc`. Unparseable titles are skipped at discovery. `cmd_parse_all` treats every fonte uniformly (`{tipo}-{num}`).

## 3. Publisher: authenticate the `ia` CLI uploads

`_ia_subprocess_env()` writes a temp `ia.ini` and points the subprocess at it via `IA_CONFIG_FILE` — fixes `AuthenticationError` on every upload without perturbing the command list.

## 4. Web: table redesign + `tipo_lei` filter + Svelte 5 hydration fix

Ported from #79 onto main's real `versoes` schema. Browse shows one representative row per law (ementa-preferred, first-dispositivo fallback); the type filter is data-driven and groups equivalent aliases (`lei.complementar`/`lc`) under one option matching `tipo_lei IN (...)`.

## Review

All Codex findings addressed (LC filter value, ementa browse, alias coalescing, hyphenated-tipo parse-all, ALRO P1 + three P2s). Hyphenated entes/tipos parsed via `parse_raw_id` + `rpartition`.

## Verification

Full suite green (`546 passed, 13 skipped`), mypy + ruff clean (the `crawler.py`/`requests` mypy note is pre-existing and unrelated); `astro build` passes.

## Open (tracked in ADR-0011)

- Confirm empirically whether casacivil's `L{N}.pdf` number is the law number or the Ditel `coddoc` (affects range legibility, not correctness).
- Rendition vocabulary + per-source label→vocab classifier (index schema ready; harvest-side classification is follow-up).