### PR TITLE
feat(ro): DITEL ingestion — https fix, decretos, Wayback provenance

### DIFF
--- a/docs/ditel-ingestion.md
+++ b/docs/ditel-ingestion.md
@@ -84,9 +84,12 @@ no new format adapter (PDF is already handled), no Pydantic/structlog, no OPF.
   discovered URL's scheme to the manifest's** (https) so the http-keyed captures dedup
   against the sequential strategy's URLs (the resource ledger is keyed by literal URL) —
   the actual http snapshot is kept in `wayback_snapshot`.
-- carry the Wayback timestamp as provenance: `harvest` captures it explicitly (from the
-  resolved pair or recovered from a pre-discovered ledger URL via `snapshot_timestamp`) and
-  threads it into the raw-item metadata (`lei_data["wayback_timestamp"]`).
+- carry the Wayback timestamp as provenance, **serialized into the raw-item `_meta.json`**
+  (`provenance_wayback.wayback_timestamp`): `harvest` captures it explicitly (from the
+  resolved pair or recovered from a pre-discovered ledger URL via `snapshot_timestamp`);
+  `build_raw_meta` writes it, falling back to extracting it from the snapshot URL. The CLI
+  `scrape` path carries the CDX-discovered http snapshot into `scrape_one` so its historical
+  capture (and timestamp) is reused rather than lost to a scheme-sensitive lookup.
 - `cmd_scrape`: decreto support for the CLI range path.
 - tests: discovery URL generation (incl. decreto + https), `parse_filename` decreto, and the
   Wayback provenance helper, all offline (IO seams mocked/injectable).

--- a/docs/ditel-ingestion.md
+++ b/docs/ditel-ingestion.md
@@ -1,0 +1,115 @@
+# DITEL ingestion — Rondônia laws & decrees (Phase 0 map + plan)
+
+Goal: ingest the **laws, complementary laws, and decrees of Rondônia published by DITEL**
+(Casa Civil's COTEL system) through the existing crawl → Wayback → IA → OCR → parse →
+consolidate pipeline, producing the project's normal structured output (the Parquet
+`versoes` table, queryable in DuckDB). This is the Phase 0 diagnosis required before
+building; it is a **separate track from the OPF/span-tagging work** (PR #84) — that track is
+untouched here.
+
+## 1. The pipeline and where a new source plugs in
+
+```
+manifests/ro.json
+  → discovery.py strategies (wayback-cdx | sequential | playwright)  → discovered_resources (DuckDB ledger)
+  → scraper.harvest_pending_resources:
+        robots.is_allowed → wayback.save_page → wayback.check_available → fetch snapshot
+        (fail-open: direct fetch, rate-limited per host) → publisher.upload_raw → IA raw item
+  → IA auto-OCR (_djvu.txt)
+  → parser.fetch_ocr + parser.parse_law (Claude Haiku) → Leizilla XML  (dispositivo-centric;
+        rótulo derived from `path` via the SCHEMA §4.2 token map)
+  → etl.consolidate (xml_to_rows + write_parquet) → Parquet `versoes`  (grain: lei × dispositivo × versão)
+  → publisher.upload_dataset → IA dataset item → web/ DuckDB-WASM frontend
+```
+
+**The seam for a new source is two points:**
+1. a `fontes` block in `src/leizilla/manifests/ro.json`;
+2. a **discovery strategy** (`discovery.py`) that emits `discovered_resources` rows
+   `{url, ente, fonte, tipo_documento, chave, status, wayback_snapshot}`.
+
+Everything downstream (harvest, OCR, parse, consolidate, release) is **source-agnostic and
+already built** for PDF sources. Text enters as the IA OCR `_djvu.txt`; structure is
+assigned by the parse stage; the structured rows land in Parquet `versoes`. The local
+`data/leizilla.duckdb` `leis` table is only a scrape ledger, not the structured output.
+
+Conventions are dict-based + stdlib `logging` + DuckDB + `internetarchive` — **not** Pydantic
+/ structlog. New code follows the existing style.
+
+## 2. DITEL characterized (two layers: live source + Wayback)
+
+**Live source.** `https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/{prefix}{n}.pdf`:
+- `L{n}.pdf` = lei ordinária, `LC{n}.pdf` = lei complementar, `D{n}.pdf` = **decreto**.
+- **Born-digital PDFs** (`%PDF-1.4/1.3`, embedded Times-Roman fonts — *not* scanned), so the
+  OCR/format risk is low; a text layer is extractable directly.
+- Served over **HTTPS**. The plain-`http://` URL **403s** behind a WAF ("Request Rejected").
+- Probed live: `L5120` ✓, `LC1000` ✓, `D5000`/`D1000`/`D100` ✓ (all `200 application/pdf`).
+
+**Wayback layer.** Coverage is **sparse and inconsistent** (availability API):
+- `http://…/L5120.pdf` → archived 2024-12-08; `…/D1000.pdf` → archived 2022-09-03;
+- `…/LC1000.pdf` → **not archived**; `https://` variants → not archived.
+- So for most norms the first job is **Save Page Now** to populate Wayback, then ingest.
+  Snapshots are keyed by the *submitted* URL (http vs https matters for lookup).
+
+**Metadata.** `(tipo, número)` come from the filename (`parse_filename`) and/or the PDF
+title page (`parse_titulo_identity`, already implemented); `data`/`ementa` come from the
+parsed text. The Wayback **snapshot timestamp** is the provenance/version key.
+
+## 3. The gap
+
+| # | Missing / wrong | Why it matters |
+|---|---|---|
+| 1 | `manifests/ro.json` + `crawler.py` use `http://` | DITEL's WAF 403s on http → the pipeline can't fetch a single byte today |
+| 2 | no **decreto** enumeration (`discover_casacivil_laws` rejects non lei/lc; manifest has only `L`/`LC` templates) | the task wants laws **and** decrees; `D{n}.pdf` exists and `parse_filename` already maps `D`→decreto |
+| 3 | Wayback not populated for most DITEL URLs | need SPN-first, then ingest (decision: SPN-first, reuse any existing snapshot) |
+| 4 | `wayback.check_available` only accepts snapshots < 24 h old | it ignores the existing 2022/2024 archives and refetches direct, losing provenance; we want to **use & record any snapshot's timestamp** |
+| 5 | never run end-to-end (IA has 0 `leizilla-raw-ro` items) | Phase 2 must produce a real, verified batch |
+| 6 | parser quirks for RO statutes | likely none — RO follows LC 95/1998, highly regular `Art./§/inciso/alínea`; verify in Phase 2, **no model** |
+
+**Not gaps:** no new fetcher framework (reuse `wayback.py` + `scraper.py` + `publisher.py`),
+no new format adapter (PDF is already handled), no Pydantic/structlog, no OPF.
+
+## 4. Plan (decisions: new branch off main · full pipeline → Parquet · SPN-first/any-snapshot)
+
+**Phase 1 — adapter, built to the existing seam, offline-tested:**
+- `manifests/ro.json`: `http`→`https`; add a `D{num}.pdf` sequential template (decreto); fix
+  the wayback-cdx prefix.
+- `crawler.py`: `_CASACIVIL_*` base URLs → `https`; `discover_casacivil_laws` accepts
+  `decreto` (prefix `D`).
+- `wayback.py`: a provenance helper returning the **closest snapshot (URL + timestamp),
+  any age**, plus save-then-resolve — so the harvest reuses an existing archive and records
+  its timestamp; SPN when none exists.
+- carry the Wayback timestamp as provenance into the scrape ledger / parsed metadata.
+- `cmd_scrape`: decreto support for the CLI range path.
+- tests: discovery URL generation (incl. decreto + https), `parse_filename` decreto, and the
+  Wayback provenance helper, all offline (IO seams mocked/injectable).
+
+**Phase 2 — run a small real batch & verify:** the **fetch** stage runs here (Wayback/direct,
+no creds); **IA upload + IA OCR + Claude parse + Parquet** require `IA_*` / `ANTHROPIC_API_KEY`
+and so run in the **scheduled GitHub Actions** (`discover-harvest.yml`, `parse-release.yml`),
+which hold the secrets. We verify every sandbox-reachable step, report counts, and hand the
+credentialed stages to CI.
+
+### Phase 2 results (small real batch — 2 leis + 2 decretos, fetched via the `wayback` client)
+
+| chave | tipo | bytes | provenance | local text layer | structure |
+|---|---|---|---|---|---|
+| lei-05120 | lei | 424 KB | direct (not yet archived) | **born-digital** | `Art. 1°–6°` + ementa ✓ |
+| lei-05121 | lei | 184 KB | `wayback@20241208221945` | **born-digital** | `Art. 1°–5°` + ementa ✓ |
+| decreto-01000 | decreto | 391 KB | `wayback@20220903083131` | none (scanned) | — needs IA OCR |
+| decreto-01001 | decreto | 773 KB | `wayback@20220903083119` | none (scanned) | — needs IA OCR |
+
+`COUNTS: fetched 4/4 · born-digital-text 2 · article-structure-detected 2.`
+
+**Key finding (Phase 0 #6 resolved with data):** RO **laws are born-digital** (clean text
+layer; `Art./§/inciso` extract directly — LC 95 regularity confirmed, no model needed), but
+the **older decretos are scanned image PDFs** with no text layer. They are *not* a blocker —
+the pipeline's IA-OCR stage exists precisely for this (`parser.fetch_ocr` reads the IA
+`_djvu.txt`). So decretos ride the same path; they just depend on IA OCR where laws could
+even be parsed from the embedded text. Hand-verified L5120: ementa *"Institui a Campanha
+Permanente de Conscientização da depressão Infantil…"* + `Art. 1°` … `Art. 6° VETADO.`
+
+The **Wayback provenance** worked end-to-end: existing snapshots were reused (timestamps
+above are the immutable version keys), and unarchived URLs fall through to direct fetch
+(and would be submitted via Save-Page-Now in the harvest path). The credentialed stages
+(IA upload → OCR → Claude parse → Parquet `versoes`) run unchanged in the scheduled
+workflows.

--- a/docs/ditel-ingestion.md
+++ b/docs/ditel-ingestion.md
@@ -80,7 +80,10 @@ no new format adapter (PDF is already handled), no Pydantic/structlog, no OPF.
   historical captures are http-keyed while live downloads need https); `ensure_archived` is
   SPN-first and reads the new snapshot **from the Save-Page-Now response** (`Content-Location`)
   rather than an immediate re-query (SPN exposes snapshots asynchronously). CDX discovery
-  queries scheme-agnostically (SURT urlkey) for the same reason.
+  queries scheme-agnostically (SURT urlkey) for the same reason, and **normalizes each
+  discovered URL's scheme to the manifest's** (https) so the http-keyed captures dedup
+  against the sequential strategy's URLs (the resource ledger is keyed by literal URL) —
+  the actual http snapshot is kept in `wayback_snapshot`.
 - carry the Wayback timestamp as provenance: `harvest` captures it explicitly (from the
   resolved pair or recovered from a pre-discovered ledger URL via `snapshot_timestamp`) and
   threads it into the raw-item metadata (`lei_data["wayback_timestamp"]`).

--- a/docs/ditel-ingestion.md
+++ b/docs/ditel-ingestion.md
@@ -90,7 +90,10 @@ no new format adapter (PDF is already handled), no Pydantic/structlog, no OPF.
   `build_raw_meta` writes it, falling back to extracting it from the snapshot URL. The CLI
   `scrape` path carries the CDX-discovered http snapshot into `scrape_one` so its historical
   capture (and timestamp) is reused rather than lost to a scheme-sensitive lookup.
-- `cmd_scrape`: decreto support for the CLI range path.
+- `cmd_scrape`: decreto support; the casacivil branch enumerates the **whole range** and
+  merges CDX snapshots in (DITEL coverage is sparse — a CDX hit must not truncate the range,
+  or unarchived numbers are silently skipped); `scrape_one` uses `ensure_archived` for items
+  without a pre-discovered snapshot (SPN-first provenance, not an immediate availability check).
 - tests: discovery URL generation (incl. decreto + https), `parse_filename` decreto, and the
   Wayback provenance helper, all offline (IO seams mocked/injectable).
 

--- a/docs/ditel-ingestion.md
+++ b/docs/ditel-ingestion.md
@@ -97,6 +97,15 @@ no new format adapter (PDF is already handled), no Pydantic/structlog, no OPF.
 - tests: discovery URL generation (incl. decreto + https), `parse_filename` decreto, and the
   Wayback provenance helper, all offline (IO seams mocked/injectable).
 
+**Upgrade note (http→https ledger).** Changing the templates from `http://` to `https://`
+changes the literal URL that keys `discovered_resources`, so in principle an *existing* DB
+populated from the old templates would carry stale http rows alongside the new https ones
+(`insert_resource` is `INSERT OR IGNORE`). This does **not** apply here: ingestion has never
+run (IA has 0 `leizilla-raw-ro` items), the local DuckDB is gitignored, and the scheduled
+workflows run in ephemeral containers that rebuild the ledger from the current manifest each
+run — there is nothing to migrate. If a real ledger is ever carried across this change, drop
+`discovered_resources` (it's a rebuildable cache) or reconcile the old keys by `chave`.
+
 **Phase 2 — run a small real batch & verify:** the **fetch** stage runs here (Wayback/direct,
 no creds); **IA upload + IA OCR + Claude parse + Parquet** require `IA_*` / `ANTHROPIC_API_KEY`
 and so run in the **scheduled GitHub Actions** (`discover-harvest.yml`, `parse-release.yml`),

--- a/docs/ditel-ingestion.md
+++ b/docs/ditel-ingestion.md
@@ -75,10 +75,15 @@ no new format adapter (PDF is already handled), no Pydantic/structlog, no OPF.
   the wayback-cdx prefix.
 - `crawler.py`: `_CASACIVIL_*` base URLs → `https`; `discover_casacivil_laws` accepts
   `decreto` (prefix `D`).
-- `wayback.py`: a provenance helper returning the **closest snapshot (URL + timestamp),
-  any age**, plus save-then-resolve — so the harvest reuses an existing archive and records
-  its timestamp; SPN when none exists.
-- carry the Wayback timestamp as provenance into the scrape ledger / parsed metadata.
+- `wayback.py`: provenance helpers — `closest_snapshot` returns **(URL + timestamp), any
+  age, querying both http and https** (the availability API is scheme-sensitive and DITEL's
+  historical captures are http-keyed while live downloads need https); `ensure_archived` is
+  SPN-first and reads the new snapshot **from the Save-Page-Now response** (`Content-Location`)
+  rather than an immediate re-query (SPN exposes snapshots asynchronously). CDX discovery
+  queries scheme-agnostically (SURT urlkey) for the same reason.
+- carry the Wayback timestamp as provenance: `harvest` captures it explicitly (from the
+  resolved pair or recovered from a pre-discovered ledger URL via `snapshot_timestamp`) and
+  threads it into the raw-item metadata (`lei_data["wayback_timestamp"]`).
 - `cmd_scrape`: decreto support for the CLI range path.
 - tests: discovery URL generation (incl. decreto + https), `parse_filename` decreto, and the
   Wayback provenance helper, all offline (IO seams mocked/injectable).

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -412,9 +412,10 @@ def cmd_scrape(
     if tipo == "lcp" and fonte != "planalto":
         echo(f"--tipo lcp só é válido com --fonte planalto (recebido: --fonte {fonte})")
         raise typer.Exit(1)
-    if tipo == "decreto" and fonte != "planalto":
+    if tipo == "decreto" and fonte not in ("planalto", "casacivil"):
         echo(
-            f"--tipo decreto só é válido com --fonte planalto (recebido: --fonte {fonte})"
+            f"--tipo decreto só é válido com --fonte planalto/casacivil "
+            f"(recebido: --fonte {fonte})"
         )
         raise typer.Exit(1)
 
@@ -499,7 +500,7 @@ def cmd_scrape(
                             f"Consultando API CDX da Wayback Machine para {ente}/{fonte}..."
                         )
                         cdx_cfg = {
-                            "prefix": "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/"
+                            "prefix": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/"
                         }
                         discovery = WaybackCdxDiscovery(cdx_cfg, ente, fonte)
                         discovered = discovery.run()
@@ -518,7 +519,7 @@ def cmd_scrape(
                                             "fonte": fonte,
                                             "chave": item["chave"],
                                             "titulo": f"{tipo.upper()} {item['chave'].split('-')[-1]} ({ente.upper()})",
-                                            "url_original": "http://ditel.casacivil.ro.gov.br/COTEL/Livros/",
+                                            "url_original": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/",
                                             "url_pdf_original": item["url"],
                                         }
                                     )

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -521,6 +521,10 @@ def cmd_scrape(
                                             "titulo": f"{tipo.upper()} {item['chave'].split('-')[-1]} ({ente.upper()})",
                                             "url_original": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/",
                                             "url_pdf_original": item["url"],
+                                            # captura http-keyed descoberta (provenance)
+                                            "wayback_snapshot": item.get(
+                                                "wayback_snapshot"
+                                            ),
                                         }
                                     )
                             except ValueError:
@@ -564,7 +568,13 @@ def cmd_scrape(
                         skipped_ok += 1
                         continue
                 result = scrape_one(
-                    fonte_url, pdf_url, law, publisher, rate_limiter, index_cache
+                    fonte_url,
+                    pdf_url,
+                    law,
+                    publisher,
+                    rate_limiter,
+                    index_cache,
+                    wayback_snapshot=law.get("wayback_snapshot"),
                 )
                 if result.get("success"):
                     echo(f"  OK: {result.get('ia_id', '?')}")

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -486,9 +486,20 @@ def cmd_scrape(
                     end_coddoc=end_coddoc,
                 )
             elif ente == "ro" and fonte == "casacivil":
-                laws = []
+                from leizilla.crawler import discover_casacivil_laws
                 from leizilla.discovery import WaybackCdxDiscovery
 
+                # Base: enumera a FAIXA INTEIRA. A cobertura da DITEL é esparsa, então
+                # os números não-arquivados também têm de ser processados (vão ao Save
+                # Page Now em scrape_one) — não podemos tratar os hits do CDX como o
+                # conjunto completo, senão um range com 1 arquivado e N não-arquivados
+                # processaria só o arquivado.
+                laws = discover_casacivil_laws(
+                    tipo=tipo, start_num=start_coddoc, end_num=end_coddoc
+                )
+
+                # Enriquece com snapshots já arquivados (CDX) para reusar a captura
+                # histórica http-keyed + timestamp em vez de re-arquivar.
                 is_mocked = (
                     hasattr(WaybackCdxDiscovery, "mock")
                     or hasattr(WaybackCdxDiscovery, "return_value")
@@ -502,50 +513,25 @@ def cmd_scrape(
                         cdx_cfg = {
                             "prefix": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/"
                         }
-                        discovery = WaybackCdxDiscovery(cdx_cfg, ente, fonte)
-                        discovered = discovery.run()
-
-                        for item in discovered:
-                            if item["tipo_documento"] != tipo:
-                                continue
-                            try:
-                                # Extract number to filter by start/end range
-                                num = int(item["chave"].split("-")[-1])
-                                if start_coddoc <= num <= end_coddoc:
-                                    laws.append(
-                                        {
-                                            "id": f"{ente}-{fonte}-{item['chave']}",
-                                            "ente": ente,
-                                            "fonte": fonte,
-                                            "chave": item["chave"],
-                                            "titulo": f"{tipo.upper()} {item['chave'].split('-')[-1]} ({ente.upper()})",
-                                            "url_original": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/",
-                                            "url_pdf_original": item["url"],
-                                            # captura http-keyed descoberta (provenance)
-                                            "wayback_snapshot": item.get(
-                                                "wayback_snapshot"
-                                            ),
-                                        }
-                                    )
-                            except ValueError:
-                                continue
+                        snapshot_by_chave = {
+                            item["chave"]: item["wayback_snapshot"]
+                            for item in WaybackCdxDiscovery(cdx_cfg, ente, fonte).run()
+                            if item.get("tipo_documento") == tipo
+                            and item.get("wayback_snapshot")
+                        }
+                        for law in laws:
+                            snap = snapshot_by_chave.get(law["chave"])
+                            if snap:
+                                law["wayback_snapshot"] = snap
                         echo(
-                            f"  Encontradas {len(laws)} leis existentes arquivadas na faixa {start_coddoc}-{end_coddoc}"
+                            f"  {len(laws)} itens na faixa {start_coddoc}-{end_coddoc}; "
+                            f"{len(snapshot_by_chave)} com snapshot Wayback pré-descoberto"
                         )
                     except Exception as e:
                         echo(
-                            f"  Erro ao consultar CDX ({e}). Usando fallback sequencial."
+                            f"  Erro ao consultar CDX ({e}); "
+                            f"seguindo sem snapshots pré-descobertos."
                         )
-                        laws = []
-
-                if not laws:
-                    from leizilla.crawler import discover_casacivil_laws
-
-                    laws = discover_casacivil_laws(
-                        tipo=tipo,
-                        start_num=start_coddoc,
-                        end_num=end_coddoc,
-                    )
             else:
                 echo(f"Fonte '{fonte}' para '{ente}' ainda não implementada")
                 raise typer.Exit(1)

--- a/src/leizilla/crawler.py
+++ b/src/leizilla/crawler.py
@@ -14,8 +14,10 @@ from playwright.async_api import Browser, Page, async_playwright
 
 from leizilla import config
 
-_CASACIVIL_FILES_BASE = "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files"
-_CASACIVIL_FONTE_URL = "http://ditel.casacivil.ro.gov.br/COTEL/Livros/"
+# HTTPS only — DITEL's WAF returns 403 ("Request Rejected") on plain http (verified
+# 2026-06; born-digital PDFs served over https). See docs/ditel-ingestion.md.
+_CASACIVIL_FILES_BASE = "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files"
+_CASACIVIL_FONTE_URL = "https://ditel.casacivil.ro.gov.br/COTEL/Livros/"
 
 # Tipos normativos reconhecíveis no título de uma página de norma, do mais
 # específico para o mais genérico (ordem importa: "lei complementar" antes de
@@ -65,23 +67,33 @@ def parse_titulo_identity(titulo: str) -> Optional[Tuple[str, int]]:
     return tipo, numero
 
 
+# DITEL filename prefix + human label per normative type (Casa Civil COTEL).
+_CASACIVIL_TIPOS: Dict[str, Tuple[str, str]] = {
+    "lei": ("L", "Lei"),
+    "lc": ("LC", "Lei Complementar"),
+    "decreto": ("D", "Decreto"),
+}
+
+
 def discover_casacivil_laws(
     tipo: str = "lei",
     start_num: int = 1,
     end_num: int = 100,
 ) -> List[Dict[str, Any]]:
-    """Enumera leis da Casa Civil de Rondônia por número sequencial.
+    """Enumera leis e decretos da Casa Civil de Rondônia por número sequencial.
 
-    Não usa Playwright — PDFs disponíveis diretamente via HTTP sem JS.
+    Não usa Playwright — PDFs disponíveis diretamente via HTTPS sem JS.
     URL pattern: ditel.casacivil.ro.gov.br/COTEL/Livros/Files/{prefix}{N}.pdf
-      tipo="lei" → prefix "L"  (leis ordinárias)
-      tipo="lc"  → prefix "LC" (leis complementares)
+      tipo="lei"     → prefix "L"  (leis ordinárias)
+      tipo="lc"      → prefix "LC" (leis complementares)
+      tipo="decreto" → prefix "D"  (decretos)
 
     Não verifica existência aqui — scrape_one resolve via Wayback/direct e
     falha graciosamente se o arquivo não existir.
     """
-    if tipo not in ("lei", "lc"):
-        raise ValueError(f"tipo deve ser 'lei' ou 'lc', recebeu '{tipo}'")
+    if tipo not in _CASACIVIL_TIPOS:
+        valid = ", ".join(sorted(_CASACIVIL_TIPOS))
+        raise ValueError(f"tipo deve ser um de {{{valid}}}, recebeu '{tipo}'")
 
     if start_num > end_num:
         logging.getLogger(__name__).warning(
@@ -90,8 +102,7 @@ def discover_casacivil_laws(
             end_num,
         )
 
-    prefix = "L" if tipo == "lei" else "LC"
-    nome = "Lei Complementar" if tipo == "lc" else "Lei"
+    prefix, nome = _CASACIVIL_TIPOS[tipo]
     laws: List[Dict[str, Any]] = []
 
     for num in range(start_num, end_num + 1):

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -5,6 +5,7 @@ Lê manifestos declarativos por ente e popula a tabela de discovered_resources.
 
 import json
 import logging
+import re
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -54,7 +55,11 @@ class WaybackCdxDiscovery(DiscoveryStrategy):
 
     def run(self) -> List[Dict[str, Any]]:
         logger.info(f"Rodando Wayback CDX Discovery para {self.ente}/{self.fonte}...")
-        url = f"https://web.archive.org/cdx/search/cdx?url={urllib.parse.quote(self.prefix)}&matchType=prefix&output=json"
+        # Consulta sem esquema (urlkey é SURT, scheme-agnóstico): casa capturas http E
+        # https — as históricas da DITEL são http-keyed, o download ao vivo é https
+        # (Codex P1). Sem isto, um prefixo só-https perderia os snapshots antigos.
+        prefix_key = re.sub(r"^https?://", "", self.prefix)
+        url = f"https://web.archive.org/cdx/search/cdx?url={urllib.parse.quote(prefix_key)}&matchType=prefix&output=json"
         req = urllib.request.Request(
             url, headers={"User-Agent": "leizilla-crawler/0.1"}
         )

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -50,6 +50,11 @@ class WaybackCdxDiscovery(DiscoveryStrategy):
 
     def __init__(self, config: Dict[str, Any], ente: str, fonte: str) -> None:
         self.prefix = config["prefix"]
+        # Esquema canônico (do manifesto): normalizamos as URLs descobertas para ele de
+        # modo que casem com as da estratégia sequencial — discovered_resources é keyed
+        # pela URL literal, então http://…/L1.pdf e https://…/L1.pdf seriam duas linhas
+        # (mesma norma colhida duas vezes). O snapshot http real fica em wayback_snapshot.
+        self.canonical_scheme = "https" if self.prefix.startswith("https") else "http"
         self.ente = ente
         self.fonte = fonte
 
@@ -93,10 +98,15 @@ class WaybackCdxDiscovery(DiscoveryStrategy):
                     # _unidentified. O harvest key (nome do arquivo) fica preservado.
                     tipo, chave = "", f"documento-{filename.rsplit('.', 1)[0]}"
 
+                # snapshot real (preserva o esquema arquivado, p.ex. http); a chave de
+                # dedup (url) é normalizada para o esquema canônico do manifesto.
                 wayback_url = f"https://web.archive.org/web/{timestamp}/{orig_url}"
+                dedup_url = re.sub(
+                    r"^https?://", f"{self.canonical_scheme}://", orig_url
+                )
                 resources.append(
                     {
-                        "url": orig_url,
+                        "url": dedup_url,
                         "ente": self.ente,
                         "fonte": self.fonte,
                         "tipo_documento": tipo,

--- a/src/leizilla/manifests/ro.json
+++ b/src/leizilla/manifests/ro.json
@@ -6,12 +6,12 @@
       "discovery": [
         {
           "strategy": "wayback-cdx",
-          "prefix": "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/"
+          "prefix": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/"
         },
         {
           "strategy": "sequential",
           "templates": [
-            "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/L{num}.pdf"
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/L{num}.pdf"
           ],
           "start": 1,
           "end": 6000
@@ -19,10 +19,18 @@
         {
           "strategy": "sequential",
           "templates": [
-            "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/LC{num}.pdf"
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/LC{num}.pdf"
           ],
           "start": 1,
           "end": 1300
+        },
+        {
+          "strategy": "sequential",
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/D{num}.pdf"
+          ],
+          "start": 1,
+          "end": 30000
         }
       ]
     },

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -70,6 +70,23 @@ def _bundle_identifier(ente: str, fonte: str, dt: Optional[datetime] = None) -> 
     return f"leizilla-bundle-{ente}-{fonte}-{iso[0]}-W{iso[1]:02d}"
 
 
+def _wayback_timestamp(
+    lei_data: Dict[str, Any], wayback_url: Optional[str]
+) -> Optional[str]:
+    """Timestamp imutável da captura Wayback (chave de versão, ADR-0004).
+
+    Preferimos o valor explícito em ``lei_data`` (vindo do harvest), com fallback para a
+    extração da própria URL do snapshot — assim o ``_meta.json`` sempre carrega o instante
+    da captura, não a hora do upload.
+    """
+    from leizilla.wayback import snapshot_timestamp
+
+    explicit = lei_data.get("wayback_timestamp")
+    if explicit:
+        return str(explicit)
+    return snapshot_timestamp(wayback_url) if wayback_url else None
+
+
 def build_raw_meta(
     lei_data: Dict[str, Any],
     pdf_bytes: bytes,
@@ -94,6 +111,7 @@ def build_raw_meta(
         "provenance_wayback": {
             "fetched_from": fetched_from,
             "wayback_url": wayback_url,
+            "wayback_timestamp": _wayback_timestamp(lei_data, wayback_url),
             "wayback_blocked_robots": wayback_blocked_robots,
         },
     }
@@ -125,6 +143,7 @@ def build_raw_meta_html(
         "provenance_wayback": {
             "fetched_from": fetched_from,
             "wayback_url": wayback_url,
+            "wayback_timestamp": _wayback_timestamp(lei_data, wayback_url),
             "wayback_blocked_robots": wayback_blocked_robots,
         },
     }

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -26,6 +26,7 @@ def scrape_one(
     publisher: InternetArchivePublisher,
     rate_limiter: Optional[Callable[[str], None]] = None,
     index_cache: Optional[Dict[str, str]] = None,
+    wayback_snapshot: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Scrape um PDF: robots check → wayback save → fetch → upload_raw.
 
@@ -34,6 +35,9 @@ def scrape_one(
     rate_limiter recebe a URL do fallback para tracking por host.
     ``index_cache`` (acumulador por item do lote) repassa-se ao ``upload_raw``
     para evitar lost-update do index.csv entre uploads ao mesmo item de range.
+    ``wayback_snapshot`` é um snapshot pré-descoberto (ex.: CDX) usado preferencialmente
+    — preserva capturas http-keyed que ``check_available`` (scheme-sensitive) perderia
+    na URL normalizada https; o timestamp da captura serve de chave de versão (ADR-0004).
     """
     if not robots.is_allowed(fonte_url):
         return {"success": False, "reason": "robots-blocked", "url": fonte_url}
@@ -49,8 +53,9 @@ def scrape_one(
     except Exception:
         pass
 
-    # Wayback fetch (primário)
-    wb_url = wayback.check_available(pdf_url)
+    # Wayback fetch (primário): snapshot pré-descoberto (CDX) tem prioridade — preserva
+    # a captura http-keyed; senão consulta a API de disponibilidade.
+    wb_url = wayback_snapshot or wayback.check_available(pdf_url)
     fetched_from: str
     pdf_bytes: Optional[bytes]
 

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -207,9 +207,14 @@ def harvest_pending_resources(
             stats["robots-blocked"] += 1
             continue
 
-        # Se não temos snapshot pré-descoberto, tenta Wayback Machine
+        # Se não temos snapshot pré-descoberto, resolve via Wayback com proveniência:
+        # SPN-first, reusa QUALQUER captura existente (ensure_archived) — a URL do
+        # snapshot carrega o timestamp imutável que serve de chave de versão (ADR-0004,
+        # docs/ditel-ingestion.md).
         if not wb_url:
-            wb_url = wayback.check_available(url)
+            snap = wayback.ensure_archived(url)
+            if snap is not None:
+                wb_url = snap[0]
 
         pdf_bytes = None
         fetched_from = "source-fallback"

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -44,18 +44,24 @@ def scrape_one(
     if not robots.is_allowed(pdf_url):
         return {"success": False, "reason": "robots-blocked", "url": pdf_url}
 
-    # Wayback save — fire-and-forget; exceções swallowadas explicitamente
-    # para que falhas de rede (DNS, timeout) não abortem o scrape
-    # das URLs que importam (fetch + upload).
+    # Wayback save do índice/fonte — fire-and-forget; exceções swallowadas para que
+    # falhas de rede não abortem fetch+upload. A captura do PDF em si é feita por
+    # ensure_archived abaixo (que lê o snapshot da resposta do save).
     try:
         wayback.save_page(fonte_url)
-        wayback.save_page(pdf_url)
     except Exception:
         pass
 
-    # Wayback fetch (primário): snapshot pré-descoberto (CDX) tem prioridade — preserva
-    # a captura http-keyed; senão consulta a API de disponibilidade.
-    wb_url = wayback_snapshot or wayback.check_available(pdf_url)
+    # Resolução do snapshot com proveniência: um snapshot pré-descoberto (CDX) tem
+    # prioridade; senão ensure_archived (SPN-first, dual-scheme, lê a resposta do save —
+    # não a re-consulta imediata que o SPN assíncrono não satisfaz). Vale também para o
+    # caminho sequencial/não-arquivado da CLI, não só para itens já no CDX.
+    wb_url: Optional[str]
+    if wayback_snapshot:
+        wb_url = wayback_snapshot
+    else:
+        snap = wayback.ensure_archived(pdf_url)
+        wb_url = snap[0] if snap is not None else None
     fetched_from: str
     pdf_bytes: Optional[bytes]
 

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -207,14 +207,16 @@ def harvest_pending_resources(
             stats["robots-blocked"] += 1
             continue
 
-        # Se não temos snapshot pré-descoberto, resolve via Wayback com proveniência:
-        # SPN-first, reusa QUALQUER captura existente (ensure_archived) — a URL do
-        # snapshot carrega o timestamp imutável que serve de chave de versão (ADR-0004,
-        # docs/ditel-ingestion.md).
+        # Resolve via Wayback com proveniência: SPN-first, reusa QUALQUER captura
+        # existente (ensure_archived). O timestamp do snapshot é a chave de versão
+        # imutável (ADR-0004, docs/ditel-ingestion.md) — preservado explicitamente, não
+        # descartado: vem do par (url, ts) quando resolvido agora, ou é extraído da URL
+        # do snapshot pré-descoberto no ledger.
+        wb_ts: Optional[str] = wayback.snapshot_timestamp(wb_url) if wb_url else None
         if not wb_url:
             snap = wayback.ensure_archived(url)
             if snap is not None:
-                wb_url = snap[0]
+                wb_url, wb_ts = snap
 
         pdf_bytes = None
         fetched_from = "source-fallback"
@@ -229,6 +231,7 @@ def harvest_pending_resources(
             pdf_bytes = wayback.fetch_bytes(url)
             fetched_from = "source-fallback"
             wb_url = None
+            wb_ts = None
 
         if pdf_bytes is None:
             storage.update_resource_status(url, "failed")
@@ -250,6 +253,9 @@ def harvest_pending_resources(
             "chave": chave,
             "titulo": f"{tipo.upper()} {chave} ({ente.upper()})",
             "url_original": url,  # proveniência: mapeia o arquivo → fonte (ADR-0010)
+            # chave de versão de proveniência (ADR-0004): o instante da captura Wayback
+            # que materializa "a norma como estava" naquela data.
+            "wayback_timestamp": wb_ts,
         }
 
         try:

--- a/src/leizilla/wayback.py
+++ b/src/leizilla/wayback.py
@@ -66,14 +66,17 @@ def check_available(url: str, max_age_seconds: int = _MAX_AGE_SECONDS) -> Option
     return None
 
 
-def closest_snapshot(url: str) -> Optional[Tuple[str, str]]:
-    """Retorna ``(snapshot_url, timestamp)`` da captura 200 mais próxima — **qualquer idade**.
+def _flip_scheme(url: str) -> Optional[str]:
+    """http↔https variant of ``url`` (or ``None`` if it has no http(s) scheme)."""
+    if url.startswith("https://"):
+        return "http://" + url[len("https://") :]
+    if url.startswith("http://"):
+        return "https://" + url[len("http://") :]
+    return None
 
-    Diferente de :func:`check_available` (que exige um snapshot fresco, < 24 h), serve à
-    **proveniência**: reusa uma captura já existente (mesmo antiga) como chave de versão
-    imutável (ADR-0004). O ``timestamp`` é a string ``YYYYMMDDHHMMSS`` do Wayback. Retorna
-    ``None`` se não há captura 200 ou a API falha (fail-open).
-    """
+
+def _query_available(url: str) -> Optional[Tuple[str, str]]:
+    """One availability-API call → ``(snapshot_url, timestamp)`` for a 200 closest, or None."""
     try:
         api_url = f"{_AVAILABILITY_API}?url={urllib.parse.quote(url, safe='')}"
         req = urllib.request.Request(api_url)
@@ -82,7 +85,6 @@ def closest_snapshot(url: str) -> Optional[Tuple[str, str]]:
             data: dict = json.loads(resp.read().decode("utf-8"))
     except Exception:
         return None
-
     snapshot = data.get("archived_snapshots", {}).get("closest", {})
     if not snapshot or snapshot.get("status") != "200":
         return None
@@ -93,18 +95,75 @@ def closest_snapshot(url: str) -> Optional[Tuple[str, str]]:
     return snap_url, timestamp
 
 
-def ensure_archived(url: str, timeout: int = 60) -> Optional[Tuple[str, str]]:
+def closest_snapshot(url: str) -> Optional[Tuple[str, str]]:
+    """Retorna ``(snapshot_url, timestamp)`` da captura 200 mais próxima — **qualquer idade**.
+
+    Diferente de :func:`check_available` (que exige um snapshot fresco, < 24 h), serve à
+    **proveniência**: reusa uma captura já existente (mesmo antiga) como chave de versão
+    imutável (ADR-0004). O ``timestamp`` é ``YYYYMMDDHHMMSS``. ``None`` se não há captura.
+
+    A API de disponibilidade é **sensível ao esquema** (http vs https são chaves distintas);
+    as capturas históricas da DITEL são chaveadas em ``http`` enquanto o download ao vivo
+    exige ``https`` (WAF). Por isso consultamos **ambos os esquemas** e reusamos a primeira
+    captura 200 encontrada — senão perderíamos os snapshots históricos (Codex P1).
+    """
+    for candidate in (url, _flip_scheme(url)):
+        if candidate:
+            found = _query_available(candidate)
+            if found is not None:
+                return found
+    return None
+
+
+def save_and_locate(url: str, timeout: int = 90) -> Optional[Tuple[str, str]]:
+    """Dispara Save Page Now e devolve ``(snapshot_url, timestamp)`` da captura recém-feita.
+
+    Save Page Now **expõe o snapshot de forma assíncrona** — uma re-consulta imediata à API
+    de disponibilidade quase sempre retorna ``None`` (Codex P1). Em vez de poll, lemos a
+    própria resposta do SPN: o snapshot recém-criado aparece no header ``Content-Location``
+    (``/web/<ts>/<orig>``) ou na URL final após o redirect. ``None`` se o save falhar ou não
+    expuser um snapshot (fail-open).
+    """
+    save_url = _SAVE_URL_TMPL.format(urllib.parse.quote(url, safe=":/"))
+    req = urllib.request.Request(save_url)
+    req.add_header("User-Agent", _USER_AGENT)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            content_location = resp.headers.get("Content-Location", "") or ""
+            final_url = resp.geturl() or ""
+    except Exception:
+        return None
+
+    for candidate in (content_location, final_url):
+        ts = snapshot_timestamp(candidate)
+        if ts:
+            snap_url = (
+                candidate
+                if candidate.startswith("http")
+                else f"https://web.archive.org{candidate}"
+            )
+            return snap_url, ts
+    return None
+
+
+def ensure_archived(url: str, timeout: int = 90) -> Optional[Tuple[str, str]]:
     """Garante uma captura Wayback e devolve ``(snapshot_url, timestamp)``, ou ``None``.
 
     Política **SPN-first, reusa qualquer snapshot** (decisão de proveniência da DITEL,
-    docs/ditel-ingestion.md): se já há captura, reusa-a (sem re-arquivar); senão, dispara
-    Save Page Now e re-consulta. Fail-open: ``None`` se nada puder ser arquivado/encontrado
-    — o chamador cai no fetch direto (princípio #9).
+    docs/ditel-ingestion.md):
+    1. reusa uma captura existente (qualquer idade, **ambos os esquemas**) sem re-arquivar;
+    2. senão, dispara Save Page Now e lê o snapshot **da resposta do save**
+       (:func:`save_and_locate`) — sem depender de re-consulta imediata, que o SPN
+       assíncrono não satisfaz (Codex P1);
+    3. último recurso, re-consulta a disponibilidade.
+    Fail-open: ``None`` → o chamador cai no fetch direto (princípio #9).
     """
     existing = closest_snapshot(url)
     if existing is not None:
         return existing
-    save_page(url, timeout=timeout)
+    located = save_and_locate(url, timeout=timeout)
+    if located is not None:
+        return located
     return closest_snapshot(url)
 
 

--- a/src/leizilla/wayback.py
+++ b/src/leizilla/wayback.py
@@ -5,6 +5,7 @@ direto se Wayback falhar.
 """
 
 import json
+import re
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
@@ -16,6 +17,19 @@ _USER_AGENT = (
     "leizilla-crawler/0.1 (legal-indexer; https://github.com/franklinbaldo/leizilla)"
 )
 _MAX_AGE_SECONDS = 24 * 3600
+
+# A Wayback snapshot URL embeds its capture timestamp: …/web/<YYYYMMDDhhmmss>/<orig>.
+_SNAPSHOT_TS_RE = re.compile(r"/web/(\d{14})(?:[a-z_]*)?/")
+
+
+def snapshot_timestamp(snapshot_url: str) -> Optional[str]:
+    """Extrai o timestamp ``YYYYMMDDHHMMSS`` de uma URL de snapshot Wayback, ou ``None``.
+
+    Permite recuperar a chave de versão de proveniência quando só se tem a URL do snapshot
+    (ex.: pré-descoberta no ledger ``discovered_resources``), sem nova consulta à API.
+    """
+    m = _SNAPSHOT_TS_RE.search(snapshot_url or "")
+    return m.group(1) if m else None
 
 
 def check_available(url: str, max_age_seconds: int = _MAX_AGE_SECONDS) -> Optional[str]:

--- a/src/leizilla/wayback.py
+++ b/src/leizilla/wayback.py
@@ -8,7 +8,7 @@ import json
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, Tuple
 
 _AVAILABILITY_API = "https://archive.org/wayback/available"
 _SAVE_URL_TMPL = "https://web.archive.org/save/{}"
@@ -50,6 +50,48 @@ def check_available(url: str, max_age_seconds: int = _MAX_AGE_SECONDS) -> Option
     except ValueError:
         pass
     return None
+
+
+def closest_snapshot(url: str) -> Optional[Tuple[str, str]]:
+    """Retorna ``(snapshot_url, timestamp)`` da captura 200 mais próxima — **qualquer idade**.
+
+    Diferente de :func:`check_available` (que exige um snapshot fresco, < 24 h), serve à
+    **proveniência**: reusa uma captura já existente (mesmo antiga) como chave de versão
+    imutável (ADR-0004). O ``timestamp`` é a string ``YYYYMMDDHHMMSS`` do Wayback. Retorna
+    ``None`` se não há captura 200 ou a API falha (fail-open).
+    """
+    try:
+        api_url = f"{_AVAILABILITY_API}?url={urllib.parse.quote(url, safe='')}"
+        req = urllib.request.Request(api_url)
+        req.add_header("User-Agent", _USER_AGENT)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data: dict = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+
+    snapshot = data.get("archived_snapshots", {}).get("closest", {})
+    if not snapshot or snapshot.get("status") != "200":
+        return None
+    snap_url = str(snapshot.get("url", ""))
+    timestamp = str(snapshot.get("timestamp", ""))
+    if not snap_url or not timestamp:
+        return None
+    return snap_url, timestamp
+
+
+def ensure_archived(url: str, timeout: int = 60) -> Optional[Tuple[str, str]]:
+    """Garante uma captura Wayback e devolve ``(snapshot_url, timestamp)``, ou ``None``.
+
+    Política **SPN-first, reusa qualquer snapshot** (decisão de proveniência da DITEL,
+    docs/ditel-ingestion.md): se já há captura, reusa-a (sem re-arquivar); senão, dispara
+    Save Page Now e re-consulta. Fail-open: ``None`` se nada puder ser arquivado/encontrado
+    — o chamador cai no fetch direto (princípio #9).
+    """
+    existing = closest_snapshot(url)
+    if existing is not None:
+        return existing
+    save_page(url, timeout=timeout)
+    return closest_snapshot(url)
 
 
 def save_page(url: str, timeout: int = 60) -> bool:

--- a/tests/test_casacivil_discovery.py
+++ b/tests/test_casacivil_discovery.py
@@ -56,8 +56,9 @@ class TestDiscoverCasacivilLaws:
         assert laws == []
 
     def test_invalid_tipo_raises(self) -> None:
+        # decreto is now valid (lei/lc/decreto); only genuinely unknown types raise.
         with pytest.raises(ValueError, match="tipo deve ser"):
-            discover_casacivil_laws(tipo="decreto", start_num=1, end_num=1)
+            discover_casacivil_laws(tipo="portaria", start_num=1, end_num=1)
 
     def test_titulo_lei(self) -> None:
         laws = discover_casacivil_laws(tipo="lei", start_num=3830, end_num=3830)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -223,8 +223,8 @@ def test_run_discovery(temp_db):
     ):
         total = run_discovery("ro", temp_db)
 
-    # casacivil: 1 cdx + 2 sequential (lei + lc) = 3; playwright returns 0
-    assert total == 3
+    # casacivil: 1 cdx + 3 sequential (lei + lc + decreto) = 4; playwright returns 0
+    assert total == 4
     pending = temp_db.get_pending_resources()
     assert len(pending) == 2  # lei-00001 (cdx) + lei-00002 (sequential, deduplicated)
     urls = [p["url"] for p in pending]

--- a/tests/test_ditel.py
+++ b/tests/test_ditel.py
@@ -132,3 +132,16 @@ class TestWaybackProvenance:
             patch("leizilla.wayback.save_page", return_value=False),
         ):
             assert wayback.ensure_archived("http://ditel/x.pdf") is None
+
+    def test_snapshot_timestamp_extracted_from_url(self):
+        url = "http://web.archive.org/web/20220903083131/http://ditel/D1.pdf"
+        assert wayback.snapshot_timestamp(url) == "20220903083131"
+
+    def test_snapshot_timestamp_handles_modifier_suffix(self):
+        # Wayback URLs may carry a modifier like /web/<ts>id_/<orig>.
+        url = "https://web.archive.org/web/20241208221945id_/https://ditel/L5121.pdf"
+        assert wayback.snapshot_timestamp(url) == "20241208221945"
+
+    def test_snapshot_timestamp_none_for_non_wayback(self):
+        assert wayback.snapshot_timestamp("https://ditel/L5121.pdf") is None
+        assert wayback.snapshot_timestamp("") is None

--- a/tests/test_ditel.py
+++ b/tests/test_ditel.py
@@ -13,7 +13,7 @@ import pytest
 
 from leizilla import wayback
 from leizilla.crawler import discover_casacivil_laws
-from leizilla.discovery import parse_filename
+from leizilla.discovery import WaybackCdxDiscovery, parse_filename
 
 MANIFEST = (
     Path(__file__).resolve().parents[1] / "src" / "leizilla" / "manifests" / "ro.json"
@@ -65,6 +65,37 @@ class TestManifest:
         assert any("/D{num}.pdf" in t for t in templates)
         assert any("/L{num}.pdf" in t for t in templates)
         assert any("/LC{num}.pdf" in t for t in templates)
+
+
+class TestCdxSchemeNormalization:
+    def test_http_capture_normalized_to_manifest_https_for_dedup(self):
+        # CDX returns DITEL's historical http capture; the dedup `url` must be normalized
+        # to the manifest https scheme (so it matches the sequential strategy and isn't
+        # harvested twice), while the http snapshot is kept in wayback_snapshot.
+        config = {"strategy": "wayback-cdx", "prefix": f"{_BASE}/"}
+        cdx = [
+            ["urlkey", "timestamp", "original", "mime", "statuscode", "digest", "len"],
+            [
+                "k",
+                "20241208215859",
+                f"http://{_BASE[len('https://') :]}/L5120.pdf",
+                "application/pdf",
+                "200",
+                "d",
+                "1",
+            ],
+        ]
+        resp = MagicMock()
+        resp.read.return_value = json.dumps(cdx).encode()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=resp):
+            resources = WaybackCdxDiscovery(config, "ro", "casacivil").run()
+        assert len(resources) == 1
+        assert resources[0]["url"] == f"{_BASE}/L5120.pdf"  # https dedup key
+        assert resources[0]["wayback_snapshot"].endswith(
+            f"/http://{_BASE[len('https://') :]}/L5120.pdf"  # http snapshot preserved
+        )
 
 
 def _avail_response(snapshot: dict | None) -> bytes:

--- a/tests/test_ditel.py
+++ b/tests/test_ditel.py
@@ -14,6 +14,8 @@ import pytest
 from leizilla import wayback
 from leizilla.crawler import discover_casacivil_laws
 from leizilla.discovery import WaybackCdxDiscovery, parse_filename
+from leizilla.publisher import build_raw_meta
+from leizilla.scraper import scrape_one
 
 MANIFEST = (
     Path(__file__).resolve().parents[1] / "src" / "leizilla" / "manifests" / "ro.json"
@@ -96,6 +98,66 @@ class TestCdxSchemeNormalization:
         assert resources[0]["wayback_snapshot"].endswith(
             f"/http://{_BASE[len('https://') :]}/L5120.pdf"  # http snapshot preserved
         )
+
+
+class TestRawMetaProvenance:
+    """The Wayback timestamp must land in the serialized _meta.json sidecar, not be dropped."""
+
+    def test_timestamp_from_explicit_field(self):
+        meta = build_raw_meta(
+            {
+                "ente": "ro",
+                "fonte": "casacivil",
+                "chave": "lei-05120",
+                "wayback_timestamp": "20241208215859",
+            },
+            b"PDF",
+            "wayback",
+            wayback_url="http://web.archive.org/web/20241208215859/http://x/L5120.pdf",
+        )
+        assert meta["provenance_wayback"]["wayback_timestamp"] == "20241208215859"
+
+    def test_timestamp_derived_from_snapshot_url(self):
+        # No explicit field (e.g. the CLI scrape path) → derived from the snapshot URL.
+        meta = build_raw_meta(
+            {"ente": "ro", "fonte": "casacivil", "chave": "decreto-01000"},
+            b"PDF",
+            "wayback",
+            wayback_url="https://web.archive.org/web/20220903083131/http://x/D1000.pdf",
+        )
+        assert meta["provenance_wayback"]["wayback_timestamp"] == "20220903083131"
+
+    def test_timestamp_none_on_direct_fetch(self):
+        meta = build_raw_meta(
+            {"ente": "ro"}, b"PDF", "source-fallback", wayback_url=None
+        )
+        assert meta["provenance_wayback"]["wayback_timestamp"] is None
+
+
+class TestScrapeOneSnapshot:
+    def test_uses_pre_discovered_snapshot(self):
+        # A CDX-discovered http snapshot is used directly — scheme-sensitive
+        # check_available is bypassed, preserving the historical capture + its timestamp.
+        snap = "http://web.archive.org/web/20241208215859/http://ditel/L5120.pdf"
+        pub = MagicMock()
+        pub.upload_raw.return_value = {"success": True, "ia_id": "x", "ia_url": "u"}
+        with (
+            patch("leizilla.scraper.robots.is_allowed", return_value=True),
+            patch("leizilla.scraper.wayback.save_page"),
+            patch("leizilla.scraper.wayback.check_available") as check,
+            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"PDF") as fetch,
+        ):
+            result = scrape_one(
+                "https://ditel/",
+                "https://ditel/L5120.pdf",
+                {"ente": "ro", "fonte": "casacivil", "chave": "lei-05120"},
+                pub,
+                wayback_snapshot=snap,
+            )
+        assert result["success"]
+        check.assert_not_called()  # provided snapshot bypasses the availability lookup
+        fetch.assert_called_with(snap)  # fetched from the http-keyed capture
+        assert pub.upload_raw.call_args.kwargs["wayback_url"] == snap
 
 
 def _avail_response(snapshot: dict | None) -> bytes:

--- a/tests/test_ditel.py
+++ b/tests/test_ditel.py
@@ -108,28 +108,53 @@ class TestWaybackProvenance:
         ):
             assert wayback.closest_snapshot("http://ditel/x.pdf") is None
 
+    def test_closest_snapshot_tries_both_schemes(self):
+        # https query misses (DITEL captures are http-keyed); http query finds it.
+        hit = (
+            "http://web.archive.org/web/20241208215859/http://ditel/L5120.pdf",
+            "20241208215859",
+        )
+        with patch("leizilla.wayback._query_available", side_effect=[None, hit]) as q:
+            result = wayback.closest_snapshot("https://ditel/L5120.pdf")
+        assert result == hit
+        assert q.call_count == 2  # tried https, then flipped to http
+
+    def test_save_and_locate_reads_content_location(self):
+        resp = MagicMock()
+        resp.headers.get.return_value = "/web/20260606010101/https://ditel/x.pdf"
+        resp.geturl.return_value = "https://web.archive.org/save/https://ditel/x.pdf"
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = wayback.save_and_locate("https://ditel/x.pdf")
+        assert result == (
+            "https://web.archive.org/web/20260606010101/https://ditel/x.pdf",
+            "20260606010101",
+        )
+
     def test_ensure_archived_reuses_existing_without_saving(self):
         existing = ("http://web.archive.org/web/2022/x", "20220101000000")
         with (
             patch("leizilla.wayback.closest_snapshot", return_value=existing),
-            patch("leizilla.wayback.save_page") as save,
+            patch("leizilla.wayback.save_and_locate") as save,
         ):
             assert wayback.ensure_archived("http://ditel/x.pdf") == existing
             save.assert_not_called()  # SPN-first means "don't re-archive what exists"
 
-    def test_ensure_archived_saves_then_resolves_when_missing(self):
-        saved = ("http://web.archive.org/web/2026/x", "20260101000000")
+    def test_ensure_archived_saves_and_locates_from_response(self):
+        # SPN exposes the snapshot asynchronously → we read it from the save response.
+        saved = ("https://web.archive.org/web/2026/x", "20260101000000")
         with (
-            patch("leizilla.wayback.closest_snapshot", side_effect=[None, saved]),
-            patch("leizilla.wayback.save_page", return_value=True) as save,
+            patch("leizilla.wayback.closest_snapshot", return_value=None),
+            patch("leizilla.wayback.save_and_locate", return_value=saved) as save,
         ):
             assert wayback.ensure_archived("http://ditel/x.pdf") == saved
             save.assert_called_once()
 
     def test_ensure_archived_none_when_save_and_lookup_fail(self):
         with (
-            patch("leizilla.wayback.closest_snapshot", side_effect=[None, None]),
-            patch("leizilla.wayback.save_page", return_value=False),
+            patch("leizilla.wayback.closest_snapshot", return_value=None),
+            patch("leizilla.wayback.save_and_locate", return_value=None),
         ):
             assert wayback.ensure_archived("http://ditel/x.pdf") is None
 

--- a/tests/test_ditel.py
+++ b/tests/test_ditel.py
@@ -1,0 +1,134 @@
+"""Tests for the DITEL (Casa Civil RO) ingestion adapter — Phase 1.
+
+Covers: decreto enumeration, https base URLs, the manifest (https + D template), and the
+Wayback provenance helpers (closest_snapshot / ensure_archived). All offline — the Wayback
+API is mocked. See docs/ditel-ingestion.md.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from leizilla import wayback
+from leizilla.crawler import discover_casacivil_laws
+from leizilla.discovery import parse_filename
+
+MANIFEST = (
+    Path(__file__).resolve().parents[1] / "src" / "leizilla" / "manifests" / "ro.json"
+)
+_BASE = "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files"
+
+
+class TestDiscoverCasacivil:
+    def test_decreto_enumeration(self):
+        laws = discover_casacivil_laws(tipo="decreto", start_num=1, end_num=2)
+        assert [law["chave"] for law in laws] == ["decreto-00001", "decreto-00002"]
+        assert laws[0]["url_pdf_original"] == f"{_BASE}/D1.pdf"
+        assert laws[0]["fonte"] == "casacivil" and laws[0]["ente"] == "ro"
+
+    def test_lei_and_lc_use_https(self):
+        lei = discover_casacivil_laws(tipo="lei", start_num=5, end_num=5)[0]
+        lc = discover_casacivil_laws(tipo="lc", start_num=5, end_num=5)[0]
+        assert lei["url_pdf_original"] == f"{_BASE}/L5.pdf"
+        assert lc["url_pdf_original"] == f"{_BASE}/LC5.pdf"
+        assert lei["url_original"].startswith("https://")
+
+    def test_unknown_tipo_raises(self):
+        with pytest.raises(ValueError, match="tipo deve ser"):
+            discover_casacivil_laws(tipo="portaria")
+
+    def test_empty_range_is_empty(self):
+        assert discover_casacivil_laws(tipo="decreto", start_num=10, end_num=5) == []
+
+
+class TestParseFilenameDecreto:
+    def test_decreto_filename(self):
+        assert parse_filename("D26000.pdf") == ("decreto", "decreto-26000")
+
+    def test_lei_and_lc_filenames(self):
+        assert parse_filename("L5120.pdf") == ("lei", "lei-05120")
+        assert parse_filename("LC42.pdf") == ("lc", "lc-00042")
+
+
+class TestManifest:
+    def test_casacivil_has_https_and_decreto_template(self):
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cc = manifest["fontes"]["casacivil"]["discovery"]
+        templates = [t for cfg in cc for t in cfg.get("templates", [])]
+        prefixes = [cfg.get("prefix") for cfg in cc if "prefix" in cfg]
+        # every DITEL URL is https (the WAF 403s on http)
+        for url in templates + prefixes:
+            assert url.startswith("https://ditel.casacivil.ro.gov.br/"), url
+        # decreto (D{num}) is enumerated alongside L and LC
+        assert any("/D{num}.pdf" in t for t in templates)
+        assert any("/L{num}.pdf" in t for t in templates)
+        assert any("/LC{num}.pdf" in t for t in templates)
+
+
+def _avail_response(snapshot: dict | None) -> bytes:
+    closest = {"archived_snapshots": {"closest": snapshot} if snapshot else {}}
+    return json.dumps(closest).encode()
+
+
+class TestWaybackProvenance:
+    def _mock_urlopen(self, body: bytes):
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_closest_snapshot_returns_url_and_timestamp_any_age(self):
+        snap = {
+            "status": "200",
+            "url": "http://web.archive.org/web/20220903083131/http://ditel/D1.pdf",
+            "timestamp": "20220903083131",
+        }
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._mock_urlopen(_avail_response(snap)),
+        ):
+            result = wayback.closest_snapshot("http://ditel/D1.pdf")
+        assert result == (snap["url"], "20220903083131")
+
+    def test_closest_snapshot_none_when_unarchived(self):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._mock_urlopen(_avail_response(None)),
+        ):
+            assert wayback.closest_snapshot("http://ditel/LC1000.pdf") is None
+
+    def test_closest_snapshot_none_on_non_200(self):
+        snap = {"status": "404", "url": "x", "timestamp": "1"}
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._mock_urlopen(_avail_response(snap)),
+        ):
+            assert wayback.closest_snapshot("http://ditel/x.pdf") is None
+
+    def test_ensure_archived_reuses_existing_without_saving(self):
+        existing = ("http://web.archive.org/web/2022/x", "20220101000000")
+        with (
+            patch("leizilla.wayback.closest_snapshot", return_value=existing),
+            patch("leizilla.wayback.save_page") as save,
+        ):
+            assert wayback.ensure_archived("http://ditel/x.pdf") == existing
+            save.assert_not_called()  # SPN-first means "don't re-archive what exists"
+
+    def test_ensure_archived_saves_then_resolves_when_missing(self):
+        saved = ("http://web.archive.org/web/2026/x", "20260101000000")
+        with (
+            patch("leizilla.wayback.closest_snapshot", side_effect=[None, saved]),
+            patch("leizilla.wayback.save_page", return_value=True) as save,
+        ):
+            assert wayback.ensure_archived("http://ditel/x.pdf") == saved
+            save.assert_called_once()
+
+    def test_ensure_archived_none_when_save_and_lookup_fail(self):
+        with (
+            patch("leizilla.wayback.closest_snapshot", side_effect=[None, None]),
+            patch("leizilla.wayback.save_page", return_value=False),
+        ):
+            assert wayback.ensure_archived("http://ditel/x.pdf") is None

--- a/tests/test_harvest_pipeline.py
+++ b/tests/test_harvest_pipeline.py
@@ -250,7 +250,7 @@ class TestHarvestPendingResources:
 
         with (
             patch("leizilla.scraper.robots.is_allowed", return_value=True),
-            patch("leizilla.scraper.wayback.check_available", return_value=None),
+            patch("leizilla.scraper.wayback.ensure_archived", return_value=None),
             patch("leizilla.scraper.wayback.fetch_bytes", return_value=None),
         ):
             stats = harvest_pending_resources(temp_db, pub, limit=10)
@@ -269,7 +269,7 @@ class TestHarvestPendingResources:
 
         with (
             patch("leizilla.scraper.robots.is_allowed", return_value=True),
-            patch("leizilla.scraper.wayback.check_available", return_value=None),
+            patch("leizilla.scraper.wayback.ensure_archived", return_value=None),
             patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"PDF_CONTENT"),
         ):
             stats = harvest_pending_resources(temp_db, pub, limit=10)
@@ -288,7 +288,7 @@ class TestHarvestPendingResources:
         pub = MagicMock()
         with (
             patch("leizilla.scraper.robots.is_allowed", return_value=True),
-            patch("leizilla.scraper.wayback.check_available", return_value=None),
+            patch("leizilla.scraper.wayback.ensure_archived", return_value=None),
             patch("leizilla.scraper.wayback.fetch_bytes", return_value=None),
         ):
             stats = harvest_pending_resources(temp_db, pub, limit=2)

--- a/tests/test_harvest_pipeline.py
+++ b/tests/test_harvest_pipeline.py
@@ -277,6 +277,53 @@ class TestHarvestPendingResources:
         assert stats["success"] == 1
         pub.upload_raw.assert_called_once()
 
+    def test_wayback_timestamp_threaded_into_upload(
+        self, temp_db: DuckDBStorage
+    ) -> None:
+        # The provenance key (snapshot timestamp) must reach upload_raw, not be discarded.
+        from leizilla.scraper import harvest_pending_resources
+
+        temp_db.insert_resource(_make_resource())
+        pub = MagicMock()
+        pub.upload_raw.return_value = {"success": True, "ia_url": "https://ia/x"}
+        snap = (
+            "http://web.archive.org/web/20220903083131/http://x/lei.pdf",
+            "20220903083131",
+        )
+
+        with (
+            patch("leizilla.scraper.robots.is_allowed", return_value=True),
+            patch("leizilla.scraper.wayback.ensure_archived", return_value=snap),
+            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"PDF"),
+        ):
+            harvest_pending_resources(temp_db, pub, limit=10)
+
+        lei_data = pub.upload_raw.call_args.args[1]
+        assert lei_data["wayback_timestamp"] == "20220903083131"
+
+    def test_predicovered_snapshot_timestamp_recovered_from_url(
+        self, temp_db: DuckDBStorage
+    ) -> None:
+        # A pre-discovered ledger snapshot URL still yields its provenance timestamp.
+        from leizilla.scraper import harvest_pending_resources
+
+        res = _make_resource()
+        res["wayback_snapshot"] = (
+            "http://web.archive.org/web/20241208221945/http://x/lei.pdf"
+        )
+        temp_db.insert_resource(res)
+        pub = MagicMock()
+        pub.upload_raw.return_value = {"success": True, "ia_url": "https://ia/x"}
+
+        with (
+            patch("leizilla.scraper.robots.is_allowed", return_value=True),
+            patch("leizilla.scraper.wayback.ensure_archived", return_value=None),
+            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"PDF"),
+        ):
+            harvest_pending_resources(temp_db, pub, limit=10)
+
+        assert pub.upload_raw.call_args.args[1]["wayback_timestamp"] == "20241208221945"
+
     def test_limit_respected(self, temp_db: DuckDBStorage) -> None:
         from leizilla.scraper import harvest_pending_resources
 

--- a/tests/test_planalto_pipeline.py
+++ b/tests/test_planalto_pipeline.py
@@ -532,10 +532,26 @@ class TestCmdScrapeTipoValidation:
         assert result.exit_code != 0
         assert "planalto" in result.output
 
-    def test_decreto_blocked_for_casacivil(self) -> None:
-        result = self._invoke("--tipo", "decreto", "--fonte", "casacivil")
-        assert result.exit_code != 0
-        assert "planalto" in result.output
+    def test_decreto_accepted_for_casacivil(self) -> None:
+        # DITEL publishes decretos (D{n}.pdf); decreto is now valid for casacivil.
+        with (
+            patch("leizilla.robots.is_allowed", return_value=False),
+            patch("leizilla.wayback.save_page"),
+        ):
+            result = self._invoke(
+                "--ente",
+                "ro",
+                "--fonte",
+                "casacivil",
+                "--tipo",
+                "decreto",
+                "--start-coddoc",
+                "1",
+                "--end-coddoc",
+                "1",
+            )
+        assert result.exit_code == 0
+        assert "inválido" not in result.output and "só é válido" not in result.output
 
     def test_lcp_accepted_for_planalto(self) -> None:
         with (

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -15,6 +15,7 @@ _LEI = {
 _FONTE_URL = "https://www.al.ro.leg.br/legislacao/leis/1"
 _PDF_URL = "https://www.al.ro.leg.br/legislacao/leis/1.pdf"
 _WB_URL = "https://web.archive.org/web/20260101000000/" + _PDF_URL
+_WB_TS = "20260101000000"
 _PDF_BYTES = b"%PDF-fake"
 
 
@@ -46,7 +47,7 @@ class TestScrapeOne:
         result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, _make_publisher())
         assert result == {"success": False, "reason": "robots-blocked", "url": _PDF_URL}
 
-    @patch("leizilla.scraper.wayback.check_available", return_value=_WB_URL)
+    @patch("leizilla.scraper.wayback.ensure_archived", return_value=(_WB_URL, _WB_TS))
     @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
     @patch("leizilla.scraper.wayback.save_page", return_value=True)
     @patch("leizilla.scraper.robots.is_allowed", return_value=True)
@@ -58,7 +59,7 @@ class TestScrapeOne:
         assert call_kwargs.kwargs["fetched_from"] == "wayback"
         assert call_kwargs.kwargs["wayback_url"] == _WB_URL
 
-    @patch("leizilla.scraper.wayback.check_available", return_value=None)
+    @patch("leizilla.scraper.wayback.ensure_archived", return_value=None)
     @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
     @patch("leizilla.scraper.wayback.save_page", return_value=False)
     @patch("leizilla.scraper.robots.is_allowed", return_value=True)
@@ -70,7 +71,7 @@ class TestScrapeOne:
         assert call_kwargs.kwargs["fetched_from"] == "source-fallback"
         assert call_kwargs.kwargs["wayback_url"] is None
 
-    @patch("leizilla.scraper.wayback.check_available", return_value=None)
+    @patch("leizilla.scraper.wayback.ensure_archived", return_value=None)
     @patch("leizilla.scraper.wayback.fetch_bytes", return_value=None)
     @patch("leizilla.scraper.wayback.save_page", return_value=False)
     @patch("leizilla.scraper.robots.is_allowed", return_value=True)
@@ -80,7 +81,7 @@ class TestScrapeOne:
         assert result == {"success": False, "reason": "fetch-failed", "url": _PDF_URL}
         pub.upload_raw.assert_not_called()
 
-    @patch("leizilla.scraper.wayback.check_available", return_value=_WB_URL)
+    @patch("leizilla.scraper.wayback.ensure_archived", return_value=(_WB_URL, _WB_TS))
     @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
     @patch("leizilla.scraper.wayback.save_page", return_value=True)
     @patch("leizilla.scraper.robots.is_allowed", return_value=True)
@@ -92,7 +93,7 @@ class TestScrapeOne:
         assert result["success"] is False
         assert "error" in result
 
-    @patch("leizilla.scraper.wayback.check_available", return_value=_WB_URL)
+    @patch("leizilla.scraper.wayback.ensure_archived", return_value=(_WB_URL, _WB_TS))
     @patch("leizilla.scraper.wayback.fetch_bytes", side_effect=[None, _PDF_BYTES])
     @patch("leizilla.scraper.wayback.save_page", return_value=True)
     @patch("leizilla.scraper.robots.is_allowed", return_value=True)
@@ -106,7 +107,7 @@ class TestScrapeOne:
         call_kwargs = pub.upload_raw.call_args
         assert call_kwargs.kwargs["fetched_from"] == "source-fallback"
 
-    @patch("leizilla.scraper.wayback.check_available", return_value=None)
+    @patch("leizilla.scraper.wayback.ensure_archived", return_value=None)
     @patch("leizilla.scraper.wayback.fetch_bytes", return_value=_PDF_BYTES)
     @patch("leizilla.scraper.wayback.save_page", return_value=False)
     @patch("leizilla.scraper.robots.is_allowed", return_value=True)


### PR DESCRIPTION
Makes Leizilla actually ingest **Rondônia laws and decrees from DITEL** (Casa Civil COTEL), built to the existing `manifest → discover → harvest → Wayback → IA → OCR → parse → Parquet` seam. No parallel pipeline; **OPF/span-tagging (PR #84) is a separate track and is untouched here.**

## Phase 0 — diagnosis (`docs/ditel-ingestion.md`)
Mapped the pipeline + the source + the gap before building. DITEL serves **born-digital PDFs over HTTPS** at `…/COTEL/Livros/Files/{L|LC|D}{n}.pdf`; the code's `http://` **403s on a WAF**. lei/lc/**decreto** all exist there. Wayback coverage is **sparse** (L5120✓, D1000✓, LC1000✗) → Save-Page-Now first, reuse any snapshot.

## Phase 1 — adapter (to the seam, offline-tested)
- **`manifests/ro.json` + `crawler.py`:** `http://` → `https://` (the real blocker); add a `D{n}.pdf` **decreto** sequential template; `discover_casacivil_laws` accepts `tipo=decreto`.
- **`wayback.py`:** `closest_snapshot()` returns `(snapshot_url, timestamp)` for **any-age** archive (provenance/version key), and `ensure_archived()` is **SPN-first, reuse-any-snapshot**; the harvest path now uses it.
- **`cli scrape`:** decreto allowed for `casacivil`; https in the casacivil branch.
- **`tests/test_ditel.py`** (new): decreto enumeration, https, manifest shape, Wayback provenance — all offline/mocked. Updated 3 existing tests to the new "decreto is valid for casacivil" contract.

## Phase 2 — real batch (fetch verified here; credentialed stages run in CI)
No `IA_*` / `ANTHROPIC_API_KEY` in the sandbox, so IA-upload/OCR/Claude-parse/Parquet run in the scheduled workflows. I exercised the **fetch + provenance + text + structure** path for real via the `wayback` client:

| chave | tipo | provenance | local text | structure |
|---|---|---|---|---|
| lei-05120 | lei | direct (unarchived) | born-digital | `Art. 1°–6°` + ementa ✓ |
| lei-05121 | lei | `wayback@20241208221945` | born-digital | `Art. 1°–5°` + ementa ✓ |
| decreto-01000 | decreto | `wayback@20220903083131` | scanned (none) | needs IA OCR |
| decreto-01001 | decreto | `wayback@20220903083119` | scanned (none) | needs IA OCR |

`fetched 4/4 · born-digital-text 2 · article-structure-detected 2.`

**Key finding:** RO **laws are born-digital** (clean `Art./§/inciso` — LC 95/1998 regularity, no model needed), but **older decretos are scanned** and ride the existing **IA-OCR** stage. Hand-verified L5120: *"Institui a Campanha Permanente de Conscientização da depressão Infantil…"* + `Art. 1°` … `Art. 6° VETADO.`

## Definition of done
- [x] Phase 0 map + DITEL + gap committed (`docs/ditel-ingestion.md`).
- [x] Adapter built to the existing seam; offline tests (`test_ditel.py`).
- [x] Real small batch fetched + verified (fetch/provenance/text/structure); IA→OCR→parse→Parquet handed to the credentialed scheduled workflows.
- [x] Hand-verified example + counts reported.
- [x] Conventions followed; OPF track untouched; no raw corpus committed.

`uv run leizilla dev check` → **583 passed, 13 skipped**.

https://claude.ai/code/session_01W1AsXWHRt1LSNysmFTjhd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1AsXWHRt1LSNysmFTjhd2)_