### PR TITLE
refactor(discovery): use Protocol for DiscoveryStrategy

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1252,5 +1252,4 @@ Naming formal e regras de fallback: ver `docs/SCHEMA.md` (M0.2).
 * Visualização detalhada individual contendo título, ementa, data, link original para o PDF no IA e um visualizador de texto integrado para o OCR extraído com destaque de termos pesquisados.
 
 **Dívida técnica identificada**: Protocol formal para estratégias de discovery (`WaybackCdxDiscovery`,
-`SequentialDiscovery`, `PlaywrightCrawlerDiscovery`) — eliminaria o `# type: ignore[attr-defined]`
-em `discovery.py:216`. Candidato para M12 se houver adição de nova estratégia.
+`SequentialDiscovery`, `PlaywrightCrawlerDiscovery`) — RESOLVIDO: Substituiu-se a class base por `DiscoveryStrategyProtocol(Protocol)`.

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -9,21 +9,19 @@ import re
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Protocol, Callable
 
 from leizilla.storage import DuckDBStorage
 
 logger = logging.getLogger(__name__)
 
 
-class DiscoveryStrategy:
-    """Base class para estratégias de descoberta de recursos."""
+class DiscoveryStrategyProtocol(Protocol):
+    """Protocolo para estratégias de descoberta de recursos."""
 
-    def __init__(self, config: Dict[str, Any], ente: str, fonte: str) -> None:
-        pass
+    def __init__(self, config: Dict[str, Any], ente: str, fonte: str) -> None: ...
 
-    def run(self) -> List[Dict[str, Any]]:
-        return []
+    def run(self) -> List[Dict[str, Any]]: ...
 
 
 def parse_filename(filename: str) -> tuple[Optional[str], Optional[str]]:
@@ -45,7 +43,7 @@ def parse_filename(filename: str) -> tuple[Optional[str], Optional[str]]:
     return None, None
 
 
-class WaybackCdxDiscovery(DiscoveryStrategy):
+class WaybackCdxDiscovery:
     """Estratégia de descobrimento que consulta a API CDX da Wayback Machine."""
 
     def __init__(self, config: Dict[str, Any], ente: str, fonte: str) -> None:
@@ -118,7 +116,7 @@ class WaybackCdxDiscovery(DiscoveryStrategy):
         return resources
 
 
-class SequentialDiscovery(DiscoveryStrategy):
+class SequentialDiscovery:
     """Estratégia de descobrimento baseada em templates de URLs sequenciais."""
 
     def __init__(self, config: Dict[str, Any], ente: str, fonte: str) -> None:
@@ -157,7 +155,7 @@ class SequentialDiscovery(DiscoveryStrategy):
         return resources
 
 
-class PlaywrightCrawlerDiscovery(DiscoveryStrategy):
+class PlaywrightCrawlerDiscovery:
     """Estratégia de descobrimento que usa o LeisCrawler (Playwright) para o portal ALRO."""
 
     def __init__(self, config: Dict[str, Any], ente: str, fonte: str) -> None:
@@ -216,7 +214,7 @@ class PlaywrightCrawlerDiscovery(DiscoveryStrategy):
         return resources
 
 
-STRATEGIES: Dict[str, type[DiscoveryStrategy]] = {
+STRATEGIES: Dict[str, Callable[[Dict[str, Any], str, str], DiscoveryStrategyProtocol]] = {
     "wayback-cdx": WaybackCdxDiscovery,
     "sequential": SequentialDiscovery,
     "playwright-crawler": PlaywrightCrawlerDiscovery,


### PR DESCRIPTION
Replaces the concrete `DiscoveryStrategy` base class with a `DiscoveryStrategyProtocol` using `typing.Protocol`.
Updates `STRATEGIES` dict to use `Callable` per PEP 544 to satisfy type-checkers without needing `# type: ignore`.
Resolves known technical debt mapped in `IMPLEMENTATION.md`.

---
*PR created automatically by Jules for task [3494105908787702831](https://jules.google.com/task/3494105908787702831) started by @franklinbaldo*