### PR TITLE
feat(ditel): expand discovery to D, EC, Res, Port, DEC, DL + PDF validation

### DIFF
--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -1612,14 +1612,9 @@ def cmd_wayback_save(
                     continue
 
                 if head_check:
-                    import requests as _req
+                    from leizilla.discovery import _head_exists
 
-                    try:
-                        r = _req.head(url, timeout=10, allow_redirects=True)
-                        if r.status_code >= 400:
-                            total_skipped += 1
-                            continue
-                    except Exception:
+                    if not _head_exists(url):
                         total_skipped += 1
                         continue
 

--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -25,13 +25,45 @@ class DiscoveryStrategyProtocol(Protocol):
 
 
 def parse_filename(filename: str) -> tuple[Optional[str], Optional[str]]:
-    """Extrai tipo_documento e chave formatada do nome do arquivo (ex: L5120.pdf -> lei, lei-05120)."""
+    """Extrai tipo_documento e chave formatada do nome do arquivo.
+
+    Exemplos:
+      L5120.pdf    -> ("lei", "lei-05120")
+      LC312.pdf    -> ("lc", "lc-00312")
+      D1234.pdf    -> ("decreto", "decreto-01234")
+      EC10.pdf     -> ("ec", "ec-00010")
+      Res50.pdf    -> ("resolucao", "resolucao-00050")
+      Port100.pdf  -> ("portaria", "portaria-00100")
+      DEC1026.pdf  -> ("decreto", "decreto-01026")
+      DL11.pdf     -> ("decreto-lei", "decreto-lei-00011")
+    """
     # Remove extensão e limpa espaços
     name = filename.rsplit(".", 1)[0].strip().upper()
-    if name.startswith("LC"):
+    # Ordered from longest prefix to shortest to avoid partial matches
+    if name.startswith("PORT"):
+        num_part = name[4:]
+        if num_part.isdigit():
+            return "portaria", f"portaria-{int(num_part):05d}"
+    elif name.startswith("RES"):
+        num_part = name[3:]
+        if num_part.isdigit():
+            return "resolucao", f"resolucao-{int(num_part):05d}"
+    elif name.startswith("DEC"):
+        num_part = name[3:]
+        if num_part.isdigit():
+            return "decreto", f"decreto-{int(num_part):05d}"
+    elif name.startswith("LC"):
         num_part = name[2:]
         if num_part.isdigit():
             return "lc", f"lc-{int(num_part):05d}"
+    elif name.startswith("EC"):
+        num_part = name[2:]
+        if num_part.isdigit():
+            return "ec", f"ec-{int(num_part):05d}"
+    elif name.startswith("DL"):
+        num_part = name[2:]
+        if num_part.isdigit():
+            return "decreto-lei", f"decreto-lei-{int(num_part):05d}"
     elif name.startswith("L"):
         num_part = name[1:]
         if num_part.isdigit():
@@ -116,6 +148,25 @@ class WaybackCdxDiscovery:
         return resources
 
 
+_HEAD_RATE_LIMIT_S = 0.5
+
+
+def _head_exists(url: str, timeout: float = 10.0) -> bool:
+    """Retorna True se HEAD request retornar 200 ou 302 (arquivo existe no servidor)."""
+    try:
+        req = urllib.request.Request(
+            url,
+            method="HEAD",
+            headers={"User-Agent": "leizilla-crawler/0.1"},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status in (200, 302)
+    except urllib.error.HTTPError as exc:
+        return exc.code in (200, 302)
+    except Exception:
+        return False
+
+
 class SequentialDiscovery:
     """Estratégia de descobrimento baseada em templates de URLs sequenciais."""
 
@@ -125,15 +176,43 @@ class SequentialDiscovery:
         self.end = int(config["end"])
         self.ente = ente
         self.fonte = fonte
+        self.head_check: bool = bool(config.get("head_check", False))
 
-    def run(self) -> List[Dict[str, Any]]:
+    def run(self, storage: Optional[DuckDBStorage] = None) -> List[Dict[str, Any]]:
         logger.info(
-            f"Rodando Sequential Discovery para {self.ente}/{self.fonte} (de {self.start} a {self.end})..."
+            f"Rodando Sequential Discovery para {self.ente}/{self.fonte} "
+            f"(de {self.start} a {self.end}, head_check={self.head_check})..."
         )
+        import time
+
         resources = []
+        last_head_time = 0.0
         for num in range(self.start, self.end + 1):
             for tmpl in self.templates:
                 url = tmpl.format(num=num)
+
+                if storage:
+                    try:
+                        conn = storage.connect()
+                        res = conn.execute(
+                            "SELECT 1 FROM discovered_resources WHERE url = ?", [url]
+                        ).fetchone()
+                        if res:
+                            continue
+                    except Exception as e:
+                        logger.warning(f"Error checking DB for URL {url}: {e}")
+
+                if self.head_check:
+                    # Rate-limit HEAD requests to avoid hammering the server
+                    elapsed = time.monotonic() - last_head_time
+                    if elapsed < _HEAD_RATE_LIMIT_S:
+                        time.sleep(_HEAD_RATE_LIMIT_S - elapsed)
+                    exists = _head_exists(url)
+                    last_head_time = time.monotonic()
+                    if not exists:
+                        logger.debug(f"HEAD 404/error — skipping {url}")
+                        continue
+
                 filename = url.split("/")[-1]
                 tipo, chave = parse_filename(filename)
                 if not tipo or not chave:
@@ -152,6 +231,10 @@ class SequentialDiscovery:
                         "wayback_snapshot": None,
                     }
                 )
+        logger.info(
+            f"Sequential Discovery concluído: {len(resources)} recursos encontrados "
+            f"(head_check={self.head_check})"
+        )
         return resources
 
 
@@ -214,7 +297,9 @@ class PlaywrightCrawlerDiscovery:
         return resources
 
 
-STRATEGIES: Dict[str, Callable[[Dict[str, Any], str, str], DiscoveryStrategyProtocol]] = {
+STRATEGIES: Dict[
+    str, Callable[[Dict[str, Any], str, str], DiscoveryStrategyProtocol]
+] = {
     "wayback-cdx": WaybackCdxDiscovery,
     "sequential": SequentialDiscovery,
     "playwright-crawler": PlaywrightCrawlerDiscovery,

--- a/src/leizilla/manifests/ro.json
+++ b/src/leizilla/manifests/ro.json
@@ -14,7 +14,8 @@
             "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/L{num}.pdf"
           ],
           "start": 1,
-          "end": 6000
+          "end": 6000,
+          "head_check": false
         },
         {
           "strategy": "sequential",
@@ -22,7 +23,8 @@
             "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/LC{num}.pdf"
           ],
           "start": 1,
-          "end": 1300
+          "end": 1300,
+          "head_check": false
         },
         {
           "strategy": "sequential",
@@ -30,7 +32,53 @@
             "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/D{num}.pdf"
           ],
           "start": 1,
-          "end": 30000
+          "end": 15000,
+          "head_check": true
+        },
+        {
+          "strategy": "sequential",
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/EC{num}.pdf"
+          ],
+          "start": 1,
+          "end": 200,
+          "head_check": true
+        },
+        {
+          "strategy": "sequential",
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/Res{num}.pdf"
+          ],
+          "start": 1,
+          "end": 1000,
+          "head_check": true
+        },
+        {
+          "strategy": "sequential",
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/Port{num}.pdf"
+          ],
+          "start": 1,
+          "end": 3000,
+          "head_check": true
+        },
+        {
+          "strategy": "sequential",
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/DEC{num}.pdf"
+          ],
+          "start": 1,
+          "end": 15000,
+          "head_check": true
+        },
+        {
+          "strategy": "sequential",
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/DL{num}.pdf"
+          ],
+          "start": 1,
+          "end": 1000,
+          "head_check": true
         }
       ]
     },

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -5,6 +5,7 @@ Princípio #10: robots.txt é permanente (sem retry em URL bloqueada); rate-limi
                em fallback direto, por host (não global).
 """
 
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -245,7 +246,19 @@ def harvest_pending_resources(
             wb_ts = None
 
         if pdf_bytes is None:
+            print(f"[WARN] fetch returned None for {chave} ({url})", file=sys.stderr)
             storage.update_resource_status(url, "failed")
+            stats["failed"] += 1
+            continue
+
+        # Validate PDF magic bytes — source may serve HTML error pages with .pdf URLs
+        if not pdf_bytes[:4] == b"%PDF":
+            print(
+                f"[WARN] not a valid PDF for {chave} ({url}): "
+                f"header={pdf_bytes[:32]!r}",
+                file=sys.stderr,
+            )
+            storage.update_resource_status(url, "not-pdf")
             stats["failed"] += 1
             continue
 
@@ -295,9 +308,17 @@ def harvest_pending_resources(
                 storage.insert_lei(lei_record)
                 stats["success"] += 1
             else:
+                print(
+                    f"[WARN] upload failed for {chave}: {result.get('error', '?')}",
+                    file=sys.stderr,
+                )
                 storage.update_resource_status(url, "failed")
                 stats["failed"] += 1
-        except Exception:
+        except Exception as exc:
+            print(
+                f"[ERROR] exception for {chave}: {exc}",
+                file=sys.stderr,
+            )
             storage.update_resource_status(url, "failed")
             stats["failed"] += 1
         finally:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -22,6 +22,15 @@ def test_parse_filename():
     assert parse_filename("D9.pdf") == ("decreto", "decreto-00009")
     assert parse_filename("L100012.pdf") == ("lei", "lei-100012")
     assert parse_filename("invalid_name.pdf") == (None, None)
+    # New tipos
+    assert parse_filename("EC10.pdf") == ("ec", "ec-00010")
+    assert parse_filename("Res50.pdf") == ("resolucao", "resolucao-00050")
+    assert parse_filename("Port100.pdf") == ("portaria", "portaria-00100")
+    assert parse_filename("DEC1026.pdf") == ("decreto", "decreto-01026")
+    assert parse_filename("DL11.pdf") == ("decreto-lei", "decreto-lei-00011")
+    # Port must not match P alone or conflict with LC/L prefix ordering
+    assert parse_filename("LC5.pdf") == ("lc", "lc-00005")  # not "l"
+    assert parse_filename("EC1.PDF") == ("ec", "ec-00001")  # case insensitive
 
 
 def test_load_manifest():
@@ -55,6 +64,31 @@ def test_sequential_discovery():
     assert resources[0]["fonte"] == "casacivil"
     assert resources[0]["tipo_documento"] == "lei"
     assert resources[0]["chave"] == "lei-00001"
+
+
+def test_sequential_discovery_head_check():
+    """SequentialDiscovery with head_check=True only includes URLs that pass HEAD."""
+    config = {
+        "strategy": "sequential",
+        "templates": ["http://example.com/Files/D{num}.pdf"],
+        "start": 1,
+        "end": 5,
+        "head_check": True,
+    }
+
+    # Simulate: only D2 and D4 exist
+    def fake_head(url: str, timeout: float = 10.0) -> bool:
+        return any(f"/D{n}.pdf" in url for n in [2, 4])
+
+    with patch("leizilla.discovery._head_exists", side_effect=fake_head):
+        discoverer = SequentialDiscovery(config, "ro", "casacivil")
+        resources = discoverer.run()
+
+    assert len(resources) == 2
+    urls = [r["url"] for r in resources]
+    assert "http://example.com/Files/D2.pdf" in urls
+    assert "http://example.com/Files/D4.pdf" in urls
+    assert all(r["tipo_documento"] == "decreto" for r in resources)
 
 
 def test_wayback_cdx_discovery():
@@ -223,8 +257,9 @@ def test_run_discovery(temp_db):
     ):
         total = run_discovery("ro", temp_db)
 
-    # casacivil: 1 cdx + 3 sequential (lei + lc + decreto) = 4; playwright returns 0
-    assert total == 4
+    # casacivil: 1 cdx + 8 sequential strategies (lei, lc, D, EC, Res, Port, DEC, DL) = 9
+    assert total == 9
+
     pending = temp_db.get_pending_resources()
     assert len(pending) == 2  # lei-00001 (cdx) + lei-00002 (sequential, deduplicated)
     urls = [p["url"] for p in pending]

--- a/tests/test_harvest_pipeline.py
+++ b/tests/test_harvest_pipeline.py
@@ -270,7 +270,7 @@ class TestHarvestPendingResources:
         with (
             patch("leizilla.scraper.robots.is_allowed", return_value=True),
             patch("leizilla.scraper.wayback.ensure_archived", return_value=None),
-            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"PDF_CONTENT"),
+            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"%PDF-1.4 content"),
         ):
             stats = harvest_pending_resources(temp_db, pub, limit=10)
 
@@ -294,7 +294,7 @@ class TestHarvestPendingResources:
         with (
             patch("leizilla.scraper.robots.is_allowed", return_value=True),
             patch("leizilla.scraper.wayback.ensure_archived", return_value=snap),
-            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"PDF"),
+            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"%PDF-1.4"),
         ):
             harvest_pending_resources(temp_db, pub, limit=10)
 
@@ -318,7 +318,7 @@ class TestHarvestPendingResources:
         with (
             patch("leizilla.scraper.robots.is_allowed", return_value=True),
             patch("leizilla.scraper.wayback.ensure_archived", return_value=None),
-            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"PDF"),
+            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"%PDF-1.4"),
         ):
             harvest_pending_resources(temp_db, pub, limit=10)
 

--- a/tests/test_harvest_pipeline.py
+++ b/tests/test_harvest_pipeline.py
@@ -270,7 +270,9 @@ class TestHarvestPendingResources:
         with (
             patch("leizilla.scraper.robots.is_allowed", return_value=True),
             patch("leizilla.scraper.wayback.ensure_archived", return_value=None),
-            patch("leizilla.scraper.wayback.fetch_bytes", return_value=b"%PDF-1.4 content"),
+            patch(
+                "leizilla.scraper.wayback.fetch_bytes", return_value=b"%PDF-1.4 content"
+            ),
         ):
             stats = harvest_pending_resources(temp_db, pub, limit=10)
 


### PR DESCRIPTION
## Summary

Cherry-picked from PR #86 (`feat/ditel-all-types`) onto current main, resolving conflicts:

- **`discovery.py`**: Extended `parse_filename` to handle EC, RES, PORT, DEC, DL prefixes (longest-to-shortest to prevent partial matches). Added `_head_exists()` helper with rate-limiting for HEAD-checking before discovery. `SequentialDiscovery` gains `head_check` support and optional `storage` dedup parameter.
- **`manifests/ro.json`**: Added sequential discovery strategies for D, EC, Res, Port, DEC, DL with `head_check: true` (filters non-existent numbers before queuing).
- **`scraper.py`**: Validates PDF magic bytes (`%PDF`) before upload — rejects HTML error pages served at `.pdf` URLs, marks as `not-pdf`.
- **`cli.py`**: `wayback-save` HEAD check now uses the canonical `_head_exists()` from `discovery.py` instead of inline `requests.head`.

## What was dropped from PR #86
- `_is_in_ia_manifest()` — references old `manifest.csv` format; current main uses `index.csv` with uuid5 filenames. Needs a separate rewrite.
- wayback-save command (already in main via #91)
- OKF docs + RFC-0001 (already in main via #91)
- LiteLLM migration (separate concern, separate PR if desired)
- Web frontend changes (superseded by main's redesign)

## Test plan
- [ ] `ruff check / format` pass (CI)
- [ ] `mypy` passes (CI)
- [ ] `pytest` passes (CI) — test_discovery count updated to 9 (1 CDX + 8 sequential)
- [ ] `wayback-save` for `ec`, `resolucao`, `portaria`, `decreto-lei` discovers URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)