### PR TITLE
fix(ci): scope discover-harvest.yml discovery to --fonte (#105)

### DIFF
--- a/.github/workflows/discover-harvest.yml
+++ b/.github/workflows/discover-harvest.yml
@@ -9,6 +9,13 @@ on:
       ente:
         description: "Ente federativo (ro, sp, federal)"
         default: "ro"
+      fonte:
+        description: "Fonte do manifesto a descobrir. assembleia crawla ~5000 páginas sequencialmente (Playwright) e pode travar por horas (#105) — só escolha manualmente quando quiser rodá-la de propósito."
+        type: choice
+        default: "casacivil"
+        options:
+          - casacivil
+          - assembleia
       tipo:
         description: "Tipo (lei, lc, decreto, ec, resolucao, portaria, decreto-lei) — vazio = todos em paralelo"
         default: ""
@@ -32,7 +39,7 @@ jobs:
         env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-        run: uv run leizilla discover --ente "${{ inputs.ente }}"
+        run: uv run leizilla discover --ente "${{ inputs.ente }}" --fonte "${{ inputs.fonte }}"
 
       - name: Harvest — ${{ inputs.tipo }}
         env:
@@ -64,7 +71,7 @@ jobs:
         env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-        run: uv run leizilla discover --ente "${{ inputs.ente || 'ro' }}"
+        run: uv run leizilla discover --ente "${{ inputs.ente || 'ro' }}" --fonte "${{ inputs.fonte || 'casacivil' }}"
 
       - name: Harvest — ${{ matrix.tipo }}
         env:

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -113,6 +113,26 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
 
+### 2026-07-12 — issue #105: `discover-harvest.yml` agendado agora escopa `--fonte`
+
+O risco em aberto anotado pelo PR de `discover --fonte` (entrada abaixo) e
+detalhado na issue [#105](https://github.com/franklinbaldo/leizilla/issues/105)
+está corrigido: o workflow agendado real (`.github/workflows/discover-harvest.yml`,
+job `harvest-single` e `harvest-parallel`) chamava `leizilla discover --ente ro`
+sem filtro — a próxima execução (cron de sábado ou `workflow_dispatch` manual)
+travaria de novo por horas na `PlaywrightCrawlerDiscovery` da fonte `assembleia`,
+o mesmo bug confirmado 2× em produção.
+
+**Correção**: novo input `fonte` no `workflow_dispatch` (`type: choice`,
+`options: [casacivil, assembleia]`, `default: casacivil`); ambos os steps de
+Discover passam `--fonte` explicitamente (`inputs.fonte` no dispatch,
+`inputs.fonte || 'casacivil'` no cron semanal, mesmo padrão já usado para
+`ente`/`limit` nesse arquivo). `assembleia` só roda mediante escolha manual
+explícita no dropdown do dispatch — nunca no cron. Teste estático novo
+(`tests/test_workflow_hygiene.py`) varre todo `.github/workflows/*.yml` e falha
+se algum step invocar `leizilla discover` sem `--fonte`, prevenindo regressão
+(inclusive em workflows futuros).
+
 ### 2026-07-12 — RFC-0004 passo 3 (smoke batch) já concluído; `discover --fonte` adicionado
 
 O smoke batch de RFC-0004 (passo 3) **já estava feito** antes desta sessão

--- a/docs/rfc/0004-go-live-rondonia.md
+++ b/docs/rfc/0004-go-live-rondonia.md
@@ -84,17 +84,24 @@ repetiu o smoke batch **redundantemente** (o de 2026-07-11 já havia publicado o
 5 itens raw acima) chamando o `discover --ente ro` sem escopo e foi cancelada
 pelo timeout de 2h sem nunca chegar ao harvest.
 
-**Correção**: `discover` agora aceita `--fonte` (mesmo padrão de `harvest` e
-`reconcile`) — `leizilla discover --ente ro --fonte casacivil` roda só a
-estratégia rápida (wayback-cdx) e nunca instancia o crawler da assembleia. O
-passo 3 do runbook foi atualizado para usar essa forma. **Risco em aberto**: o
-workflow agendado `discover-harvest.yml` ainda chama `discover --ente ro` sem
-`--fonte` nos seus jobs `harvest-single`/`harvest-parallel` — a próxima execução
-semanal (ou o próximo `workflow_dispatch` manual dela) vai hangar do mesmo jeito
-até alguém escopar esse step também. Não corrigido neste PR (fora do escopo de
-"ajustar o runbook + adicionar `--fonte`" pedido) — acompanhar em
-[#105](https://github.com/franklinbaldo/leizilla/issues/105), a resolver antes
-de destravar o passo 7 (schedules com ranges completos).
+**Correção**: `discover` agora aceita `--fonte` (mesmo padrão de `reconcile`) —
+`leizilla discover --ente ro --fonte casacivil` roda só a estratégia rápida
+(wayback-cdx) e nunca instancia o crawler da assembleia. O passo 3 do runbook
+foi atualizado para usar essa forma.
+
+**Atualização 2026-07-12 (follow-up)**: o risco em aberto acima — o workflow
+agendado `discover-harvest.yml` chamando `discover --ente ro` sem `--fonte` nos
+jobs `harvest-single`/`harvest-parallel` — está corrigido
+([#105](https://github.com/franklinbaldo/leizilla/issues/105)). O
+`workflow_dispatch` ganhou um input `fonte` (`type: choice`, opções
+`casacivil`/`assembleia`, padrão `casacivil`); os dois steps de Discover passam
+`--fonte` explicitamente, com o mesmo fallback `|| 'casacivil'` já usado para
+`ente`/`limit` no disparo agendado (cron). `assembleia` só roda mediante escolha
+manual explícita no dropdown — nunca no cron semanal. Teste estático
+(`tests/test_workflow_hygiene.py`) varre `.github/workflows/*.yml` e falha se
+algum step chamar `leizilla discover` sem `--fonte`, prevenindo regressão. Isso
+remove o bloqueio de hang do passo 7 (schedules com ranges completos); a decisão
+de quando de fato destravar ranges completos continua sendo do mantenedor.
 
 ### 2. `leizilla doctor` (implementado neste PR)
 

--- a/tests/test_workflow_hygiene.py
+++ b/tests/test_workflow_hygiene.py
@@ -19,6 +19,12 @@ WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 _DISCOVER_RE = re.compile(r"\bleizilla\s+discover\b")
 
 
+def _workflow_files() -> list[Path]:
+    """GitHub Actions accepts both `.yml` and `.yaml` — check both so a future
+    workflow file doesn't silently escape this check."""
+    return sorted([*WORKFLOWS_DIR.glob("*.yml"), *WORKFLOWS_DIR.glob("*.yaml")])
+
+
 def _logical_lines(text: str) -> list[str]:
     """Join `\\`-continued shell lines so multi-line `run: |` commands are
     checked as one logical command, same as what the shell executes."""
@@ -38,12 +44,12 @@ def _logical_lines(text: str) -> list[str]:
 
 def test_workflows_dir_has_files() -> None:
     """Sanity check so a bad path above can't make the real test pass vacuously."""
-    assert list(WORKFLOWS_DIR.glob("*.yml"))
+    assert _workflow_files()
 
 
 def test_no_workflow_invokes_discover_without_fonte() -> None:
     offenders = []
-    for wf in sorted(WORKFLOWS_DIR.glob("*.yml")):
+    for wf in _workflow_files():
         for line in _logical_lines(wf.read_text(encoding="utf-8")):
             text = line.strip()
             if not text or text.startswith("#"):

--- a/tests/test_workflow_hygiene.py
+++ b/tests/test_workflow_hygiene.py
@@ -1,0 +1,58 @@
+"""Hygiene check over .github/workflows/*.yml — no dependency on the CLI/YAML libs.
+
+`leizilla discover --ente ro` (no `--fonte`) instantiates every discovery
+strategy in the manifest, including `PlaywrightCrawlerDiscovery` for
+`assembleia` (~5000 pages crawled sequentially). Confirmed in production
+(2026-07-11 and 2026-07-12) to hang for hours and get cancelled by the job
+timeout without ever reaching harvest — see issue #105. Every workflow that
+invokes `discover` must pin `--fonte` so `assembleia` only runs via an
+explicit manual choice.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+_DISCOVER_RE = re.compile(r"\bleizilla\s+discover\b")
+
+
+def _logical_lines(text: str) -> list[str]:
+    """Join `\\`-continued shell lines so multi-line `run: |` commands are
+    checked as one logical command, same as what the shell executes."""
+    merged: list[str] = []
+    buffer = ""
+    for line in text.splitlines():
+        stripped = line.rstrip()
+        if stripped.endswith("\\"):
+            buffer += stripped[:-1] + " "
+        else:
+            merged.append(buffer + line)
+            buffer = ""
+    if buffer:
+        merged.append(buffer)
+    return merged
+
+
+def test_workflows_dir_has_files() -> None:
+    """Sanity check so a bad path above can't make the real test pass vacuously."""
+    assert list(WORKFLOWS_DIR.glob("*.yml"))
+
+
+def test_no_workflow_invokes_discover_without_fonte() -> None:
+    offenders = []
+    for wf in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        for line in _logical_lines(wf.read_text(encoding="utf-8")):
+            text = line.strip()
+            if not text or text.startswith("#"):
+                continue
+            if _DISCOVER_RE.search(text) and "--fonte" not in text:
+                offenders.append(f"{wf.name}: {text}")
+    assert not offenders, (
+        "workflow(s) invoke `leizilla discover` without `--fonte` — this "
+        "instantiates every discovery strategy including the assembleia "
+        "PlaywrightCrawlerDiscovery crawler, which hangs for hours (#105):\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
Closes #105

## Empilhado sobre #104

Este PR usa `claude/rfc-0004-secrets-status` (branch do #104) como base, não
`main` — de propósito, para não competir com o #104 e porque esta correção só
faz sentido com o `--fonte` que o #104 adiciona ao CLI `discover`. O diff
efetivo é só os 4 arquivos abaixo; depois que o #104 for mergeado, o GitHub
deve reancorar este PR em `main` automaticamente (ou dá pra aplicar o mesmo
diff direto em cima do #104, como preferir).

## O problema (issue #105)

`leizilla discover --ente ro` (sem `--fonte`) instancia **todas** as
estratégias do manifesto, inclusive a `PlaywrightCrawlerDiscovery` da fonte
`assembleia` (~5000 páginas visitadas sequencialmente). Confirmado 2× em
produção (2026-07-11 e 2026-07-12) que isso trava por horas e é cancelado
pelo timeout do job sem nunca chegar ao harvest (run
[29192792845](https://github.com/franklinbaldo/leizilla/actions/runs/29192792845)).

O #104 adiciona `--fonte` ao CLI `discover`, mas deixa **de propósito** de
fora a correção do workflow agendado real — `.github/workflows/discover-harvest.yml`
(`harvest-single` e `harvest-parallel`) continuava chamando `discover --ente ro`
sem escopo. A próxima execução (cron de sábado 02:00 UTC, ou qualquer
`workflow_dispatch` manual) travaria do mesmo jeito.

## O que muda

- **`.github/workflows/discover-harvest.yml`**: novo input `fonte` no
  `workflow_dispatch` (`type: choice`, opções `casacivil`/`assembleia`,
  padrão `casacivil`); os dois steps de Discover passam `--fonte`
  explicitamente — `inputs.fonte` no dispatch, `inputs.fonte || 'casacivil'`
  no disparo agendado (mesmo padrão já usado para `ente`/`limit` nesse
  arquivo). `assembleia` só roda mediante escolha manual explícita no
  dropdown — nunca no cron semanal.
- **`tests/test_workflow_hygiene.py`** (novo): checagem estática, sem
  dependência nova, que varre todo `.github/workflows/*.yml` **e `*.yaml`**
  e falha se algum step invocar `leizilla discover` sem `--fonte` — previne
  regressão (inclusive em workflows futuros, de qualquer uma das duas
  extensões que o GitHub Actions aceita). Validado manualmente que o teste
  **falha** contra a versão antiga do workflow e **passa** com a correção.
- **`docs/rfc/0004-go-live-rondonia.md`** / **`IMPLEMENTATION.md`**: nota de
  "risco em aberto" da RFC-0004 (adicionada pelo #104) atualizada para
  "corrigido", com link para este PR/issue.

## O que este PR não faz

Não dispara nenhum workflow, não roda `discover`/`harvest`/OCR/parse/release,
não mexe em secrets. Não decide *quando* de fato destravar os schedules com
ranges completos (passo 7 da RFC-0004) — só remove o bug de hang que
bloqueava essa decisão; a decisão em si continua do mantenedor.

## Teste

- `uv run ruff check .` / `uv run ruff format --check .` — limpo.
- `uv run mypy src/ --ignore-missing-imports` — **`Success: no issues found in
  22 source files`** com o ambiente sincronizado corretamente
  (`uv sync --extra dev`). Uma verificação anterior, rodada com `ruff`/`mypy`
  resolvidos globalmente no sandbox em vez do `.venv` do projeto (que não
  tinha sido sincronizado com `--extra dev` ainda), reportou 4 erros de stub
  do `requests` — falso positivo de ambiente, não do código; refeito com o
  `.venv` correto (`types-requests` presente) e ficou limpo, batendo com o
  gate `lint-test` já verde no CI do PR-base #104 sobre o mesmo `src/`.
- `uv run pytest -q` — 724 passed, 13 skipped (2 a mais que os 722 do #104:
  os dois testes de `test_workflow_hygiene.py`).
- YAML validado com `yaml.safe_load`.
- `lint-test` não dispara neste PR (base ≠ `main`, ver comentário abaixo);
  será reverificado depois do reancoramento em `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016gHD3ZaxWDug4jutehuNWn)_