### PR TITLE
fix(ci): repair wayback-save flag drift, add observability, split monolithic jobs

### DIFF
--- a/.github/actions/notify-run-failure/action.yml
+++ b/.github/actions/notify-run-failure/action.yml
@@ -1,0 +1,58 @@
+name: "Notify run failure"
+description: >
+  Cria (ou comenta em) uma issue de rastreamento quando um job de workflow
+  agendado falha ou é cancelado. Corrige a meta-causa identificada após um
+  ano de crons mortos em silêncio: fail-open é correto para os jobs de
+  batch em si, mas não deveria significar "ninguém percebe". Use com
+  `if: failure() || cancelled()` no step que chama esta action — sem esse
+  `if`, ela roda (e abre issue) em toda execução, inclusive as bem-sucedidas.
+
+inputs:
+  job-label:
+    description: >
+      Identificador curto do job/fonte que falhou (ex.: "rondonia_crawler /
+      assembleia"). Vira parte do título da issue e da chave de
+      deduplicação — mantenha estável entre execuções do mesmo job para que
+      falhas repetidas comentem na mesma issue em vez de abrir uma nova.
+    required: true
+  github-token:
+    description: "Token com permissão de issues:write (normalmente secrets.GITHUB_TOKEN)."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        JOB_LABEL: ${{ inputs.job-label }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW: ${{ github.workflow }}
+        REF_NAME: ${{ github.ref_name }}
+        EVENT_NAME: ${{ github.event_name }}
+        JOB_STATUS: ${{ job.status }}
+      run: |
+        set -euo pipefail
+
+        TITLE="🔴 ${WORKFLOW}: ${JOB_LABEL} falhou/cancelado"
+        BODY="**Execução:** ${RUN_URL}
+        **Status do job:** ${JOB_STATUS}
+        **Branch:** ${REF_NAME}
+        **Evento:** ${EVENT_NAME}
+        **Data (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+        Aberta automaticamente por \`.github/actions/notify-run-failure\`
+        porque este job terminou com \`failure()\` ou \`cancelled()\`."
+
+        # Deduplica por título exato — evita uma issue nova a cada execução
+        # da mesma falha recorrente; comenta na existente em vez disso.
+        EXISTING="$(gh issue list --state open --json number,title \
+          --jq ".[] | select(.title == \"${TITLE}\") | .number" | head -n1)"
+
+        if [ -n "${EXISTING:-}" ]; then
+          echo "Issue #${EXISTING} já existe para '${TITLE}' — comentando."
+          gh issue comment "${EXISTING}" --body "${BODY}"
+        else
+          echo "Criando nova issue: ${TITLE}"
+          gh issue create --title "${TITLE}" --body "${BODY}"
+        fi

--- a/.github/workflows/discover-harvest.yml
+++ b/.github/workflows/discover-harvest.yml
@@ -23,6 +23,10 @@ on:
         description: "Limite de recursos por job"
         default: "500"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   # ── DISPATCH com tipo específico ──────────────────────────────────────────
   harvest-single:
@@ -50,6 +54,13 @@ jobs:
             --ente "${{ inputs.ente }}" \
             --tipo "${{ inputs.tipo }}" \
             --limit "${{ inputs.limit }}"
+
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "discover-harvest / ${{ inputs.tipo }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # ── SCHEDULED ou DISPATCH sem tipo: todos os tipos em paralelo ────────────
   harvest-parallel:
@@ -82,3 +93,10 @@ jobs:
             --ente "${{ inputs.ente || 'ro' }}" \
             --tipo "${{ matrix.tipo }}" \
             --limit "${{ inputs.limit || '500' }}"
+
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "discover-harvest / ${{ matrix.tipo }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/parse-release.yml
+++ b/.github/workflows/parse-release.yml
@@ -36,25 +36,28 @@ on:
         description: "Se 'true', pula itens já parseados em IA (incremental)"
         default: "true"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
-  parse-release:
+  # Um job por fonte/tipo, cada um com seu próprio timeout — o job "etl"
+  # (fetch-all-parsed → consolidate → release) só depende deles via `needs`
+  # e roda mesmo se algum parse individual falhar ou for pulado (if: always()),
+  # em vez de compartilhar um único job monolítico onde um parse travado
+  # impedia a publicação do dataset.
+
+  parse-assembleia:
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: mkdir -p /tmp/leizilla-xmls
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync
-
-      - name: Create output dir
-        run: mkdir -p /tmp/leizilla-xmls
-
-      # ── SCHEDULED: parse all three RO sources incrementally ──────────────
-
-      - name: Parse — ro/assembleia (scheduled)
-        if: github.event_name == 'schedule'
+      - name: Parse — ro/assembleia
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -68,8 +71,24 @@ jobs:
             --limit 50 --output-dir /tmp/leizilla-xmls \
             --skip-existing --error-threshold 20 --upload
 
-      - name: Parse — ro/casacivil lei (scheduled)
-        if: github.event_name == 'schedule'
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "parse-release / assembleia"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  parse-casacivil-lei:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: mkdir -p /tmp/leizilla-xmls
+
+      - name: Parse — ro/casacivil lei
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -83,8 +102,24 @@ jobs:
             --limit 50 --output-dir /tmp/leizilla-xmls \
             --skip-existing --error-threshold 20 --upload
 
-      - name: Parse — ro/casacivil lc (scheduled)
-        if: github.event_name == 'schedule'
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "parse-release / casacivil-lei"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  parse-casacivil-lc:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: mkdir -p /tmp/leizilla-xmls
+
+      - name: Parse — ro/casacivil lc
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -98,10 +133,24 @@ jobs:
             --limit 50 --output-dir /tmp/leizilla-xmls \
             --skip-existing --error-threshold 20 --upload
 
-      # ── DISPATCH: single fonte/tipo, user-controlled ──────────────────────
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "parse-release / casacivil-lc"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Parse batch (dispatch)
-        if: github.event_name == 'workflow_dispatch'
+  parse-dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: mkdir -p /tmp/leizilla-xmls
+
+      - name: Parse batch
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -126,7 +175,23 @@ jobs:
             $SKIP_FLAG \
             $UPLOAD_FLAG
 
-      # ── ETL + RELEASE ──────────────────────────────────────────────────────
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "parse-release / dispatch"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  etl:
+    needs: [parse-assembleia, parse-casacivil-lei, parse-casacivil-lc, parse-dispatch]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: mkdir -p /tmp/leizilla-xmls
 
       - name: Fetch all parsed XMLs from IA (cumulative Parquet)
         run: |
@@ -174,3 +239,10 @@ jobs:
             --ente "${{ inputs.ente || 'ro' }}" \
             --version "${{ inputs.dataset_version || '0' }}" \
             --dry-run
+
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "parse-release / etl"
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rondonia_crawler.yml
+++ b/.github/workflows/rondonia_crawler.yml
@@ -27,22 +27,22 @@ on:
         description: "Se 'true', pula itens já no IA (incremental)"
         default: "true"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
-  scrape:
+  # Um job por fonte/tipo: cada um tem seu próprio timeout, então se
+  # assembleia (Playwright, ~3h47 observado) estourar o prazo, não derruba
+  # casacivil-lei/lc que rodariam depois no mesmo job monolítico anterior.
+  scrape-assembleia:
     runs-on: ubuntu-latest
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync
-
-      - name: Install Playwright browsers
-        run: uv run playwright install chromium --with-deps
-
-      # ── SCHEDULED: scrape all three RO sources incrementally ─────────────
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: uv run playwright install chromium --with-deps
 
       - name: Scrape — ro/assembleia (scheduled)
         if: github.event_name == 'schedule'
@@ -54,30 +54,6 @@ jobs:
             --ente ro --fonte assembleia \
             --start 1 --end 5000 \
             --skip-existing
-
-      - name: Scrape — ro/casacivil lei (scheduled)
-        if: github.event_name == 'schedule'
-        env:
-          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
-          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-        run: |
-          uv run leizilla scrape \
-            --ente ro --fonte casacivil --tipo lei \
-            --start 1 --end 6000 \
-            --skip-existing
-
-      - name: Scrape — ro/casacivil lc (scheduled)
-        if: github.event_name == 'schedule'
-        env:
-          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
-          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-        run: |
-          uv run leizilla scrape \
-            --ente ro --fonte casacivil --tipo lc \
-            --start 1 --end 1300 \
-            --skip-existing
-
-      # ── DISPATCH: user-controlled ranges ─────────────────────────────────
 
       - name: Scrape — ro/assembleia (dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -93,6 +69,33 @@ jobs:
             --end ${{ inputs.assembleia_end || '5000' }} \
             $SKIP_FLAG
 
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "rondonia_crawler / assembleia"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  scrape-casacivil-lei:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: uv run playwright install chromium --with-deps
+
+      - name: Scrape — ro/casacivil lei (scheduled)
+        if: github.event_name == 'schedule'
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+        run: |
+          uv run leizilla scrape \
+            --ente ro --fonte casacivil --tipo lei \
+            --start 1 --end 6000 \
+            --skip-existing
+
       - name: Scrape — ro/casacivil lei (dispatch)
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -107,6 +110,33 @@ jobs:
             --end ${{ inputs.casacivil_lei_end || '6000' }} \
             $SKIP_FLAG
 
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "rondonia_crawler / casacivil-lei"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  scrape-casacivil-lc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: uv run playwright install chromium --with-deps
+
+      - name: Scrape — ro/casacivil lc (scheduled)
+        if: github.event_name == 'schedule'
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+        run: |
+          uv run leizilla scrape \
+            --ente ro --fonte casacivil --tipo lc \
+            --start 1 --end 1300 \
+            --skip-existing
+
       - name: Scrape — ro/casacivil lc (dispatch)
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -120,3 +150,10 @@ jobs:
             --start ${{ inputs.casacivil_lc_start || '1' }} \
             --end ${{ inputs.casacivil_lc_end || '1300' }} \
             $SKIP_FLAG
+
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "rondonia_crawler / casacivil-lc"
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wayback-save.yml
+++ b/.github/workflows/wayback-save.yml
@@ -13,17 +13,21 @@ on:
         description: "Fonte (casacivil, assembleia)"
         default: "casacivil"
       tipo:
-        description: "Tipo de lei (lei, lc, decreto, ec, resolucao, portaria, decreto-lei) — vazio = todos"
+        description: "Tipo de lei (lei, lc, decreto, ec, resolucao, portaria, decreto-lei) — vazio = todos (a CLI já processa todos os tipos do manifesto numa única chamada)"
         default: ""
       start:
-        description: "Número inicial do range"
-        default: "1"
-      end:
-        description: "Número final (0 = fim do manifesto)"
-        default: "0"
+        description: "Número inicial do range. Se vazio, a CLI usa cdx_max - 20."
+        default: ""
+      probe_window:
+        description: "Quantos números além do máximo arquivado no CDX provar por tipo"
+        default: "200"
       delay:
         description: "Segundos entre submissões"
         default: "2"
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   wayback-save:
@@ -39,41 +43,22 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Wayback Save (todos os tipos)
-        if: ${{ github.event.inputs.tipo == '' || github.event_name == 'schedule' }}
+      - name: Wayback Save
         env:
           IAS3_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
         run: |
-          for tipo in lei lc ec resolucao portaria decreto-lei; do
-            echo "=== Submetendo tipo: $tipo ==="
-            uv run leizilla wayback-save \
-              --ente ${{ github.event.inputs.ente || 'ro' }} \
-              --fonte ${{ github.event.inputs.fonte || 'casacivil' }} \
-              --tipo $tipo \
-              --start ${{ github.event.inputs.start || '1' }} \
-              --end ${{ github.event.inputs.end || '0' }} \
-              --delay ${{ github.event.inputs.delay || '2' }}
-          done
-          echo "=== Submetendo tipo: decreto (range grande, pode demorar) ==="
           uv run leizilla wayback-save \
-            --ente ${{ github.event.inputs.ente || 'ro' }} \
-            --fonte ${{ github.event.inputs.fonte || 'casacivil' }} \
-            --tipo decreto \
-            --start ${{ github.event.inputs.start || '1' }} \
-            --end ${{ github.event.inputs.end || '0' }} \
-            --delay ${{ github.event.inputs.delay || '2' }}
+            --ente "${{ github.event.inputs.ente || 'ro' }}" \
+            --fonte "${{ github.event.inputs.fonte || 'casacivil' }}" \
+            ${{ github.event.inputs.tipo != '' && format('--tipo {0}', github.event.inputs.tipo) || '' }} \
+            ${{ github.event.inputs.start != '' && format('--start {0}', github.event.inputs.start) || '' }} \
+            --probe-window "${{ github.event.inputs.probe_window || '200' }}" \
+            --delay "${{ github.event.inputs.delay || '2' }}"
 
-      - name: Wayback Save (tipo específico)
-        if: ${{ github.event.inputs.tipo != '' && github.event_name != 'schedule' }}
-        env:
-          IAS3_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
-          IAS3_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-        run: |
-          uv run leizilla wayback-save \
-            --ente ${{ github.event.inputs.ente || 'ro' }} \
-            --fonte ${{ github.event.inputs.fonte || 'casacivil' }} \
-            --tipo ${{ github.event.inputs.tipo }} \
-            --start ${{ github.event.inputs.start || '1' }} \
-            --end ${{ github.event.inputs.end || '0' }} \
-            --delay ${{ github.event.inputs.delay || '2' }}
+      - name: Notify on failure
+        if: ${{ failure() || cancelled() }}
+        uses: ./.github/actions/notify-run-failure
+        with:
+          job-label: "wayback-save"
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_workflow_hygiene.py
+++ b/tests/test_workflow_hygiene.py
@@ -11,12 +11,62 @@ explicit manual choice.
 
 from __future__ import annotations
 
+import json
 import re
+import subprocess
 from pathlib import Path
 
-WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
 _DISCOVER_RE = re.compile(r"\bleizilla\s+discover\b")
+_LEIZILLA_INVOCATION_RE = re.compile(r"\bleizilla\s+([a-z][\w-]*)(?:\s+([a-z][\w-]*))?")
+_FLAG_RE = re.compile(r"--[a-zA-Z][\w-]*")
+
+# `leizilla wayback-save`'s workflow used `--end`, a flag removed when the
+# CLI switched to `--probe-window`-based probing — the cron ran instantly-red
+# every week for months and nobody noticed (see the observability test in
+# this same file). This introspects the *live* Typer app so any future
+# rename/removal of a flag anywhere in the CLI is caught the same way,
+# instead of relying on someone remembering to grep every workflow by hand.
+_CLI_INTROSPECTION_SCRIPT = r"""
+import json
+import typer
+from leizilla.cli import app
+
+group = typer.main.get_command(app)
+
+
+def flags_of(cmd):
+    flags = set()
+    for param in cmd.params:
+        flags.update(getattr(param, "opts", []) or [])
+        flags.update(getattr(param, "secondary_opts", []) or [])
+    return sorted(f for f in flags if f.startswith("--"))
+
+
+result = {}
+for name, cmd in group.commands.items():
+    if hasattr(cmd, "commands"):
+        for sub_name, sub_cmd in cmd.commands.items():
+            result[f"{name} {sub_name}"] = flags_of(sub_cmd)
+    else:
+        result[name] = flags_of(cmd)
+
+print(json.dumps(result))
+"""
+
+
+def _cli_flag_map() -> dict[str, set[str]]:
+    """{command name (e.g. "scrape" or "dev subcmd"): set of valid --flags}."""
+    proc = subprocess.run(
+        ["uv", "run", "python", "-c", _CLI_INTROSPECTION_SCRIPT],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {cmd: set(flags) for cmd, flags in json.loads(proc.stdout).items()}
 
 
 def _workflow_files() -> list[Path]:
@@ -61,4 +111,41 @@ def test_no_workflow_invokes_discover_without_fonte() -> None:
         "instantiates every discovery strategy including the assembleia "
         "PlaywrightCrawlerDiscovery crawler, which hangs for hours (#105):\n"
         + "\n".join(offenders)
+    )
+
+
+def test_workflow_flags_match_cli_signatures() -> None:
+    """Statically validate every `leizilla <cmd> ...` invocation in every
+    workflow against the actual Typer command signatures, killing the whole
+    class of workflow<->CLI drift bugs (e.g. wayback-save.yml's `--end`,
+    which stopped existing when the CLI moved to `--probe-window`)."""
+    flag_map = _cli_flag_map()
+    offenders = []
+    for wf in _workflow_files():
+        for line in _logical_lines(wf.read_text(encoding="utf-8")):
+            text = line.strip()
+            if not text or text.startswith("#"):
+                continue
+            match = _LEIZILLA_INVOCATION_RE.search(text)
+            if not match:
+                continue
+            cmd, maybe_sub = match.group(1), match.group(2)
+            nested_key = f"{cmd} {maybe_sub}" if maybe_sub else None
+            key = nested_key if nested_key in flag_map else cmd
+            valid_flags = flag_map.get(key)
+            if valid_flags is None:
+                # Unknown command name (e.g. `leizilla --help`) — not this
+                # test's job; test_workflows_dir_has_files-style typos in
+                # the command itself would surface at run time regardless.
+                continue
+            used_flags = set(_FLAG_RE.findall(text))
+            unknown = used_flags - valid_flags
+            if unknown:
+                offenders.append(
+                    f"{wf.name}: `leizilla {key}` does not accept "
+                    f"{sorted(unknown)} (valid: {sorted(valid_flags)}) — line: {text}"
+                )
+    assert not offenders, (
+        "workflow(s) invoke leizilla commands with flags that don't exist "
+        "on the current CLI signature:\n" + "\n".join(offenders)
     )


### PR DESCRIPTION
## Summary
- `wayback-save.yml` invoked `leizilla wayback-save --end ...`, a flag that was renamed to `--probe-window` — the weekly cron has been failing instantly for months, and nothing surfaced that failure anywhere.
- Added a generalized `test_workflow_flags_match_cli_signatures` test that introspects the live Typer/Click CLI and validates every `leizilla <cmd>` invocation in every workflow against the real flag signatures, so this class of drift is caught in CI instead of silently in prod.
- Added a reusable `notify-run-failure` composite action that opens/comments on a GitHub issue whenever a scheduled job ends `failure()`/`cancelled()` — wired into every job across `wayback-save.yml`, `rondonia_crawler.yml`, `parse-release.yml`, `discover-harvest.yml`.
- Split the monolithic `scrape`/`parse-release` jobs into one job per source/tipo, each with its own `timeout-minutes`, so a hung source (e.g. assembleia's Playwright crawl, observed taking ~3h47) can no longer take down sibling steps queued behind it in the same job.

## Test plan
- [x] `uv run pytest -q` — 725 passed, 13 skipped, no regressions
- [x] `uv run ruff check` clean
- [x] All workflow YAML re-parsed with `yaml.safe_load` — valid
- [ ] Trigger `wayback-save`, `rondonia_crawler`, `parse-release` via `workflow_dispatch` post-merge to confirm the flag fix holds against the live CLI/environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cer4wHLPHztUVHhVZuwWJV