### PR TITLE
fix(parser): log the reason parse_law() rejects a document

### DIFF
--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -9,6 +9,7 @@ LiteLLM serve (RFC-0006). Precedência: --model > LLM_MODEL > auto pela chave.
 """
 
 import json
+import logging
 import math
 import os
 import urllib.error
@@ -20,6 +21,8 @@ from typing import Any, Dict, Optional, Tuple
 
 from leizilla import config
 from leizilla.ia_utils import resolve_raw_url
+
+logger = logging.getLogger(__name__)
 
 _HAIKU = "claude-haiku-4-5"
 _GEMINI_FLASH = "gemini/gemini-2.5-flash"
@@ -313,30 +316,55 @@ def parse_law(
     raw = (response.choices[0].message.content or "") if response.choices else ""
     result = _extract_json(raw)
     if result is None:
+        logger.warning("%s: LLM response has no extractable JSON: %r", ia_id, raw[:300])
         return None
 
     try:
         confidence = float(result.get("confidence", 0.0))
     except (TypeError, ValueError):
+        logger.warning(
+            "%s: non-numeric confidence value: %r", ia_id, result.get("confidence")
+        )
         return None
     if not math.isfinite(confidence) or confidence < _MIN_CONFIDENCE:
+        logger.warning(
+            "%s: confidence %.2f below threshold %.2f — reason: %s",
+            ia_id,
+            confidence,
+            _MIN_CONFIDENCE,
+            result.get("error", "(LLM não informou motivo)"),
+        )
         return None
 
     xml = result.get("xml", "")
     if not xml or not _is_well_formed(xml):
+        logger.warning(
+            "%s: confidence %.2f mas xml ausente/malformado", ia_id, confidence
+        )
         return None
 
     tipo = result.get("tipo")
     numero = result.get("numero")
     ano = result.get("ano")
     if not tipo or numero is None or not ano:
+        logger.warning(
+            "%s: confidence %.2f mas campos obrigatórios ausentes "
+            "(tipo=%r numero=%r ano=%r)",
+            ia_id,
+            confidence,
+            tipo,
+            numero,
+            ano,
+        )
         return None
     numero_str = str(numero).strip()
     if not numero_str.isdigit():
+        logger.warning("%s: numero não numérico: %r", ia_id, numero)
         return None
     try:
         ano = int(ano)
     except (TypeError, ValueError):
+        logger.warning("%s: ano inválido: %r", ia_id, result.get("ano"))
         return None
     ia_id_parsed = f"leizilla-{ente}-{tipo}-{numero_str.zfill(5)}-{ano}"
 


### PR DESCRIPTION
## O problema

`parse_law()` retorna `None` silenciosamente em todo caminho de rejeição
(JSON malformado, confiança baixa, `xml`/`tipo`/`numero`/`ano` ausentes) — o
`parse-all` só imprime `"Parse falhou — skip"`, sem nenhum dado pra triagem.

O prompt já pede ao LLM um campo `"error"` explicando o motivo quando a
confiança é baixa (`{"confidence": 0.0, "error": "brief reason"}`), mas esse
campo nunca era lido em lugar nenhum do código.

## Como foi descoberto

Rodando o smoke batch real da RFC-0004 (`parse-all --fonte casacivil --tipo
lei --limit 10`), 9 de 15 itens falharam com `"Parse falhou — skip"` e
nenhuma pista de por quê. Inspecionando manualmente o OCR de um item que
falhou (`lei-00001`, 1983) contra um que passou (`lei-00010`, confiança
0.80), o motivo real apareceu: um trecho do meio do artigo estava
irrecuperavelmente corrompido no OCR (`"Antigo UBS cosa lshator o io) oo;
o jyito fo jog) ato é ep Su eira"`) — o modelo corretamente recusou
inventar o conteúdo ausente. Isso é o gate fail-closed (M3.1) funcionando
como projetado, mas descobrir isso exigiu baixar e comparar OCR bruto à
mão — não deveria.

## O que muda

Adiciona logging no nível de módulo (mesmo padrão já usado em
`discovery.py`/`publisher.py`) em cada um dos caminhos de rejeição de
`parse_law()`, incluindo o `ia_id`, a confiança obtida e — quando
disponível — o motivo que o próprio LLM informou. Sem mudar o contrato de
retorno da função (ainda `Optional[ParseResult]`), então nenhum call site
ou teste existente precisou mudar.

## Teste

- `uv run pytest -q` — 725 passed, 13 skipped (mesmo total do PR #108, sem
  regressão).
- `uv run ruff check` / `ruff format --check` — limpo.
- `uv run mypy src/ --ignore-missing-imports` — `Success: no issues found in
  22 source files`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HEZzmNF2Gr6oqmmDcG4arX)_