### PR TITLE
docs(opf): reactivate Phase 3 fine-tune as a smoke test on gold v0

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -56,7 +56,7 @@
 | **M5.3** — Benchmark DuckDB-WASM real + FTS | 🔴 blocked | — | Aguarda dataset publicado (~100k+ rows RO). ILIKE no DuckDB columnar é suficiente para ~300k rows estimados; FTS só se benchmark in-browser medir > 1s. |
 | **M14.1** — OPF fine-tune: fundação de prep de dados | 🟡 in-progress | — | ADR-0012 + ontologia `leizilla_normas_v1` + sampler estratificado (`opf-sample`) + helper `opf_annotate.py` vendorado + doc `docs/opf-finetune.md`. Fase 1 de 4 (prep → anotar → treinar Colab → integrar). |
 | **M14.2** — OPF gold v0 (anotação por subagentes) | 🟡 in-progress | — | Gold seed em `data/opf/gold/` (6 leis federais reais, 251 spans) via subagentes LLM (shard-por-doc) + resolução determinística de offset + ensemble de avaliadores (strict/category/blind/adversarial) no eval slice. Fase 2 de 4. |
-| **M14.3** — OPF treino/eval (notebook Colab GPU) | ⚪ adiado | — | `notebooks/opf_train_colab.ipynb` pronto, mas o **fine-tune está adiado** (2026-06-06): regex (`segmenter.py`, exact 0.95/overlap 0.99) + parse Claude cobrem o regime regular/born-digital de RO (confirmado pela ingestão DITEL, PR #85). Reativar com evidência de fontes OCR-ruidosas/irregulares ou outros entes. Ver ADR-0012 "Atualização (2026-06-06)". |
+| **M14.3** — OPF treino/eval (notebook Colab GPU) | 🟡 reativado | — | `notebooks/opf_train_colab.ipynb` pronto (aponta pro `main`, gold v0 já commitado — nenhuma mudança de código necessária). **Reativado por decisão do mantenedor em 2026-07-14** (não pelo gatilho de evidência da atualização de 2026-06-06 — o v0 segue single-fonte/texto limpo). Falta rodar no Colab (GPU), fora do alcance de sessões sem GPU/Drive interativo. Ver ADR-0012 "Atualização (2026-07-14)". |
 | **M14.4** — Segmentador regex baseline + eval/errors/structure vs gold | 🟢 done | — | `segmenter.py` (Pattern B) + CLIs `opf-regex-eval` (`--errors`) e `opf-segment-check`. `evaluate_against_gold` (exact/overlap P/R/F1), `find_errors` (lista FP/FN/boundary com contexto — guiou as regras e achou drift de período no gold + provável omissão), `validate_structure` (validação da norma inteira sem gold: lacunas na numeração de artigos, fora de ordem, ementa/vigência ausentes). Regras: splitter ciente de abreviações/números, verbo operativo na revogação (notas `(Revogado pela…)` excluídas, precision 0.33→1.00 em compilados), strip de marcador líder, guard à direita, marcadores sem período final (gold normalizado). v0: exact micro-F1 **0.95** / overlap **0.99**. 28 testes. |
 
 Legenda: ⚪ todo · 🟡 in-progress · 🟢 done · 🔴 blocked
@@ -112,6 +112,32 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 ## Decisões técnicas (log cronológico)
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
+
+### 2026-07-14 — M14.3: fine-tune OPF reativado (smoke test no gold v0), por decisão do mantenedor
+
+Supersede a atualização de 2026-06-06 da ADR-0012 (fine-tune adiado até evidência de
+OCR ruidoso/formatação irregular/outro ente). O mantenedor decidiu retomar a Fase 3
+agora mesmo assim, como **smoke test explícito** — não porque o gatilho de evidência
+foi atingido. O gold v0 segue com a limitação conhecida desde M14.2: fonte única
+(Planalto federal), texto limpo (HTML oficial, não `_djvu.txt`), sem ruído de OCR.
+
+Nenhuma mudança de código foi necessária: `notebooks/opf_train_colab.ipynb` já aponta
+`GOLD_GIT_URL`/`GOLD_GIT_REF` para `main`, e o gold v0 (`data/opf/gold/`) já está
+commitado lá desde M14.2 (confirmado presente em `origin/main`, commit `6d202e3`).
+Falta apenas executar o notebook — treino em GPU via Colab está fora do alcance de
+sessões sem acesso a GPU/Drive interativo.
+
+**Contexto da decisão**: na mesma sessão, o primeiro dataset real (`leizilla-dataset-ro-v0`,
+19 leis de RO) foi publicado no IA (RFC-0004 passos 4-6), incluindo um caso de OCR
+genuinamente ruidoso (`lei-00001-1983`, trecho de artigo corrompido) que ilustra — mas
+não por si só configura o gatilho formal da ADR-0012 (que pede medição contra o
+baseline 0.95/0.99, não um exemplo isolado) — o tipo de evidência que a atualização de
+2026-06-06 previa.
+
+**Recomendação registrada, não executada**: expandir o gold com OCR real e ruidoso de
+RO (multi-fonte, via `opf-sample` sobre os raw items já publicados + o mesmo método de
+anotação por subagentes de M14.2) antes de um treino com pretensão de produção. Ver
+ADR-0012 "Atualização (2026-07-14)" e `docs/opf-finetune.md` para o detalhe completo.
 
 ### 2026-07-12 — issue #105: `discover-harvest.yml` agendado agora escopa `--fonte`
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -56,7 +56,7 @@
 | **M5.3** — Benchmark DuckDB-WASM real + FTS | 🔴 blocked | — | Aguarda dataset publicado (~100k+ rows RO). ILIKE no DuckDB columnar é suficiente para ~300k rows estimados; FTS só se benchmark in-browser medir > 1s. |
 | **M14.1** — OPF fine-tune: fundação de prep de dados | 🟡 in-progress | — | ADR-0012 + ontologia `leizilla_normas_v1` + sampler estratificado (`opf-sample`) + helper `opf_annotate.py` vendorado + doc `docs/opf-finetune.md`. Fase 1 de 4 (prep → anotar → treinar Colab → integrar). |
 | **M14.2** — OPF gold v0 (anotação por subagentes) | 🟡 in-progress | — | Gold seed em `data/opf/gold/` (6 leis federais reais, 251 spans) via subagentes LLM (shard-por-doc) + resolução determinística de offset + ensemble de avaliadores (strict/category/blind/adversarial) no eval slice. Fase 2 de 4. |
-| **M14.3** — OPF treino/eval (notebook Colab GPU) | 🟡 reativado | — | `notebooks/opf_train_colab.ipynb` pronto (aponta pro `main`, gold v0 já commitado — nenhuma mudança de código necessária). **Reativado por decisão do mantenedor em 2026-07-14** (não pelo gatilho de evidência da atualização de 2026-06-06 — o v0 segue single-fonte/texto limpo). Falta rodar no Colab (GPU), fora do alcance de sessões sem GPU/Drive interativo. Ver ADR-0012 "Atualização (2026-07-14)". |
+| **M14.3** — OPF treino/eval (notebook Colab GPU) | 🟡 in-progress | — | `notebooks/opf_train_colab.ipynb` pronto (aponta pro `main`, gold v0 já commitado; 3 bugs reais de CLI achados em revisão e corrigidos — `--seed`→`--shuffle-seed`, `--checkpoint` ausente no train, `--label-space-json` inválido no eval). **Reativado por decisão do mantenedor em 2026-07-14** (não pelo gatilho de evidência da atualização de 2026-06-06 — o v0 segue single-fonte/texto limpo). Falta rodar no Colab (GPU), fora do alcance de sessões sem GPU/Drive interativo. Ver ADR-0012 "Atualização (2026-07-14)". |
 | **M14.4** — Segmentador regex baseline + eval/errors/structure vs gold | 🟢 done | — | `segmenter.py` (Pattern B) + CLIs `opf-regex-eval` (`--errors`) e `opf-segment-check`. `evaluate_against_gold` (exact/overlap P/R/F1), `find_errors` (lista FP/FN/boundary com contexto — guiou as regras e achou drift de período no gold + provável omissão), `validate_structure` (validação da norma inteira sem gold: lacunas na numeração de artigos, fora de ordem, ementa/vigência ausentes). Regras: splitter ciente de abreviações/números, verbo operativo na revogação (notas `(Revogado pela…)` excluídas, precision 0.33→1.00 em compilados), strip de marcador líder, guard à direita, marcadores sem período final (gold normalizado). v0: exact micro-F1 **0.95** / overlap **0.99**. 28 testes. |
 
 Legenda: ⚪ todo · 🟡 in-progress · 🟢 done · 🔴 blocked
@@ -121,11 +121,16 @@ agora mesmo assim, como **smoke test explícito** — não porque o gatilho de e
 foi atingido. O gold v0 segue com a limitação conhecida desde M14.2: fonte única
 (Planalto federal), texto limpo (HTML oficial, não `_djvu.txt`), sem ruído de OCR.
 
-Nenhuma mudança de código foi necessária: `notebooks/opf_train_colab.ipynb` já aponta
+A plumbing de dados não precisou mudar: `notebooks/opf_train_colab.ipynb` já aponta
 `GOLD_GIT_URL`/`GOLD_GIT_REF` para `main`, e o gold v0 (`data/opf/gold/`) já está
-commitado lá desde M14.2 (confirmado presente em `origin/main`, commit `6d202e3`).
-Falta apenas executar o notebook — treino em GPU via Colab está fora do alcance de
-sessões sem acesso a GPU/Drive interativo.
+commitado lá desde M14.2 (commit `d9fd0b0`, "feat(opf): gold v0 dataset via labeling +
+evaluator-ensemble subagents"). O notebook em si, porém, tinha três bugs reais de
+argumento de CLI — achados numa revisão desta reativação e corrigidos, verificados
+contra uma instalação real do `openai/privacy-filter`: `--seed` não existe (flag real
+`--shuffle-seed`); o modelo-base persistido no Drive nunca era passado a `opf train`
+via `--checkpoint` (caía no default efêmero); `opf eval` não aceita
+`--label-space-json`. Falta apenas executar o notebook corrigido — treino em GPU via
+Colab está fora do alcance de sessões sem acesso a GPU/Drive interativo.
 
 **Contexto da decisão**: na mesma sessão, o primeiro dataset real (`leizilla-dataset-ro-v0`,
 19 leis de RO) foi publicado no IA (RFC-0004 passos 4-6), incluindo um caso de OCR

--- a/docs/adr/0012-opf-structural-span-tagging.md
+++ b/docs/adr/0012-opf-structural-span-tagging.md
@@ -21,7 +21,13 @@ exatamente como o próprio notebook já documenta em sua célula final ("v0 is a
 test + baseline, not a deliverable model").
 
 `notebooks/opf_train_colab.ipynb` já aponta para `main` e o gold v0 já está commitado
-lá — nenhuma mudança de código foi necessária para destravar o run; falta só executá-lo
+lá — a plumbing de dados (git ref, gold, ontologia) não precisou mudar. O notebook em
+si, porém, tinha três bugs reais de argumento de CLI, achados e corrigidos numa revisão
+desta reativação (verificados contra uma instalação real do `openai/privacy-filter`):
+`--seed` não existe (o flag real é `--shuffle-seed`); o modelo-base persistido no Drive
+nunca era passado a `opf train` via `--checkpoint` (caía no default efêmero
+`/root/.opf/privacy_filter`); e `opf eval` não aceita `--label-space-json` (o checkpoint
+já carrega a ontologia com que foi treinado). Falta só executar o notebook corrigido
 (GPU via Colab, fora do alcance de sessões sem acesso a GPU/Drive interativo).
 Expandir o gold com OCR real de RO (multi-fonte, incluindo casos ruidosos como o de
 `lei-00001-1983` encontrado na sessão de go-live desta mesma data) permanece o caminho

--- a/docs/adr/0012-opf-structural-span-tagging.md
+++ b/docs/adr/0012-opf-structural-span-tagging.md
@@ -1,11 +1,32 @@
 # ADR-0012 — OPF (token-classifier) como caminho de anotação estrutural das normas, complementar ao parser generativo
 
-**Status**: Aprovada — **fine-tune adiado (2026-06-06, ver atualização abaixo)**
+**Status**: Aprovada — **fine-tune reativado (2026-07-14, ver atualização abaixo)**
 **Data**: 2026-06-05
 **Contexto**: Anotação estrutural de normas — fine-tune do OpenAI Privacy Filter (OPF)
 **Relaciona-se com**: [ADR-0010](0010-raw-content-addressed-parsed-urn.md) (raw OCR
 content-addressed é o insumo), `parser.py` (parser generativo via Claude Haiku),
 [SCHEMA.md](../SCHEMA.md) (modelo dispositivo-cêntrico, rótulo derivado do `path`).
+
+## Atualização (2026-07-14) — fine-tune (Fase 3) REATIVADO como smoke test no gold v0
+
+A atualização de 2026-06-06 (abaixo) condicionava reativar a Fase 3 a evidência de
+OCR ruidoso/formatação irregular/outro ente. O mantenedor decidiu retomar o treino
+agora mesmo assim, como **smoke test explícito sobre o gold v0** (leis federais do
+Planalto, texto limpo, 251 spans, fonte única) — não porque o gatilho de evidência
+foi atingido, mas por decisão direta de prosseguir. Registro isso para transparência:
+a limitação conhecida do v0 segue valendo (`known_limitations` no
+`manifest.json` — "lacks OCR noise the production OPF will see"), e o resultado deste
+run deve ser lido como baseline/smoke test, não como modelo pronto para produção —
+exatamente como o próprio notebook já documenta em sua célula final ("v0 is a smoke
+test + baseline, not a deliverable model").
+
+`notebooks/opf_train_colab.ipynb` já aponta para `main` e o gold v0 já está commitado
+lá — nenhuma mudança de código foi necessária para destravar o run; falta só executá-lo
+(GPU via Colab, fora do alcance de sessões sem acesso a GPU/Drive interativo).
+Expandir o gold com OCR real de RO (multi-fonte, incluindo casos ruidosos como o de
+`lei-00001-1983` encontrado na sessão de go-live desta mesma data) permanece o caminho
+recomendado para um treino de produção — decisão explicitamente adiada para depois
+deste smoke test, a critério do mantenedor.
 
 ## Atualização (2026-06-06) — fine-tune (Fase 3) ADIADO; ferramentas model-free mantidas
 

--- a/docs/opf-finetune.md
+++ b/docs/opf-finetune.md
@@ -1,13 +1,17 @@
 # Fine-tuning OPF to annotate Leizilla normas
 
 > **Status (2026-07-14): the GPU fine-tune (Phase 3) is REACTIVATED as a smoke test on
-> gold v0.** The 2026-06-06 deferral (below) is superseded by mantainer decision, not by
+> gold v0.** The 2026-06-06 deferral (below) is superseded by maintainer decision, not by
 > the evidence trigger it originally called for — the v0 gold is still single-fonte,
-> clean-text federal Planalto (no OCR noise). Run `notebooks/opf_train_colab.ipynb`
-> (already points at `main`, gold v0 already committed — no code changes needed) as a
-> baseline/smoke test, not a production model. See ADR-0012 "Atualização (2026-07-14)"
-> for the full rationale and the recommended next step (expand gold with real,
-> multi-fonte RO OCR before a production-grade run).
+> clean-text federal Planalto (no OCR noise). `notebooks/opf_train_colab.ipynb` already
+> points at `main` and gold v0 is already committed there; a code review of this
+> reactivation also found and fixed three real CLI-argument bugs in the notebook itself
+> (`--seed` doesn't exist — the real flag is `--shuffle-seed`; the Drive-persisted base
+> model was never passed to `opf train` via `--checkpoint`; `opf eval` doesn't accept
+> `--label-space-json`), all verified against a live install of `openai/privacy-filter`.
+> Run it as a baseline/smoke test, not a production model. See ADR-0012
+> "Atualização (2026-07-14)" for the full rationale and the recommended next step (expand
+> gold with real, multi-fonte RO OCR before a production-grade run).
 
 This is Leizilla's concrete recipe for the [`opf-finetune`
 skill](https://github.com/franklinbaldo/skills/tree/main/opf-finetune). Read the skill

--- a/docs/opf-finetune.md
+++ b/docs/opf-finetune.md
@@ -1,12 +1,13 @@
 # Fine-tuning OPF to annotate Leizilla normas
 
-> **Status (2026-06-06): the GPU fine-tune (Phase 3) is DEFERRED.** The DITEL ingestion work
-> (PR #85) confirmed RO laws are born-digital and LC 95-regular, and the deterministic
-> `segmenter.py` already scores exact 0.95 / overlap 0.99 — so regex + the Claude parser
-> cover the regular case without a model. The **model-free tooling here is active and
-> useful** (segmenter, `evaluate_against_gold`/`find_errors`, `validate_structure`); only the
-> *training* is on hold, to be revisited with evidence from OCR-noisy/irregular sources or
-> other entes. See ADR-0012 "Atualização (2026-06-06)".
+> **Status (2026-07-14): the GPU fine-tune (Phase 3) is REACTIVATED as a smoke test on
+> gold v0.** The 2026-06-06 deferral (below) is superseded by mantainer decision, not by
+> the evidence trigger it originally called for — the v0 gold is still single-fonte,
+> clean-text federal Planalto (no OCR noise). Run `notebooks/opf_train_colab.ipynb`
+> (already points at `main`, gold v0 already committed — no code changes needed) as a
+> baseline/smoke test, not a production model. See ADR-0012 "Atualização (2026-07-14)"
+> for the full rationale and the recommended next step (expand gold with real,
+> multi-fonte RO OCR before a production-grade run).
 
 This is Leizilla's concrete recipe for the [`opf-finetune`
 skill](https://github.com/franklinbaldo/skills/tree/main/opf-finetune). Read the skill

--- a/notebooks/opf_train_colab.ipynb
+++ b/notebooks/opf_train_colab.ipynb
@@ -171,18 +171,11 @@
    "outputs": [],
    "source": [
     "# 6. Validate the gold BEFORE spending a GPU run (offset/overlap/label-space gate).\n",
-    "rc = subprocess.run(\n",
-    "    [\n",
-    "        sys.executable,\n",
-    "        f\"{SRC}/scripts/opf_annotate.py\",\n",
-    "        \"validate\",\n",
-    "        f\"{DATA_DIR}/train.jsonl\",\n",
-    "        \"--label-space\",\n",
-    "        f\"{DATA_DIR}/label_space.json\",\n",
-    "    ]\n",
-    ").returncode\n",
-    "for _split in (\"val\", \"test\"):\n",
-    "    subprocess.run(\n",
+    "# Every split's exit code is checked -- a bad val/test split must fail loudly here,\n",
+    "# not silently reach training/eval (opf_annotate.py validate returns 1 on error).\n",
+    "validation_rc = {}\n",
+    "for _split in (\"train\", \"val\", \"test\"):\n",
+    "    validation_rc[_split] = subprocess.run(\n",
     "        [\n",
     "            sys.executable,\n",
     "            f\"{SRC}/scripts/opf_annotate.py\",\n",
@@ -191,8 +184,9 @@
     "            \"--label-space\",\n",
     "            f\"{DATA_DIR}/label_space.json\",\n",
     "        ]\n",
-    "    )\n",
-    "assert rc == 0, \"train.jsonl failed validation — fix the gold before training\""
+    "    ).returncode\n",
+    "_failed = [s for s, rc in validation_rc.items() if rc != 0]\n",
+    "assert not _failed, f\"gold validation failed for: {_failed} -- fix before training\""
    ]
   },
   {
@@ -203,10 +197,8 @@
    "outputs": [],
    "source": [
     "# 7. Train. Output dir gets config.json + model.safetensors + finetune_summary.json\n",
-    "#    + USAGE.txt. Flag names beyond the three core ones below are version-dependent —\n",
-    "#    if this errors, read the `opf train --help` output from the cell above and adjust\n",
-    "#    (e.g. the device / context-length / seed flags). The skill's\n",
-    "#    examples/scripts/finetuning/finetune_custom_label_demo.sh is the closest template.\n",
+    "#    + USAGE.txt. Flags verified against a live `opf train --help`\n",
+    "#    (openai/privacy-filter, 2026-07-14) -- re-check if a future opf version errors here.\n",
     "train_args = [\n",
     "    \"train\",\n",
     "    f\"{DATA_DIR}/train.jsonl\",\n",
@@ -216,12 +208,14 @@
     "    f\"{DATA_DIR}/label_space.json\",\n",
     "    \"--output-dir\",\n",
     "    OUT_LOCAL,\n",
-    "    # --- verify the following names against `opf train --help` for your opf version ---\n",
+    "    \"--checkpoint\",\n",
+    "    LOCAL_BASE,  # Drive-persisted base (cell 4) -- without this opf re-downloads to\n",
+    "    # the ephemeral /root/.opf/privacy_filter default instead of reusing the cache.\n",
     "    \"--device\",\n",
     "    DEVICE,\n",
     "    \"--n-ctx\",\n",
     "    str(N_CTX),\n",
-    "    \"--seed\",\n",
+    "    \"--shuffle-seed\",\n",
     "    str(SEED),\n",
     "]\n",
     "opf(*train_args)"
@@ -250,6 +244,8 @@
     "# 9. Evaluate on the held-out PT-BR test slice. Look at span-level F1 split into\n",
     "#    exact vs partial/overlap (boundary drift is OPF's failure mode on formatted text)\n",
     "#    and the PER-CATEGORY breakdown with support. Capture the output to test_eval.txt.\n",
+    "# Note: `opf eval` takes no --label-space-json -- the checkpoint already encodes the\n",
+    "# label space it was trained with (verified against a live `opf eval --help`, 2026-07-14).\n",
     "res = subprocess.run(\n",
     "    [\n",
     "        sys.executable,\n",
@@ -257,8 +253,6 @@
     "        \"opf\",\n",
     "        \"eval\",\n",
     "        f\"{DATA_DIR}/test.jsonl\",\n",
-    "        \"--label-space-json\",\n",
-    "        f\"{DATA_DIR}/label_space.json\",\n",
     "        \"--checkpoint\",\n",
     "        RUN_DIR,\n",
     "    ],\n",
@@ -268,7 +262,8 @@
     "print(res.stdout)\n",
     "print(res.stderr)\n",
     "with open(f\"{RUN_DIR}/test_eval.txt\", \"w\", encoding=\"utf-8\") as fh:\n",
-    "    fh.write(res.stdout + \"\\n\" + res.stderr)"
+    "    fh.write(res.stdout + \"\\n\" + res.stderr)\n",
+    "assert res.returncode == 0, \"opf eval failed -- see test_eval.txt / stderr above\""
    ]
   },
   {


### PR DESCRIPTION
## O que muda

Registro formal de uma decisão do mantenedor: reativar o fine-tune do OPF
(M14.3/Fase 3), adiado pela atualização de 2026-06-06 da ADR-0012 até haver
evidência de OCR ruidoso/formatação irregular/outro ente.

**Importante: isso não é "o gatilho de evidência foi atingido"** — é uma
decisão direta de prosseguir mesmo assim, como smoke test explícito. O
gold v0 segue com a limitação conhecida desde M14.2 (fonte única, texto
limpo do Planalto federal, sem ruído de OCR real). Documento isso com
transparência em três lugares: ADR-0012 (nova entrada "Atualização
2026-07-14"), `docs/opf-finetune.md` (banner de status) e IMPLEMENTATION.md
(linha M14.3 + entrada no log de decisões).

## Update: revisão encontrou e corrigiu 3 bugs reais no notebook

O commit inicial desta PR afirmava "nenhuma mudança de código necessária —
o notebook está pronto para rodar como está". Uma revisão de código (com
verificação contra uma instalação real do `openai/privacy-filter`) mostrou
que isso era **falso**. `notebooks/opf_train_colab.ipynb` tinha três bugs
reais de argumento de CLI que teriam quebrado o run:

- `opf train` não tem flag `--seed` — o flag real é `--shuffle-seed`.
  O notebook falharia imediatamente com argumento não reconhecido.
- O modelo-base persistido no Drive (`LOCAL_BASE`, ~2.8GB) nunca era
  passado a `opf train` via `--checkpoint` — caía silenciosamente no
  cache efêmero default do `opf` em vez de reusar o que foi persistido.
- `opf eval` não aceita `--label-space-json` (só `train` aceita — o
  checkpoint já carrega a ontologia com que foi treinado).

Também corrigido: as validações de `val.jsonl`/`test.jsonl` não checavam
o código de saída (só `train.jsonl` checava), então um split quebrado não
impediria um treino caro em GPU; a avaliação final também não checava
`returncode`. Mais um typo ("mantainer"→"maintainer"), o status
`🟡 reativado` (fora da legenda da tabela) revertido para `🟡 in-progress`
com o detalhe no texto livre, e uma citação de commit errada (o gold v0
foi criado em `d9fd0b0`, não em `6d202e3` — que só normalizou dados
depois).

## O que NÃO muda

O schema/pipeline de produção — isso é só o notebook opcional de
fine-tune (Fase 3, fora do caminho de produção) + a documentação da
decisão de reativá-lo.

## Teste

- Notebook: JSON válido (`json.load` ok); todos os flags corrigidos
  verificados contra `opf train --help` / `opf eval --help` de uma
  instalação real e local do `openai/privacy-filter` (não apenas lidos
  na documentação do pacote).
- `ruff`/`mypy`/`pytest`: não deveriam ser afetados (nenhum arquivo
  Python de produção tocado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEZzmNF2Gr6oqmmDcG4arX)_