### PR TITLE
fix(ci): pace parsing and IA uploads within service quotas

### DIFF
--- a/.github/workflows/discover-harvest.yml
+++ b/.github/workflows/discover-harvest.yml
@@ -2,7 +2,9 @@ name: Discover & Harvest (manifest-driven)
 
 on:
   schedule:
-    # Sábado 02:00 UTC — jobs paralelos por tipo garantem ~7x throughput vs serial
+    # Sábado 02:00 UTC — paralelismo dos 7 tipos limitado a 2 por vez
+    # (max-parallel na matrix abaixo), pra não fazer o IA recusar a rajada
+    # de uploads como spam (achado de produção, 2026-07-14).
     - cron: "0 2 * * 6"
   workflow_dispatch:
     inputs:
@@ -26,6 +28,12 @@ on:
 permissions:
   contents: read
   issues: write
+
+# Singleton: evita um dispatch manual correndo ao mesmo tempo que o cron
+# semanal (ambos disputariam upload no IA e discovery duplicado).
+concurrency:
+  group: discover-harvest
+  cancel-in-progress: false
 
 jobs:
   # ── DISPATCH com tipo específico ──────────────────────────────────────────
@@ -62,13 +70,19 @@ jobs:
           job-label: "discover-harvest / ${{ inputs.tipo }}"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # ── SCHEDULED ou DISPATCH sem tipo: todos os tipos em paralelo ────────────
+  # ── SCHEDULED ou DISPATCH sem tipo: todos os tipos, paralelismo limitado ──
   harvest-parallel:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.tipo == '')
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:
       fail-fast: false
+      # max-parallel: 2 (não 7, o default) — os 7 jobs fariam upload pro IA
+      # ao mesmo tempo; uma rajada assim levou o IA a recusar uploads como
+      # spam em produção (2026-07-14: "Please reduce your request rate").
+      # `_run_ia_upload` (publisher.py) já paceia/retry por processo, mas não
+      # protege contra 7 PROCESSOS distintos batendo juntos.
+      max-parallel: 2
       matrix:
         tipo: [lei, lc, decreto, ec, resolucao, portaria, decreto-lei]
 

--- a/.github/workflows/parse-release.yml
+++ b/.github/workflows/parse-release.yml
@@ -2,7 +2,14 @@ name: Parse + ETL + Release Dataset
 
 on:
   schedule:
-    - cron: "0 6 * * 1"  # Monday 06:00 UTC — dia após scraping dominical
+    # Diário 06:00 UTC. Antes rodava só segunda com --limit 50 x 3 fontes em
+    # paralelo (até 150 parses/dia) contra um orçamento real de free-tier de
+    # ~20 requisições/dia por modelo (confirmado em produção, 2026-07-14:
+    # 429 RESOURCE_EXHAUSTED, quotaId GenerateRequestsPerDayPerProjectPerModel,
+    # quotaValue 20) — as 3 fontes competiam pelo mesmo orçamento diário
+    # inteiro num único dia da semana, desperdiçando a maior parte das
+    # chamadas em 429. Pacing novo: 6+6+6=18/dia, com margem sob o teto.
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       ente:
@@ -40,9 +47,19 @@ permissions:
   contents: read
   issues: write
 
+# Singleton: um dispatch manual nunca deve rodar ao mesmo tempo que o cron
+# diário (ambos disputariam o mesmo orçamento de LLM/IA) — a segunda run
+# fica na fila em vez de correr em paralelo.
+concurrency:
+  group: parse-release
+  cancel-in-progress: false
+
 jobs:
-  # Um job por fonte/tipo, cada um com seu próprio timeout — o job "etl"
-  # (fetch-all-parsed → consolidate → release) só depende deles via `needs`
+  # As 3 fontes agendadas rodam em SÉRIE (via `needs`), não em paralelo: cada
+  # uma usa o mesmo GEMINI_API_KEY, e a cota do free tier é por modelo por
+  # projeto (não por job) — rodar em paralelo só faz duas delas queimarem o
+  # orçamento em 429 enquanto a primeira ainda está consumindo. O job "etl"
+  # (fetch-all-parsed → consolidate → release) só depende delas via `needs`
   # e roda mesmo se algum parse individual falhar ou for pulado (if: always()),
   # em vez de compartilhar um único job monolítico onde um parse travado
   # impedia a publicação do dataset.
@@ -68,7 +85,7 @@ jobs:
           uv run leizilla parse-all \
             --ente ro --fonte assembleia \
             --start 1 --end 5000 \
-            --limit 50 --output-dir /tmp/leizilla-xmls \
+            --limit 6 --output-dir /tmp/leizilla-xmls \
             --skip-existing --error-threshold 20 --upload
 
       - name: Notify on failure
@@ -79,7 +96,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   parse-casacivil-lei:
-    if: github.event_name == 'schedule'
+    needs: parse-assembleia
+    if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -99,7 +117,7 @@ jobs:
           uv run leizilla parse-all \
             --ente ro --fonte casacivil --tipo lei \
             --start 1 --end 6000 \
-            --limit 50 --output-dir /tmp/leizilla-xmls \
+            --limit 6 --output-dir /tmp/leizilla-xmls \
             --skip-existing --error-threshold 20 --upload
 
       - name: Notify on failure
@@ -110,7 +128,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   parse-casacivil-lc:
-    if: github.event_name == 'schedule'
+    needs: parse-casacivil-lei
+    if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -130,7 +149,7 @@ jobs:
           uv run leizilla parse-all \
             --ente ro --fonte casacivil --tipo lc \
             --start 1 --end 1300 \
-            --limit 50 --output-dir /tmp/leizilla-xmls \
+            --limit 6 --output-dir /tmp/leizilla-xmls \
             --skip-existing --error-threshold 20 --upload
 
       - name: Notify on failure

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -113,6 +113,57 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
 
+### 2026-07-14 — Pacing de parse/harvest dentro de cotas + retry/backoff no upload IA
+
+**Achado**: `parse-release.yml` rodava só às segundas, com 3 jobs paralelos
+(assembleia + casacivil-lei + casacivil-lc) a `--limit 50` cada — até 150
+tentativas de parse num único dia, contra um orçamento real de free tier de
+**~20 requisições/dia por modelo** (confirmado em produção nesta mesma
+sessão: `429 RESOURCE_EXHAUSTED`, `quotaId
+GenerateRequestsPerDayPerProjectPerModel-FreeTier`, `quotaValue: 20`, tanto
+para `gemini-2.5-flash` quanto `gemini-2.5-flash-lite`). As 3 fontes
+competiam pelo mesmo orçamento diário compartilhado, e a maior parte das
+150 tentativas terminava em 429 — desperdício, não distribuição. Achado
+análogo em `discover-harvest.yml`: matrix de 7 tipos em paralelo (sem
+`max-parallel`) faz até 7 processos de upload baterem no IA ao mesmo tempo;
+uma rajada de ~15 uploads em ~10min já levou o IA a recusar como spam
+("Please reduce your request rate...") na sessão de go-live desta mesma
+data.
+
+**Correção — `fix(ci): pace parsing and IA uploads within service quotas`**:
+
+1. **`parse-release.yml`**: cron mudou de semanal (segunda) para **diário**,
+   `--limit 50` → **`--limit 6`** por fonte (18/dia, margem sob o teto de
+   20), e as 3 fontes agendadas passam a rodar **em série** via `needs`
+   (não mais em paralelo) — evita que rodem simultaneamente disputando o
+   mesmo orçamento de LLM. `if: always()` nas dependentes garante que uma
+   fonte falhando não pule as seguintes. `concurrency: group: parse-release`
+   impede que um dispatch manual sobreponha o cron.
+2. **`discover-harvest.yml`**: `max-parallel: 2` na matrix de 7 tipos (era
+   sem limite) + `concurrency: group: discover-harvest`.
+3. **`publisher.py`**: novo método `InternetArchivePublisher._run_ia_upload`
+   substitui as 7 chamadas diretas a `subprocess.run(["ia", "upload", ...])`
+   — retry exponencial (até 5 tentativas, backoff 2s→60s + jitter) **só**
+   para stderr que casa um padrão de erro transitório confirmado (rate
+   limit do IA, 5xx, connection reset/timeout); erro de credencial, arquivo
+   inválido ou conflito lógico propaga na primeira tentativa, sem retry.
+   Espaça uploads sucessivos via `make_rate_limiter` (extraído de
+   `scraper.py` para o novo módulo `leizilla/ratelimit.py`, reaproveitado
+   sem duplicar — import cíclico impedia importar direto de `scraper.py`).
+   **Limitação documentada**: como o upload é via subprocess do CLI `ia`
+   (não a lib `internetarchive`), só há acesso ao stderr como texto, não
+   aos headers HTTP reais — não há `Retry-After` de protocolo para honrar,
+   o backoff é uma aproximação. 8 novos testes em
+   `TestRunIaUploadRetry` (`tests/test_publisher.py`) com respostas
+   simuladas (sucesso, retry-então-sucesso, erro não retryable, esgotamento
+   de tentativas, crescimento exponencial do backoff, pacing entre uploads).
+
+**Não feito nesta PR** (fora de escopo, mencionado para o futuro): seletor
+que transfira orçamento não usado de uma fonte vazia para a fila seguinte;
+troca do CLI `ia` pela biblioteca `internetarchive` (daria acesso a
+`Retry-After` real); `max-parallel: 1` estrito no harvest (ficou em 2,
+equilíbrio entre throughput e risco de throttle).
+
 ### 2026-07-14 — M14.3: manifesto do notebook OPF ganha proveniência completa (fast follow do PR #110)
 
 A revisão do PR #110 (que corrigiu os 3 bugs de CLI do notebook) apontou uma ressalva

--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -8,10 +8,12 @@ import io
 import json
 import logging
 import os
+import random
 import re
 import shutil
 import subprocess
 import tempfile
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -37,6 +39,7 @@ from leizilla.ia_utils import (
     uuid5_collision,
     uuid5_name,
 )
+from leizilla.ratelimit import make_rate_limiter
 
 _DATASET_IDENTIFIER_RE = (
     r"^leizilla-dataset-(?P<ente>[a-z][a-z0-9-]*)-v(?P<version>\d+)$"
@@ -581,12 +584,84 @@ def _ia_subprocess_env(
     return {**os.environ, "IA_CONFIG_FILE": cfg_path}
 
 
+# Padrões no stderr do `ia upload` que indicam falha transitória (retry pode ajudar).
+# Único achado real em produção até agora (2026-07-14, sessão de go-live): uma rajada
+# de ~15 uploads em ~10min levou o IA a recusar com "Please reduce your request
+# rate ... appears to be spam" — sem 429 numérico nem Retry-After no corpo. Por
+# design, tudo que NÃO casar aqui não é reentregue (credencial inválida, arquivo
+# rejeitado, conflito lógico — repetir não muda o resultado).
+_RETRYABLE_IA_ERROR_RE = re.compile(
+    r"reduce your request rate"
+    r"|\b(429|500|502|503|504)\b"
+    r"|connection (reset|refused|aborted)"
+    r"|read timed out"
+    r"|\btimeout\b",
+    re.IGNORECASE,
+)
+_IA_UPLOAD_MIN_INTERVAL_S = 2.0  # espaçamento mínimo entre uploads bem-sucedidos
+_IA_UPLOAD_MAX_ATTEMPTS = 5
+_IA_UPLOAD_BASE_DELAY_S = 2.0
+_IA_UPLOAD_MAX_DELAY_S = 60.0
+_IA_RATE_LIMIT_KEY = "https://archive.org/"  # host fixo p/ make_rate_limiter (ADR-0008)
+
+
 class InternetArchivePublisher:
     """Upload para IA e geração de datasets Parquet."""
 
     def __init__(self) -> None:
         self.access_key = config.IA_ACCESS_KEY
         self.secret_key = config.IA_SECRET_KEY
+        self._upload_rate_limiter = make_rate_limiter(_IA_UPLOAD_MIN_INTERVAL_S)
+
+    def _run_ia_upload(self, args: list[str]) -> "subprocess.CompletedProcess[str]":
+        """Roda ``ia upload ...`` com espaçamento + retry exponencial (ADR-0008).
+
+        Duas defesas contra o throttle/spam-flag do IA visto em produção
+        (2026-07-14, ~15 uploads em ~10min): (1) espaça uploads sucessivos por
+        ``_IA_UPLOAD_MIN_INTERVAL_S`` via o rate limiter por host já usado no
+        scraper (``leizilla.ratelimit``); (2) em falha, tenta de novo só se o
+        stderr casar ``_RETRYABLE_IA_ERROR_RE`` — erro de credencial, arquivo
+        inválido ou conflito lógico propaga na primeira tentativa.
+
+        Nota de limitação: isto invoca o CLI ``ia`` via subprocess, não a
+        biblioteca ``internetarchive`` diretamente — só vemos o texto do
+        stderr, não os headers HTTP reais. Não há ``Retry-After`` para honrar
+        aqui (a mensagem de throttle observada também não embute um valor
+        numérico); o backoff é uma aproximação por tentativa, não um
+        Retry-After de protocolo.
+
+        O rate limiter só paceia contra a chamada ANTERIOR a ``_run_ia_upload``
+        (uma vez, antes do loop) — não a cada tentativa de retry interna, já
+        que o backoff exponencial já espaça as tentativas da MESMA chamada;
+        pacear os dois ao mesmo tempo só somaria esperas redundantes.
+        """
+        self._upload_rate_limiter(_IA_RATE_LIMIT_KEY)
+        env = _ia_subprocess_env(self.access_key, self.secret_key)
+        for attempt in range(1, _IA_UPLOAD_MAX_ATTEMPTS + 1):
+            try:
+                return subprocess.run(
+                    args, capture_output=True, text=True, check=True, env=env
+                )
+            except subprocess.CalledProcessError as e:
+                if (
+                    attempt == _IA_UPLOAD_MAX_ATTEMPTS
+                    or not _RETRYABLE_IA_ERROR_RE.search(e.stderr or "")
+                ):
+                    raise
+                delay = min(
+                    _IA_UPLOAD_MAX_DELAY_S,
+                    _IA_UPLOAD_BASE_DELAY_S * (2 ** (attempt - 1)),
+                )
+                delay += random.uniform(0, delay * 0.25)  # jitter
+                logger.warning(
+                    "ia upload: erro transiente (tentativa %d/%d), retry em %.1fs: %s",
+                    attempt,
+                    _IA_UPLOAD_MAX_ATTEMPTS,
+                    delay,
+                    (e.stderr or "").strip()[:200],
+                )
+                time.sleep(delay)
+        raise AssertionError("unreachable — loop always returns or raises")
 
     def upload_raw(
         self,
@@ -679,7 +754,7 @@ class InternetArchivePublisher:
                 f"identificador {ia_id}, capturado pelo projeto Leizilla."
             )
             try:
-                subprocess.run(
+                self._run_ia_upload(
                     [
                         "ia",
                         "upload",
@@ -701,11 +776,7 @@ class InternetArchivePublisher:
                         f"coverage:{coverage}",
                         "--metadata",
                         f"description:{desc}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                    ]
                 )
             except FileNotFoundError:
                 return {
@@ -815,7 +886,7 @@ class InternetArchivePublisher:
                 f"identificador {ia_id}, capturado pelo projeto Leizilla."
             )
             try:
-                subprocess.run(
+                self._run_ia_upload(
                     [
                         "ia",
                         "upload",
@@ -837,11 +908,7 @@ class InternetArchivePublisher:
                         f"coverage:{coverage}",
                         "--metadata",
                         f"description:{desc}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                    ]
                 )
             except FileNotFoundError:
                 return {
@@ -895,7 +962,7 @@ class InternetArchivePublisher:
                 files.append(str(meta_dst))
             files.append(str(index_path))
             try:
-                subprocess.run(
+                self._run_ia_upload(
                     [
                         "ia",
                         "upload",
@@ -911,11 +978,7 @@ class InternetArchivePublisher:
                         "language:pt",
                         "--metadata",
                         f"coverage:{_entity_coverage(ente)}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                    ]
                 )
             except subprocess.CalledProcessError as e:
                 logger.warning(
@@ -931,7 +994,7 @@ class InternetArchivePublisher:
             index_path = Path(tmp) / INDEX_FILENAME
             index_path.write_text(index_csv, encoding="utf-8")
             try:
-                subprocess.run(
+                self._run_ia_upload(
                     [
                         "ia",
                         "upload",
@@ -939,11 +1002,7 @@ class InternetArchivePublisher:
                         str(index_path),
                         "--metadata",
                         "mediatype:texts",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                    ]
                 )
             except subprocess.CalledProcessError as e:
                 logger.warning("reconcile: reescrita do índice de espera falhou: %s", e)
@@ -1144,7 +1203,7 @@ class InternetArchivePublisher:
                 f"processado pelo projeto Leizilla."
             )
             try:
-                subprocess.run(
+                self._run_ia_upload(
                     [
                         "ia",
                         "upload",
@@ -1165,11 +1224,7 @@ class InternetArchivePublisher:
                         f"coverage:{coverage}",
                         "--metadata",
                         f"description:{desc}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                    ]
                 )
                 return {
                     "success": True,
@@ -1226,7 +1281,7 @@ class InternetArchivePublisher:
                 f"Contém {effective_row_count} linhas."
             )
             try:
-                subprocess.run(
+                self._run_ia_upload(
                     [
                         "ia",
                         "upload",
@@ -1247,11 +1302,7 @@ class InternetArchivePublisher:
                         f"coverage:{coverage}",
                         "--metadata",
                         f"description:{desc}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                    ]
                 )
                 return {
                     "success": True,
@@ -1296,7 +1347,7 @@ class InternetArchivePublisher:
             shutil.copy2(str(file_path), str(dst_path))
 
             try:
-                subprocess.run(
+                self._run_ia_upload(
                     [
                         "ia",
                         "upload",
@@ -1316,11 +1367,7 @@ class InternetArchivePublisher:
                         f"coverage:{coverage}",
                         "--metadata",
                         f"description:{desc}",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    env=_ia_subprocess_env(self.access_key, self.secret_key),
+                    ]
                 )
                 return {"success": True}
             except FileNotFoundError:

--- a/src/leizilla/ratelimit.py
+++ b/src/leizilla/ratelimit.py
@@ -1,0 +1,37 @@
+"""Per-host rate limiting shared by scraper.py and publisher.py (ADR-0008).
+
+Extracted from scraper.py so publisher.py can reuse it for IA upload pacing
+without an import cycle (scraper.py already imports InternetArchivePublisher
+from publisher.py).
+"""
+
+import time
+from typing import Callable, Dict
+from urllib.parse import urlparse
+
+_RATE_LIMIT_S = 1.0
+
+
+def make_rate_limiter(min_interval: float = _RATE_LIMIT_S) -> Callable[[str], None]:
+    """Rate limiter por host: garante >= min_interval entre baterias diretas no mesmo host.
+
+    Hosts diferentes não bloqueiam uns aos outros — permite scraping paralelo
+    de múltiplas fontes (assembleia + casacivil + ...) sem serializar por fonte.
+    """
+    last: Dict[str, float] = {}
+
+    def limiter(url: str) -> None:
+        host = urlparse(url).hostname or ""
+        # Primeira batida em um host nunca espera. Usamos um sentinela explícito
+        # (host ausente no dict) em vez de 0.0: o epoch de time.monotonic() é
+        # arbitrário, então `monotonic() - 0.0` pode ser < min_interval logo após
+        # o boot e provocar um sleep espúrio na primeira chamada (hosts distintos
+        # devem permanecer independentes).
+        previous = last.get(host)
+        if previous is not None:
+            elapsed = time.monotonic() - previous
+            if elapsed < min_interval:
+                time.sleep(min_interval - elapsed)
+        last[host] = time.monotonic()
+
+    return limiter

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -7,17 +7,14 @@ Princípio #10: robots.txt é permanente (sem retry em URL bloqueada); rate-limi
 
 import sys
 import tempfile
-import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
-from urllib.parse import urlparse
 
 from leizilla import robots, wayback
 from leizilla.parser import fetch_html
 from leizilla.publisher import InternetArchivePublisher
+from leizilla.ratelimit import make_rate_limiter
 from leizilla.storage import DuckDBStorage
-
-_RATE_LIMIT_S = 1.0
 
 
 def scrape_one(
@@ -163,29 +160,9 @@ def scrape_one_html(
         return {"success": False, "reason": "upload-failed", "error": str(exc)}
 
 
-def make_rate_limiter(min_interval: float = _RATE_LIMIT_S) -> Callable[[str], None]:
-    """Rate limiter por host: garante >= min_interval entre baterias diretas no mesmo host.
-
-    Hosts diferentes não bloqueiam uns aos outros — permite scraping paralelo
-    de múltiplas fontes (assembleia + casacivil + ...) sem serializar por fonte.
-    """
-    last: Dict[str, float] = {}
-
-    def limiter(url: str) -> None:
-        host = urlparse(url).hostname or ""
-        # Primeira batida em um host nunca espera. Usamos um sentinela explícito
-        # (host ausente no dict) em vez de 0.0: o epoch de time.monotonic() é
-        # arbitrário, então `monotonic() - 0.0` pode ser < min_interval logo após
-        # o boot e provocar um sleep espúrio na primeira chamada (hosts distintos
-        # devem permanecer independentes).
-        previous = last.get(host)
-        if previous is not None:
-            elapsed = time.monotonic() - previous
-            if elapsed < min_interval:
-                time.sleep(min_interval - elapsed)
-        last[host] = time.monotonic()
-
-    return limiter
+# make_rate_limiter moved to leizilla.ratelimit (re-imported above) so
+# publisher.py can reuse it for IA upload pacing without an import cycle
+# (this module already imports InternetArchivePublisher from publisher.py).
 
 
 def harvest_pending_resources(

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -244,6 +244,137 @@ class TestUploadParsed:
         assert "upload failed" in result["error"]
 
 
+class TestRunIaUploadRetry:
+    """_run_ia_upload: retry exponencial pautado por padrão de erro no stderr do
+    `ia` (achado real de produção, 2026-07-14: rajada de uploads levou o IA a
+    recusar com 'Please reduce your request rate ... appears to be spam')."""
+
+    def _publisher(self) -> InternetArchivePublisher:
+        pub = InternetArchivePublisher()
+        pub.access_key = "test-key"
+        pub.secret_key = "test-secret"
+        return pub
+
+    @patch("time.sleep")
+    def test_succeeds_without_retry_on_first_attempt(self, mock_sleep):
+        pub = self._publisher()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = pub._run_ia_upload(["ia", "upload", "some-id"])
+        assert result.returncode == 0
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    def test_retries_on_rate_limit_error_then_succeeds(self, mock_sleep):
+        import subprocess
+
+        pub = self._publisher()
+        rate_limit_error = subprocess.CalledProcessError(
+            1,
+            "ia",
+            stderr=(
+                "Please reduce your request rate. - Your upload of "
+                "leizilla-ro-lei-00290-1984 appears to be spam."
+            ),
+        )
+        success = MagicMock(returncode=0)
+        with patch(
+            "subprocess.run", side_effect=[rate_limit_error, rate_limit_error, success]
+        ) as mock_run:
+            result = pub._run_ia_upload(["ia", "upload", "some-id"])
+        assert result is success
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2  # backoff before attempt 2 and attempt 3
+
+    @patch("time.sleep")
+    def test_retries_on_5xx_and_timeout_errors(self, mock_sleep):
+        import subprocess
+
+        pub = self._publisher()
+        success = MagicMock(returncode=0)
+        for stderr in (
+            "503 Service Unavailable",
+            "connection reset by peer",
+            "read timed out",
+        ):
+            err = subprocess.CalledProcessError(1, "ia", stderr=stderr)
+            with patch("subprocess.run", side_effect=[err, success]) as mock_run:
+                result = pub._run_ia_upload(["ia", "upload", "some-id"])
+            assert result is success
+            assert mock_run.call_count == 2
+
+    @patch("time.sleep")
+    def test_does_not_retry_non_retryable_error(self, mock_sleep):
+        import subprocess
+
+        pub = self._publisher()
+        auth_error = subprocess.CalledProcessError(
+            1, "ia", stderr="Unauthorized: invalid access key"
+        )
+        with patch("subprocess.run", side_effect=auth_error) as mock_run:
+            try:
+                pub._run_ia_upload(["ia", "upload", "some-id"])
+                raise AssertionError("expected CalledProcessError to propagate")
+            except subprocess.CalledProcessError:
+                pass
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    def test_gives_up_after_max_attempts_on_persistent_rate_limit(self, mock_sleep):
+        import subprocess
+
+        pub = self._publisher()
+        rate_limit_error = subprocess.CalledProcessError(
+            1, "ia", stderr="Please reduce your request rate."
+        )
+        with patch("subprocess.run", side_effect=rate_limit_error) as mock_run:
+            try:
+                pub._run_ia_upload(["ia", "upload", "some-id"])
+                raise AssertionError("expected CalledProcessError to propagate")
+            except subprocess.CalledProcessError:
+                pass
+        assert mock_run.call_count == 5  # _IA_UPLOAD_MAX_ATTEMPTS
+
+    @patch("time.sleep")
+    def test_backoff_delay_grows_exponentially(self, mock_sleep):
+        import subprocess
+
+        pub = self._publisher()
+        rate_limit_error = subprocess.CalledProcessError(
+            1, "ia", stderr="503 Service Unavailable"
+        )
+        success = MagicMock(returncode=0)
+        with patch(
+            "subprocess.run", side_effect=[rate_limit_error, rate_limit_error, success]
+        ):
+            pub._run_ia_upload(["ia", "upload", "some-id"])
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert len(delays) == 2
+        assert delays[0] < delays[1]
+
+    def test_paces_successive_uploads_via_shared_rate_limiter(self):
+        pub = self._publisher()
+        with (
+            patch.object(pub, "_upload_rate_limiter") as mock_limiter,
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            pub._run_ia_upload(["ia", "upload", "id-1"])
+            pub._run_ia_upload(["ia", "upload", "id-2"])
+        assert mock_limiter.call_count == 2
+
+    def test_file_not_found_is_not_retried(self):
+        pub = self._publisher()
+        with patch("subprocess.run", side_effect=FileNotFoundError("no ia binary")):
+            try:
+                pub._run_ia_upload(["ia", "upload", "some-id"])
+                raise AssertionError("expected FileNotFoundError to propagate")
+            except FileNotFoundError:
+                pass
+
+
 class TestListParsedRawIds:
     """Testes para list_parsed_raw_ids — consulta IA sem credenciais."""
 

--- a/tests/test_publisher_dataset.py
+++ b/tests/test_publisher_dataset.py
@@ -46,7 +46,10 @@ def _make_parquet(tmp_path: Path) -> Path:
 
 
 def _publisher(access: str = "key", secret: str = "secret") -> InternetArchivePublisher:
-    pub = InternetArchivePublisher.__new__(InternetArchivePublisher)
+    # __init__ real (não __new__) -- precisamos do _upload_rate_limiter que ele
+    # cria; sobrescrever access_key/secret_key depois é só pra controlar o teste
+    # sem depender de config.IA_ACCESS_KEY/IA_SECRET_KEY do ambiente.
+    pub = InternetArchivePublisher()
     pub.access_key = access
     pub.secret_key = secret
     return pub


### PR DESCRIPTION
## O problema

`parse-release.yml` rodava só às segundas, com 3 jobs paralelos (assembleia +
casacivil-lei + casacivil-lc) a `--limit 50` cada — até 150 tentativas de
parse num único dia, contra um orçamento real de free tier de **~20
requisições/dia por modelo** (confirmado em produção nesta mesma sessão: `429
RESOURCE_EXHAUSTED`, `quotaId GenerateRequestsPerDayPerProjectPerModel-FreeTier`,
`quotaValue: 20`, tanto para `gemini-2.5-flash` quanto para
`gemini-2.5-flash-lite`). As 3 fontes competiam pelo mesmo orçamento diário
compartilhado, e a maior parte das 150 tentativas terminava em 429 —
desperdício, não distribuição.

Achado análogo em `discover-harvest.yml`: matrix de 7 tipos em paralelo (sem
`max-parallel`) faz até 7 processos de upload baterem no IA ao mesmo tempo;
uma rajada de uploads concorrentes já levou o IA a recusar como spam
("Please reduce your request rate...") durante o go-live desta mesma sessão.

## O que muda

### 1. `parse-release.yml` — agendamento

- Cron mudou de semanal (segunda) para **diário** (`0 6 * * *`).
- `--limit 50` → **`--limit 6`** por fonte (até 18 itens tentados/dia no
  total, com margem sob o teto de ~20/dia). Nota: o `--limit` conta itens
  *tentados* (após skip-existing), não chamadas de modelo — um item sem OCR
  ainda consome o limite sem chamar `litellm.completion()`, então o consumo
  real de cota tende a ser ≤18/dia, não exatamente 18.
- As 3 fontes agendadas rodam em **série** (`needs:` encadeado), não em
  paralelo — todas competem pela mesma cota de modelo, então paralelizar só
  faz duas queimarem o orçamento em 429 enquanto a primeira ainda consome.
- Jobs downstream usam `if: always() && github.event_name == 'schedule'`
  para não pular a cadeia se um parse individual falhar.
- `concurrency: {group: parse-release, cancel-in-progress: false}` no nível
  do workflow — um dispatch manual nunca roda ao mesmo tempo que o cron
  diário (fica na fila).
- `--skip-existing` mantido; o dataset publicado ao final continua
  cumulativo (via `fetch-all-parsed` → `consolidate` → `release-dataset`).

### 2. Cliente de upload do IA + `discover-harvest.yml`

- `publisher.py`: novo método `_run_ia_upload()` envolve todas as chamadas
  `subprocess.run(["ia", "upload", ...])` com:
  - um rate limiter de intervalo mínimo entre uploads (`make_rate_limiter`,
    extraído para um novo módulo-folha `leizilla/ratelimit.py` pra evitar
    import circular entre `scraper.py` e `publisher.py`);
  - retry com backoff exponencial best-effort baseado em padrões reconhecidos
    no `stderr` (rate-limit/spam do IA, 5xx, connection-reset, timeout) —
    erros de auth, arquivo inválido ou conflito lógico continuam falhando
    imediatamente, sem retry;
  - **correção**: como o upload usa o CLI `ia` via subprocess, não há acesso
    aos headers HTTP reais nem a um `Retry-After` de protocolo (a mensagem de
    throttle observada em produção também não embute um valor numérico) — o
    backoff é uma aproximação por tentativa (2s, 4s, 8s, 16s com
    `_IA_UPLOAD_MAX_ATTEMPTS=5`; a 5ª falha propaga direto, sem um 5º sleep,
    então o teto configurado de 60s nunca é de fato alcançado nessa
    configuração), não um `Retry-After` honrado;
  - teto de tentativas (5) pra não retry infinito.
- `discover-harvest.yml`: `max-parallel: 2` na matrix de 7 tipos (era
  ilimitado/7), mais o mesmo `concurrency` guard no nível do workflow.
- Testes novos em `tests/test_publisher.py` (`TestRunIaUploadRetry`, 8
  métodos): sucesso sem retry, retry-então-sucesso em padrões de rate-limit/
  5xx/connection-reset/timeout, sem retry em erro não-transitório (auth),
  esgotamento de tentativas, crescimento do delay exponencial, pacing do
  rate limiter entre chamadas sucessivas, `FileNotFoundError` propaga sem
  retry.

## O que NÃO muda nesta PR

- Seletor de transferência de orçamento entre filas vazias/cheias entre as
  3 fontes (fica pra depois).
- `ia` CLI (subprocess) não foi trocado pela lib `internetarchive` — o
  `Retry-After` real (header HTTP) continua inacessível; o parsing atual é
  best-effort sobre o texto do stderr.
- `max-parallel: 1` mais estrito no harvest (foi pra 2 por hora, não pra 1).
  O rate limiter de `_run_ia_upload` é por instância/processo — não há
  coordenação global entre os até 2 jobs paralelos do harvest; a defesa
  agregada real nesta PR é a redução de 7 para 2 jobs simultâneos. Se depois
  do merge o IA ainda recusar rajadas, o próximo ajuste é `max-parallel: 1`
  antes de adicionar pacing global ou trocar de biblioteca.

## Teste

- `uv run ruff check` / `ruff format --check` nos arquivos Python tocados:
  limpo.
- `uv run mypy src/ --ignore-missing-imports`: limpo (23 arquivos).
- `uv run pytest -q`: **733 passed, 13 skipped** (suite completa).
- YAML validado via `python3 -c "import yaml; yaml.safe_load(...)"` nos dois
  workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
