### PR TITLE
fix(ci): repair claude-routine.yml — silently broken since 2026-06-08

### DIFF
--- a/.github/workflows/claude-routine.yml
+++ b/.github/workflows/claude-routine.yml
@@ -32,6 +32,10 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write  # necessário p/ claude-code-action buscar token via OIDC
+                    # (não passamos github_token próprio); sem isso a action
+                    # falha em "Failed to setup GitHub token" (achado: toda
+                    # execução agendada de 2026-06-08 a 2026-07-13 falhou).
 
 jobs:
   routine:
@@ -41,8 +45,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Carregar prompt de manutenção
+        # O input `prompt` da action só aceita texto literal, não um path
+        # (diferente do `prompt_file` de versões antigas da action, removido
+        # upstream) — carregamos o conteúdo do arquivo aqui.
+        id: load_prompt
+        run: |
+          {
+            echo 'text<<PROMPT_EOF'
+            cat docs/routines/maintenance-prompt.md
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Executar rotina de manutenção
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}  # Required: Add ANTHROPIC_API_KEY in Settings → Secrets
-          prompt_file: docs/routines/maintenance-prompt.md
+          prompt: ${{ steps.load_prompt.outputs.text }}

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -113,6 +113,38 @@ Fonte oficial → ETAPA 1 (raw IA item)        → IA OCR automático (_djvu.txt
 
 Toda decisão importante recebe entrada aqui com data. Não delete entradas — supersede com nova entrada referenciando a anterior.
 
+### 2026-07-15 — `claude-routine.yml` quebrado silenciosamente desde 2026-06-08
+
+**Achado**: auditoria dos runs agendados (`event: schedule`) mostrou que a
+sessão de manutenção automática (Mon/Thu, `docs/routines/maintenance-prompt.md`)
+falhava em ~20s em **todas as execuções da amostra**, de 2026-06-08 a
+2026-07-13 (11 runs consecutivos) — mais de um mês sem rodar de fato,
+silenciosamente (só um `Notify on failure` — sem alarme visível fora do Actions
+tab). Duas causas, ambas drift de versão da action `anthropics/claude-code-action@beta`:
+
+1. `prompt_file: docs/routines/maintenance-prompt.md` não é mais um input
+   válido da action (`##[warning]Unexpected input(s) 'prompt_file'`) — o
+   prompt real nunca chegava a ser usado.
+2. Sem `github_token` próprio no `with:`, a action tenta obter um token via
+   GitHub OIDC (fluxo padrão do GitHub App gerenciado pela Anthropic), o que
+   exige `permissions: id-token: write` — ausente no workflow, causando
+   `Failed to setup GitHub token: Could not fetch an OIDC token`.
+
+**Correção**: `permissions.id-token: write` adicionado; novo step carrega o
+conteúdo de `maintenance-prompt.md` num output (`$GITHUB_OUTPUT` com heredoc)
+e passa via `prompt: ${{ steps.load_prompt.outputs.text }}` (input atual da
+action; `prompt` só aceita texto literal, não path).
+
+Auditoria também cobriu `wayback-save.yml` (falhava por `--end` inexistente
+na CLI — já corrigido em commit posterior ao da amostra de falha, nenhuma ação
+necessária) e `rondonia_crawler.yml` (cancelamento por timeout do job
+monolítico antigo — já dividido em 3 jobs com timeouts próprios, também sem
+ação necessária). `discover-harvest.yml` teve um `decreto` cancelado por
+timeout de 360min com Discover sozinho levando ~4h — o `max-parallel: 2` do
+PR #112 deve ajudar, mas vale monitorar o próximo sábado; se `decreto`
+continuar estourando, considerar separar Discover e Harvest em jobs com
+timeout próprio.
+
 ### 2026-07-14 — Pacing de parse/harvest dentro de cotas + retry/backoff no upload IA
 
 **Achado**: `parse-release.yml` rodava só às segundas, com 3 jobs paralelos


### PR DESCRIPTION
## O achado

Depois de mergear a #112, fui auditar a saúde geral dos workflows agendados
(`event: schedule`) em vez de seguir direto pro próximo item do roadmap — e
achei um problema mais importante que qualquer item da fila: **a sessão de
manutenção automática (`claude-routine.yml`, Mon/Thu) falha em ~20s em
absolutamente todas as execuções amostradas, de 2026-06-08 a 2026-07-13 (11
de 11)**. Mais de um mês rodando "no papel" mas nunca de fato executando —
sem alarme visível fora da aba Actions (só o step `Notify on failure`, que
por sua vez também nunca chegou a rodar nada útil).

## Causa raiz (drift de versão da action)

Duas mudanças no schema de input de `anthropics/claude-code-action@beta`
desde que este workflow foi escrito:

1. `prompt_file: docs/routines/maintenance-prompt.md` não é mais um input
   reconhecido (`##[warning]Unexpected input(s) 'prompt_file'`) — o prompt
   real do arquivo nunca era lido; a action seguia com prompt vazio/padrão.
2. Sem `github_token` explícito, a action tenta obter um token via GitHub
   OIDC (fluxo padrão do GitHub App gerenciado pela Anthropic) — isso exige
   `permissions: id-token: write` no workflow, que estava ausente. Resultado:
   `Failed to setup GitHub token: Could not fetch an OIDC token. Did you
   remember to add id-token: write to your workflow permissions?`, seguido
   de um fallback que retorna `401 Bad credentials`.

## O que muda

- `permissions:` ganha `id-token: write`.
- Novo step "Carregar prompt de manutenção" lê `docs/routines/maintenance-prompt.md`
  e expõe o conteúdo via `$GITHUB_OUTPUT` (heredoc — confirmei que o arquivo
  não contém a string delimitadora `PROMPT_EOF`).
- `prompt_file: ...` → `prompt: ${{ steps.load_prompt.outputs.text }}` — o
  input atual só aceita texto literal, não um path (confirmado lendo
  `action.yml`/docs da action upstream; não há suporte a `@arquivo`).

## Outros workflows agendados auditados (sem ação necessária)

- **`wayback-save.yml`** — a falha amostrada (`No such option: --end`) já
  foi corrigida em commit posterior; o arquivo atual usa `--probe-window`/
  `--delay` sem `--end`. Só falta confirmar na próxima segunda 03:00 UTC.
- **`rondonia_crawler.yml`** — o cancelamento amostrado veio de um job
  monolítico antigo estourando o timeout; já foi dividido em 3 jobs
  (`scrape-assembleia`/`scrape-casacivil-lei`/`scrape-casacivil-lc`) com
  timeouts próprios. A decisão de manter esse workflow legado agendado
  (vs. depender só de `discover-harvest.yml`) fica pra issue #95.
- **`discover-harvest.yml`** — o job `decreto` da matrix estourou o timeout
  de 360min (Discover sozinho levou ~4h). O `max-parallel: 2` da #112 deve
  ajudar a reduzir a pressão que causava isso; registrei em
  `IMPLEMENTATION.md` como algo a monitorar no próximo sábado — se
  `decreto` continuar estourando, o próximo passo é separar Discover e
  Harvest em jobs com timeout independente.

## Teste

- `python3 -c "import yaml; yaml.safe_load(...)"` no workflow editado: OK.
- Não dá pra testar a execução real da `claude-code-action` localmente
  (depende do runner + secrets do GitHub Actions) — a validação de fato só
  acontece na próxima segunda/quinta 10:00 UTC, ou via `workflow_dispatch`
  manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HEZzmNF2Gr6oqmmDcG4arX)_