### PR TITLE
feat(opf): opf-bootstrap command + Phase 2.5 gold-scaling plan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports] # Ajuste conforme a necessidade do projeto
+        additional_dependencies: [types-requests] # sem stubs o hook falha (import-untyped) em wayback/doctor/crawler
 ci:
   autofix_commit_msg: "style: auto-fixes from pre-commit hooks"
   autoupdate_commit_msg: "chore: pre-commit autoupdate"

--- a/docs/opf-finetune.md
+++ b/docs/opf-finetune.md
@@ -109,6 +109,57 @@ Commit `data/opf/gold/{train,val,test}.jsonl` + `data/opf/gold/manifest.json` to
 (the `.gitignore` whitelist already allows `data/opf/gold/**`). The split must be
 PT-BR, in-domain, and leak-free (no same/near-duplicate doc across splits).
 
+### Phase 2.5 — scale the gold (three paths, cheapest first)
+
+Scaling past v0 does **not** mean re-running the de-novo labeling flow on more
+documents. Three paths, ordered by cost per gold document — validated on the sibling
+causaganha segmenter (2026-07-16), which scaled 20 → 106 real gold docs in one day
+with the same tooling:
+
+**Path 1 — regex-bootstrap + subagent *audit* (default).** The regex baseline already
+scores exact micro-F1 0.95 on gold, which flips the labeling economics: pre-label every
+sampled document with it, then have one subagent per document only **verify and
+correct** — confirm the easy markers, fix the known residuals (`§` inside citation
+lists, ementa preamble over-capture). An audit pass is much cheaper and more reliable
+per document than labeling from scratch:
+
+```bash
+uv run leizilla opf-sample    --ente ro --fontes assembleia,casacivil --n 50 --seed 13
+uv run leizilla opf-bootstrap --pool data/opf/pool/pool.jsonl
+# -> data/opf/pool/bootstrapped.jsonl   (regex pre-labels, info.audit_status=pending)
+# -> data/opf/pool/bootstrap_manifest.json (spans per category — read this FIRST)
+```
+
+Each bootstrapped record carries `info.prelabeled_by="regex_segmenter_v1"` — keep that
+provenance through to the gold manifest so bootstrapped gold is always distinguishable
+from de-novo gold. After the audit, run the usual `validate` + preview gates before
+promotion; the eval slice still gets the 4-role ensemble regardless of how the labels
+were produced.
+
+**Path 2 — project parsed XML back onto OCR text (silver at scale).** The parse
+pipeline already produced XSD-validated Leizilla XML for whole normas (M4/M12) — each
+dispositivo carries its rótulo (`Art. 5º`, `§ 2º`, …). Aligning those rótulos back to
+the source OCR text yields marker spans mechanically, at whatever scale the parsed
+corpus has. Treat the result as **silver** (training-mix material), never eval gold:
+the parser's own errors would leak into the labels. Same two gates as any
+weak-supervision source: mechanical validation, then a stratified spot-check audit
+before it enters a training mix.
+
+**Path 3 — targeted pre-filters for the starved categories.** When
+`bootstrap_manifest.json` shows a category with little/no support in a general sample
+(the sibling project's measured lesson: an 18-doc general round produced *zero* new
+spans for its rarest category, while an 8-doc pre-filtered round hit 7/8), don't sample
+more general documents — pre-filter the pool for where the category actually lives
+before dispatching auditors:
+
+- `ali_marcador` → documents dense in `^[a-z]\)` lines (CLT/CDC-style coded statutes);
+- `vigencia` / `revogacao` → emendas and leis matching `entra em vigor|revogam-se`;
+- keep the **staged vs. active** convention (above) while a category crosses ~25 spans.
+
+Stratification rule unchanged in every path: equal allocation per fonte (skill
+Warning 1) — the OCR-noisy assembleia/casacivil documents are the valuable ones, not
+more clean Planalto text.
+
 ### Phase 3 — train + eval (Colab GPU)
 
 Training needs a GPU and the OPF CLI; CI does not run it. The ready-to-run notebook is

--- a/docs/opf-finetune.md
+++ b/docs/opf-finetune.md
@@ -109,10 +109,10 @@ Commit `data/opf/gold/{train,val,test}.jsonl` + `data/opf/gold/manifest.json` to
 (the `.gitignore` whitelist already allows `data/opf/gold/**`). The split must be
 PT-BR, in-domain, and leak-free (no same/near-duplicate doc across splits).
 
-### Phase 2.5 — scale the gold (three paths, cheapest first)
+### Phase 2.5 — scale the gold (four paths, cheapest first)
 
 Scaling past v0 does **not** mean re-running the de-novo labeling flow on more
-documents. Three paths, ordered by cost per gold document — validated on the sibling
+documents. Four paths, ordered by cost per gold document — validated on the sibling
 causaganha segmenter (2026-07-16), which scaled 20 → 106 real gold docs in one day
 with the same tooling:
 
@@ -155,6 +155,33 @@ before dispatching auditors:
 - `ali_marcador` → documents dense in `^[a-z]\)` lines (CLT/CDC-style coded statutes);
 - `vigencia` / `revogacao` → emendas and leis matching `entra em vigor|revogam-se`;
 - keep the **staged vs. active** convention (above) while a category crosses ~25 spans.
+
+**Path 4 — synthetic normas (offsets exact by construction).** Legislative structure
+is highly templated, which makes a deterministic renderer unusually effective here —
+the approach is ported from causaganha's synthetic segmenter (RFC 0011 there), where
+it was validated against a real fine-tune:
+
+```bash
+uv run leizilla opf-synth --n 200 --seed 13 --ali-per-inciso 3
+# -> data/opf/synthetic/synthetic.jsonl + synthetic_manifest.json
+```
+
+What synthetic uniquely buys, beyond volume:
+
+- **Starved categories on demand** — every real law has ~1 `ementa`/`vigencia`/
+  `revogacao`; the renderer emits them per document and `ali_marcador` at any density.
+- **Hard negatives as first-class citizens** — marker-shaped surfaces that must NOT be
+  labeled, drawn from the regex baseline's own audited failure modes (lowercase `art.`
+  cross-references, `§` inside citation chains, compiled-text `(Revogado pela Lei …)`
+  history notes). A model only learns a distinction its training data contains.
+- **Off-regex OCR surfaces** — degradations the regex misses *by construction*
+  (dropped period in `Art 5º`, `§` misread as `S`), i.e. exactly the residual where
+  OPF must earn its keep over the 0.95-F1 baseline.
+
+Ground rules: synthetic goes into the **training mix only**, never val/test; every
+record carries `info.source="synthetic"` + generator seed; marker surfaces on the
+clean profile must stay regex-parseable (enforced by test — synthetic that drifts
+off-regime would teach conventions the corpus doesn't have).
 
 Stratification rule unchanged in every path: equal allocation per fonte (skill
 Warning 1) — the OCR-noisy assembleia/casacivil documents are the valuable ones, not

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -1475,6 +1475,54 @@ def cmd_opf_bootstrap(
     echo(f"manifest -> {manifest_path}")
 
 
+@app.command("opf-synth")
+def cmd_opf_synth(
+    n: int = typer.Option(100, help="Quantidade de normas sintéticas"),
+    seed: int = typer.Option(13, help="Seed do gerador (reprodutibilidade)"),
+    ali_per_inciso: int = typer.Option(
+        2, help="Densidade de ali_marcador (alíneas por inciso)"
+    ),
+    ocr_noise_fraction: float = typer.Option(
+        0.3, help="Fração de docs com superfícies do regime OCR (ex.: '§ 1 o')"
+    ),
+    out_dir: Path = typer.Option(
+        Path("data/opf/synthetic"),
+        help="Diretório de saída (synthetic.jsonl + synthetic_manifest.json)",
+    ),
+) -> None:
+    """Gerar normas sintéticas com offsets exatos (fase 2.5, caminho 4).
+
+    SOMENTE para o mix de treino — nunca val/test (eval fica real e verificado).
+    Alimenta sob demanda as categorias escassas (ali_marcador, vigencia,
+    revogacao), injeta hard negatives dos modos de falha auditados do regex
+    (art. minúsculo em citação, § em cadeia de referência, nota de histórico
+    '(Revogado pela Lei…)') e ensaia superfícies do regime OCR que o baseline
+    regex perde por construção. Ver docs/opf-finetune.md.
+    """
+    from leizilla import synthetic
+
+    records, manifest = synthetic.build_dataset(
+        n,
+        seed=seed,
+        ali_per_inciso=ali_per_inciso,
+        ocr_noise_fraction=ocr_noise_fraction,
+    )
+
+    from leizilla import opf
+
+    synth_path = out_dir / "synthetic.jsonl"
+    manifest_path = out_dir / "synthetic_manifest.json"
+    written = opf.write_pool(records, synth_path)
+    opf.write_manifest(manifest, manifest_path)
+
+    echo(f"{written} normas sintéticas -> {synth_path}")
+    spans_per_cat = cast(Dict[str, int], manifest["spans_per_category"])
+    for cat, count in spans_per_cat.items():
+        echo(f"  {cat}: {count} spans")
+    echo(f"manifest -> {manifest_path}")
+    echo("\nUso: mix de treino apenas — NUNCA val/test.")
+
+
 @app.command("opf-regex-eval")
 def cmd_opf_regex_eval(
     gold_dir: Path = typer.Option(

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -1417,6 +1417,64 @@ def cmd_opf_sample(
     echo(f"manifest -> {manifest_path}")
 
 
+@app.command("opf-bootstrap")
+def cmd_opf_bootstrap(
+    pool: Path = typer.Option(
+        Path("data/opf/pool/pool.jsonl"), help="Pool amostrado (saída de opf-sample)"
+    ),
+    out_dir: Path = typer.Option(
+        Path("data/opf/pool"),
+        help="Diretório de saída (bootstrapped.jsonl + bootstrap_manifest.json)",
+    ),
+) -> None:
+    """Pré-rotular o pool com o segmentador regex (anotação em modo auditoria).
+
+    Caminho 1 do plano de escala do gold (docs/opf-finetune.md, fase 2.5): o
+    baseline regex já atinge F1 exato 0.95 no gold, então em vez de subagentes
+    rotularem do zero, o regex pré-rotula tudo e cada subagente apenas VERIFICA e
+    corrige (residuais conhecidos: § em listas de citação, ementa com preâmbulo).
+    O manifest agrega spans por categoria — confira ANTES de despachar auditores
+    se a amostra alimenta as categorias escassas (ali_marcador, vigencia,
+    revogacao); uma amostra geral pode render zero para categoria rara.
+    """
+    from leizilla import opf
+
+    if not pool.exists():
+        echo(f"Pool não encontrado: {pool} (rode opf-sample primeiro)")
+        raise typer.Exit(1)
+
+    records = opf.load_pool(pool)
+    if not records:
+        echo(f"Pool vazio: {pool}")
+        raise typer.Exit(1)
+
+    result = opf.bootstrap_pool(records)
+
+    boot_path = out_dir / "bootstrapped.jsonl"
+    manifest_path = out_dir / "bootstrap_manifest.json"
+    n = opf.write_pool(result.records, boot_path)
+    opf.write_manifest(result.manifest, manifest_path)
+
+    echo(f"\n{n} registros pré-rotulados -> {boot_path}")
+    echo(f"{result.manifest['total_spans']} spans no total:")
+    spans_per_cat = cast(Dict[str, int], result.manifest["spans_per_category"])
+    docs_per_cat = cast(Dict[str, int], result.manifest["docs_with_category"])
+    for cat, count in spans_per_cat.items():
+        echo(f"  {cat}: {count} spans em {docs_per_cat.get(cat, 0)} docs")
+    missing = [
+        c
+        for c in ("ementa", "vigencia", "revogacao", "ali_marcador")
+        if c not in spans_per_cat
+    ]
+    if missing:
+        echo(
+            "\nAVISO: categorias sem NENHUM span nesta amostra: "
+            + ", ".join(missing)
+            + " — considere um pré-filtro dirigido antes de auditar (fase 2.5, caminho 3)."
+        )
+    echo(f"manifest -> {manifest_path}")
+
+
 @app.command("opf-regex-eval")
 def cmd_opf_regex_eval(
     gold_dir: Path = typer.Option(

--- a/src/leizilla/doctor.py
+++ b/src/leizilla/doctor.py
@@ -140,7 +140,7 @@ def default_http_check(url: str, timeout: float = HTTP_TIMEOUT_SECONDS) -> bool:
     import requests
 
     resp = requests.head(url, timeout=timeout, allow_redirects=True)
-    return resp.status_code < 500
+    return bool(resp.status_code < 500)
 
 
 def run_doctor(

--- a/src/leizilla/opf.py
+++ b/src/leizilla/opf.py
@@ -35,7 +35,7 @@ import random
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from leizilla.ocr import fetch_and_clean_ocr
 from leizilla.publisher import list_raw_ids
@@ -87,7 +87,7 @@ def parse_sources(ente: str, fontes: str) -> List[Source]:
     return out
 
 
-def sample_raw_ids(ids: Sequence[str], n: int, seed: int) -> List[str]:
+def sample_raw_ids(ids: Iterable[str], n: int, seed: int) -> List[str]:
     """Deterministically pick up to ``n`` ids from ``ids`` for a fixed ``seed``.
 
     Sorts first so the input set's iteration order can't perturb the draw, then uses a
@@ -193,6 +193,87 @@ def write_manifest(manifest: Dict[str, object], path: Path) -> None:
     with path.open("w", encoding="utf-8") as fh:
         json.dump(manifest, fh, ensure_ascii=False, indent=2)
         fh.write("\n")
+
+
+def bootstrap_pool(
+    records: Sequence[Dict[str, object]],
+    *,
+    segment_fn: Callable[[str], List[Dict[str, object]]] | None = None,
+) -> PoolResult:
+    """Pre-label pool ``records`` with the regex baseline, for audit-mode annotation.
+
+    Path 1 of the gold-scaling plan (docs/opf-finetune.md, Phase 2.5): the regex
+    baseline already scores exact micro-F1 0.95 on gold, which flips the labeling
+    economics — instead of subagents labeling every document from scratch, the
+    regex pre-labels everything and a subagent per document only *verifies and
+    corrects* (confirm the easy markers; fix the known residuals: ``§`` inside
+    citation lists, ementa preamble over-capture). An audit pass is cheaper and
+    more reliable per document than de-novo labeling. Measured on the sibling
+    causaganha segmenter (2026-07-16): regex-bootstrapped labels merged into gold
+    only after mechanical validation plus a stratified spot-check — the same two
+    gates apply here before any bootstrapped record is promoted.
+
+    Each output record keeps the pool record's ``text``/``info`` and gains:
+
+    - ``label``: the regex baseline's spans (OPF schema, offsets exact);
+    - ``info.prelabeled_by``: provenance marker (never absent — auditors and the
+      gold manifest must be able to tell bootstrapped records from de-novo ones);
+    - ``info.audit_status``: ``"pending"`` — flipped to ``"verified"`` by the
+      audit pass, and ``validate``d before promotion;
+    - ``info.category_counts``: per-category span counts for this document — the
+      targeting signal for Path 3 (pick alíneas-dense docs to feed
+      ``ali_marcador``, emendas with vigência/revogação cues, ...).
+
+    The manifest aggregates per-category totals across the pool so a scaling round
+    can see at a glance which starved categories this sample would actually feed
+    (the sibling project's Round C lesson: a general sample can yield *zero* for a
+    rare category — check before dispatching auditors, not after).
+    """
+    if segment_fn is None:
+        from leizilla.segmenter import segment as segment_fn  # type: ignore[assignment]
+    assert segment_fn is not None
+
+    out_records: List[Dict[str, object]] = []
+    totals: Dict[str, int] = {}
+    docs_with_category: Dict[str, int] = {}
+
+    for rec in records:
+        text = str(rec.get("text", ""))
+        spans = segment_fn(text)
+        counts: Dict[str, int] = {}
+        for sp in spans:
+            cat = str(sp["category"])
+            counts[cat] = counts.get(cat, 0) + 1
+            totals[cat] = totals.get(cat, 0) + 1
+        for cat in counts:
+            docs_with_category[cat] = docs_with_category.get(cat, 0) + 1
+        info = dict(rec.get("info") or {})  # type: ignore[call-overload]
+        info["prelabeled_by"] = "regex_segmenter_v1"
+        info["audit_status"] = "pending"
+        info["category_counts"] = counts
+        out_records.append({"text": text, "label": list(spans), "info": info})
+
+    manifest: Dict[str, object] = {
+        "category_version": CATEGORY_VERSION,
+        "prelabeled_by": "regex_segmenter_v1",
+        "total_records": len(out_records),
+        "total_spans": sum(totals.values()),
+        "spans_per_category": dict(sorted(totals.items())),
+        "docs_with_category": dict(sorted(docs_with_category.items())),
+        "generated_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
+    return PoolResult(records=out_records, manifest=manifest)
+
+
+def load_pool(path: Path) -> List[Dict[str, object]]:
+    """Read a pool/bootstrapped JSONL file back into records."""
+    records: List[Dict[str, object]] = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
 
 
 def load_label_space(path: Path) -> Tuple[str, List[str]]:

--- a/src/leizilla/synthetic.py
+++ b/src/leizilla/synthetic.py
@@ -1,0 +1,256 @@
+"""Synthetic norma generator for OPF training (Phase 2.5, Path 4).
+
+Deterministic renderer that writes fictional-but-well-formed Brazilian
+legislation and records every label's character offsets **at the moment of
+insertion** — ``text[start:end] == surface`` holds by construction, never by
+post-hoc search. The approach (and its guard-rails) is ported from the sibling
+causaganha project's synthetic segmenter (RFC 0011 there), where it was
+validated against a real fine-tune run on 2026-07-16.
+
+Why synthetic earns a place next to the real-data paths (docs/opf-finetune.md,
+Phase 2.5): legislative structure is highly templated, so a renderer can
+
+- feed the **starved categories on demand** (``ali_marcador``, ``vigencia``,
+  ``revogacao`` — one per document in real laws, any density here);
+- inject **hard negatives** as first-class citizens: surfaces that *look* like
+  markers but must NOT be labeled, drawn from the regex baseline's own audited
+  failure modes (lowercase ``art.`` cross-references, ``§`` inside citation
+  chains, compiled-text ``(Revogado pela Lei …)`` history notes). A model only
+  learns the distinction if training data contains the confusable case.
+- rehearse **OCR-degraded marker surfaces** the regex misses by construction
+  (dropped period in ``Art 5º``, ``§`` misread as ``S``) — the messy cases are
+  exactly where OPF must earn its keep over the 0.95-F1 regex baseline.
+
+Ground rules (same as every weak-supervision source in this repo):
+
+- Synthetic records go into the **training mix only** — never ``val``/``test``
+  (eval must stay real, PT-BR, ensemble-verified).
+- Every record carries ``info.source = "synthetic"`` + the generator seed, so
+  synthetic data stays distinguishable end to end.
+- Surfaces are register-consistent with the real corpus conventions the gold
+  follows (markers exclude the trailing period; vigência/revogação spans are
+  sentence units with the leading marker stripped) — kept aligned with
+  ``segmenter.py``'s cue patterns by test.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Dict, List, Tuple
+
+from leizilla.segmenter import Span
+
+# --- phrase banks (fictional subject matter; structure mirrors real normas) -----------
+
+_SUBJECTS = [
+    "o Programa Estadual de Incentivo à Leitura",
+    "a Política de Preservação dos Rios",
+    "o Fundo de Apoio ao Artesanato Regional",
+    "o Conselho de Transparência Administrativa",
+    "a Semana de Prevenção de Acidentes Domésticos",
+    "o Cadastro de Feiras Livres",
+]
+
+_CLAUSES = [
+    "compete ao órgão gestor definir as diretrizes de execução",
+    "os recursos serão aplicados exclusivamente na finalidade prevista",
+    "a participação social será assegurada em todas as etapas",
+    "o regulamento disporá sobre os critérios de habilitação",
+    "as despesas correrão à conta de dotações orçamentárias próprias",
+    "fica autorizada a celebração de convênios com entidades civis",
+]
+
+_VIGENCIA_SENTENCES = [
+    "Esta Lei entra em vigor na data de sua publicação.",
+    "Esta Lei entra em vigor após decorridos 90 dias de sua publicação oficial.",
+]
+
+_REVOGACAO_SENTENCES = [
+    "Revogam-se as disposições em contrário.",
+    "Fica revogada a Lei nº 1.234, de 5 de junho de 1990.",
+]
+
+# Hard negatives: marker-shaped surfaces that must NOT be labeled. Each is a
+# (filler sentence, rationale) pair; rationales document the regex-audit finding
+# the negative rehearses.
+_HARD_NEGATIVES = [
+    (
+        "O disposto aplica-se na forma do art. 233 da Lei nº 8.069, "
+        "de 13 de julho de 1990.",
+        "lowercase art. cross-reference (capitalisation filter)",
+    ),
+    (
+        "Observa-se o previsto no § 2º do art. 5º desta Lei.",
+        "§ citation chain (xref left/right context)",
+    ),
+    (
+        "O benefício anterior foi extinto. (Revogado pela Lei nº 9.999, de 2001)",
+        "compiled-text history note, not an operative revogação",
+    ),
+    (
+        "Aplica-se, no caso do inciso XII, o rito simplificado.",
+        "spelled inciso reference, not a marker",
+    ),
+]
+
+_ORDINALS = ["º", "°", " o"]  # all three tolerated by the regex regime (_ORD)
+
+# Genuinely off-regex OCR degradations — surfaces the regex baseline misses BY
+# CONSTRUCTION (verified against segmenter.py's patterns: _ART requires the
+# period after "Art"; _PAR_NUM requires the literal §). Real OCR drops the
+# period and misreads § as a letter; a human annotating degraded OCR gold would
+# still tag these as markers, so the model must learn them — this residual is
+# exactly where OPF earns its keep over the 0.95-F1 regex.
+_ART_TEMPLATES_NOISE = ["Art. {n}{o}", "Art {n}{o}"]
+_PAR_TEMPLATES_NOISE = ["§ {n}{o}", "S {n}{o}"]
+
+
+class _Builder:
+    """Append-only text buffer that records offsets as it grows."""
+
+    def __init__(self) -> None:
+        self._parts: List[str] = []
+        self._length = 0
+        self.spans: List[Span] = []
+
+    def write(self, text: str) -> None:
+        self._parts.append(text)
+        self._length += len(text)
+
+    def write_labeled(self, text: str, category: str) -> None:
+        start = self._length
+        self.write(text)
+        self.spans.append({"category": category, "start": start, "end": self._length})
+
+    def build(self) -> str:
+        return "".join(self._parts)
+
+
+def _ordinal(rng: random.Random, *, noise: bool) -> str:
+    if noise:
+        return rng.choice(_ORDINALS)
+    return rng.choice(_ORDINALS[:2])
+
+
+def build_norma(
+    seed: int,
+    *,
+    n_articles: int = 4,
+    ali_per_inciso: int = 2,
+    hard_negatives: bool = True,
+    ocr_noise: bool = False,
+) -> Tuple[str, List[Span]]:
+    """Render one synthetic norma. Returns ``(text, spans)`` with exact offsets.
+
+    ``ali_per_inciso`` directly controls ``ali_marcador`` density — the starved
+    category real Planalto laws rarely feed. ``ocr_noise`` enables marker
+    surfaces from the OCR regime (spaced ordinals) that the regex baseline
+    misses by design.
+    """
+    rng = random.Random(seed)
+    b = _Builder()
+
+    year = rng.randint(1995, 2024)
+    b.write(
+        f"LEI Nº {rng.randint(100, 9999)}, DE {rng.randint(1, 28)} DE JANEIRO DE {year}.\n"
+    )
+
+    subject = rng.choice(_SUBJECTS)
+    b.write_labeled(f"Dispõe sobre {subject} e dá outras providências.", "ementa")
+    b.write(
+        "\nO PRESIDENTE DA REPÚBLICA Faço saber que o Congresso Nacional decreta e eu sanciono a seguinte Lei:\n"
+    )
+
+    for art_n in range(1, n_articles + 1):
+        is_last = art_n == n_articles
+        art_tpl = rng.choice(_ART_TEMPLATES_NOISE) if ocr_noise else "Art. {n}{o}"
+        b.write_labeled(
+            art_tpl.format(n=art_n, o=_ordinal(rng, noise=ocr_noise)), "art_marcador"
+        )
+        if is_last:
+            # closing article: vigência clause (sentence span, leading marker
+            # stripped — the marker was emitted separately above).
+            b.write(" ")
+            b.write_labeled(rng.choice(_VIGENCIA_SENTENCES), "vigencia")
+            b.write("\n")
+            b.write_labeled(rng.choice(_REVOGACAO_SENTENCES), "revogacao")
+            b.write("\n")
+            continue
+
+        b.write(f" Fica instituído {rng.choice(_SUBJECTS)}.\n")
+        if hard_negatives and art_n == 1:
+            neg, _why = rng.choice(_HARD_NEGATIVES)
+            b.write(neg + "\n")
+
+        par_tpl = rng.choice(_PAR_TEMPLATES_NOISE) if ocr_noise else "§ {n}{o}"
+        b.write_labeled(
+            par_tpl.format(n=1, o=_ordinal(rng, noise=ocr_noise)), "par_marcador"
+        )
+        b.write(f" Para os fins desta Lei, {rng.choice(_CLAUSES)}.\n")
+        if rng.random() < 0.3:
+            b.write_labeled("Parágrafo único", "par_marcador")
+            b.write(f". Na hipótese do caput, {rng.choice(_CLAUSES)}.\n")
+
+        for inc_i, roman in enumerate(["I", "II"], start=1):
+            b.write_labeled(f"{roman} -", "inc_marcador")
+            b.write(
+                f" {rng.choice(_CLAUSES)}:\n"
+                if inc_i == 1
+                else f" {rng.choice(_CLAUSES)};\n"
+            )
+            if inc_i == 1:
+                for ali_i in range(ali_per_inciso):
+                    letter = chr(ord("a") + ali_i)
+                    b.write_labeled(f"{letter})", "ali_marcador")
+                    b.write(f" {rng.choice(_CLAUSES)};\n")
+
+    text = b.build()
+    spans = sorted(b.spans, key=lambda s: (s["start"], s["end"]))
+    return text, spans
+
+
+def build_dataset(
+    n: int,
+    *,
+    seed: int = 13,
+    ali_per_inciso: int = 2,
+    ocr_noise_fraction: float = 0.3,
+) -> Tuple[List[Dict[str, object]], Dict[str, object]]:
+    """Render ``n`` synthetic records (OPF schema) + a per-category manifest.
+
+    A deterministic fraction of documents uses the OCR-noise marker regime.
+    Records carry ``info.source="synthetic"`` — training-mix only, never gold.
+    """
+    records: List[Dict[str, object]] = []
+    totals: Dict[str, int] = {}
+    for i in range(n):
+        doc_seed = seed * 100_000 + i
+        noise = (i / max(n, 1)) < ocr_noise_fraction
+        text, spans = build_norma(
+            doc_seed, ali_per_inciso=ali_per_inciso, ocr_noise=noise
+        )
+        for sp in spans:
+            totals[sp["category"]] = totals.get(sp["category"], 0) + 1
+        records.append(
+            {
+                "text": text,
+                "label": list(spans),
+                "info": {
+                    "source": "synthetic",
+                    "generator": "leizilla.synthetic.build_norma",
+                    "seed": doc_seed,
+                    "ocr_noise": noise,
+                },
+            }
+        )
+    manifest: Dict[str, object] = {
+        "source": "synthetic",
+        "generator": "leizilla.synthetic.build_norma",
+        "n": n,
+        "seed": seed,
+        "ali_per_inciso": ali_per_inciso,
+        "ocr_noise_fraction": ocr_noise_fraction,
+        "spans_per_category": dict(sorted(totals.items())),
+        "usage": "training-mix only; never val/test (eval stays real + verified)",
+    }
+    return records, manifest

--- a/src/leizilla/synthetic.py
+++ b/src/leizilla/synthetic.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import random
 from typing import Dict, List, Tuple
 
+from leizilla.opf import CATEGORY_VERSION
 from leizilla.segmenter import Span
 
 # --- phrase banks (fictional subject matter; structure mirrors real normas) -----------
@@ -101,8 +102,14 @@ _ORDINALS = ["º", "°", " o"]  # all three tolerated by the regex regime (_ORD)
 # period and misreads § as a letter; a human annotating degraded OCR gold would
 # still tag these as markers, so the model must learn them — this residual is
 # exactly where OPF earns its keep over the 0.95-F1 regex.
-_ART_TEMPLATES_NOISE = ["Art. {n}{o}", "Art {n}{o}"]
-_PAR_TEMPLATES_NOISE = ["§ {n}{o}", "S {n}{o}"]
+#
+# Deliberately single-template (not a period-preserving/period-dropping pair):
+# segmenter._ORD already tolerates every ordinal variant in _ORDINALS, so a
+# pair would let the ordinal-only branch roll a still-regex-matching "Art. 5º"
+# surface half the time under a doc flagged ocr_noise=True, diluting the
+# off-regex training signal the noise regime exists to provide.
+_ART_TEMPLATES_NOISE = ["Art {n}{o}"]
+_PAR_TEMPLATES_NOISE = ["S {n}{o}"]
 
 
 class _Builder:
@@ -223,9 +230,12 @@ def build_dataset(
     """
     records: List[Dict[str, object]] = []
     totals: Dict[str, int] = {}
+    noise_rng = random.Random(seed)
     for i in range(n):
         doc_seed = seed * 100_000 + i
-        noise = (i / max(n, 1)) < ocr_noise_fraction
+        # A per-doc draw (not an index-prefix cutoff) so noisy docs are spread
+        # across the dataset instead of all clustering at the head of the file.
+        noise = noise_rng.random() < ocr_noise_fraction
         text, spans = build_norma(
             doc_seed, ali_per_inciso=ali_per_inciso, ocr_noise=noise
         )
@@ -244,6 +254,7 @@ def build_dataset(
             }
         )
     manifest: Dict[str, object] = {
+        "category_version": CATEGORY_VERSION,
         "source": "synthetic",
         "generator": "leizilla.synthetic.build_norma",
         "n": n,

--- a/tests/test_opf.py
+++ b/tests/test_opf.py
@@ -268,8 +268,23 @@ class TestCmdOpfBootstrap:
         rec = json.loads(boot.read_text(encoding="utf-8").splitlines()[0])
         assert rec["info"]["prelabeled_by"] == "regex_segmenter_v1"
         assert rec["label"]
-        # the starved-category warning fires when a category is absent
-        assert "AVISO" in result.output or "ali_marcador" not in result.output
+
+    def test_warns_on_starved_category(self, tmp_path: Path) -> None:
+        # A doc with only an art_marcador span (no ementa/vigencia/revogacao/
+        # ali_marcador) should trigger the starved-category AVISO for all four.
+        pool = tmp_path / "pool.jsonl"
+        opf.write_pool(
+            [{"text": "Art. 1º Fica criado o programa.", "label": [], "info": {}}],
+            pool,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["opf-bootstrap", "--pool", str(pool), "--out-dir", str(tmp_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "AVISO" in result.output
+        for cat in ("ementa", "vigencia", "revogacao", "ali_marcador"):
+            assert cat in result.output
 
     def test_missing_pool_exits_nonzero(self, tmp_path: Path) -> None:
         runner = CliRunner()

--- a/tests/test_opf.py
+++ b/tests/test_opf.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Union, cast
 
 from typer.testing import CliRunner
 
@@ -21,49 +22,49 @@ ANNOTATE = REPO_ROOT / "scripts" / "opf_annotate.py"
 
 
 class TestParseSources:
-    def test_splits_and_dedups(self):
+    def test_splits_and_dedups(self) -> None:
         sources = opf.parse_sources("ro", "assembleia, casacivil ,assembleia")
         assert [s.label for s in sources] == ["ro/assembleia", "ro/casacivil"]
 
-    def test_drops_blanks(self):
+    def test_drops_blanks(self) -> None:
         assert opf.parse_sources("ro", " , ,") == []
 
 
 class TestSampleRawIds:
-    def test_takes_all_when_n_exceeds(self):
+    def test_takes_all_when_n_exceeds(self) -> None:
         ids = {"b", "a", "c"}
         assert opf.sample_raw_ids(ids, 10, seed=1) == ["a", "b", "c"]
 
-    def test_deterministic_for_seed(self):
+    def test_deterministic_for_seed(self) -> None:
         ids = [f"id-{i:03d}" for i in range(100)]
         a = opf.sample_raw_ids(ids, 5, seed=13)
         b = opf.sample_raw_ids(ids, 5, seed=13)
         assert a == b
         assert len(a) == 5
 
-    def test_seed_changes_draw(self):
+    def test_seed_changes_draw(self) -> None:
         ids = [f"id-{i:03d}" for i in range(100)]
         a = opf.sample_raw_ids(ids, 5, seed=13)
         b = opf.sample_raw_ids(ids, 5, seed=99)
         assert a != b
 
-    def test_input_order_does_not_perturb(self):
+    def test_input_order_does_not_perturb(self) -> None:
         ids = [f"id-{i:03d}" for i in range(50)]
         forward = opf.sample_raw_ids(ids, 7, seed=5)
         backward = opf.sample_raw_ids(list(reversed(ids)), 7, seed=5)
         assert forward == backward
 
 
-def _fake_list(mapping):
+def _fake_list(mapping: dict) -> Callable[[str, str], Union[Set[str], List[str]]]:
     return lambda ente, fonte: mapping.get((ente, fonte), set())
 
 
-def _fake_fetch(texts):
+def _fake_fetch(texts: dict) -> Callable[[str], Optional[str]]:
     return lambda raw_id: texts.get(raw_id)
 
 
 class TestBuildAnnotationPool:
-    def test_stratifies_across_sources(self):
+    def test_stratifies_across_sources(self) -> None:
         sources = [opf.Source("ro", "assembleia"), opf.Source("ro", "casacivil")]
         list_fn = _fake_list(
             {
@@ -84,11 +85,12 @@ class TestBuildAnnotationPool:
         )
 
         assert len(result.records) == 4
-        fontes = {r["info"]["fonte"] for r in result.records}  # type: ignore[index]
-        assert fontes == {"assembleia", "casacivil"}
-        assert result.manifest["per_source"]["ro/assembleia"]["kept"] == 2
+        infos = [cast(Dict[str, Any], r["info"]) for r in result.records]
+        assert {i["fonte"] for i in infos} == {"assembleia", "casacivil"}
+        per_source = cast(Dict[str, Dict[str, int]], result.manifest["per_source"])
+        assert per_source["ro/assembleia"]["kept"] == 2
 
-    def test_skips_short_and_missing_ocr(self):
+    def test_skips_short_and_missing_ocr(self) -> None:
         sources = [opf.Source("ro", "assembleia")]
         list_fn = _fake_list({("ro", "assembleia"): {"ok", "short", "missing"}})
         fetch_fn = _fake_fetch({"ok": "y" * 300, "short": "tiny", "missing": None})
@@ -103,12 +105,14 @@ class TestBuildAnnotationPool:
         )
 
         assert len(result.records) == 1
-        assert result.records[0]["info"]["raw_id"] == "ok"  # type: ignore[index]
-        counts = result.manifest["per_source"]["ro/assembleia"]
+        info = cast(Dict[str, Any], result.records[0]["info"])
+        assert info["raw_id"] == "ok"
+        per_source = cast(Dict[str, Dict[str, int]], result.manifest["per_source"])
+        counts = per_source["ro/assembleia"]
         assert counts["kept"] == 1
         assert counts["skipped"] == 2
 
-    def test_records_are_opf_schema_with_empty_label(self):
+    def test_records_are_opf_schema_with_empty_label(self) -> None:
         sources = [opf.Source("ro", "casacivil")]
         list_fn = _fake_list({("ro", "casacivil"): {"c1"}})
         fetch_fn = _fake_fetch({"c1": "z" * 300})
@@ -125,7 +129,7 @@ class TestBuildAnnotationPool:
         assert rec["label"] == []
         assert rec["info"] == {"raw_id": "c1", "ente": "ro", "fonte": "casacivil"}
 
-    def test_cap_clamps_allocation(self):
+    def test_cap_clamps_allocation(self) -> None:
         sources = [opf.Source("ro", "assembleia")]
         ids = {f"id-{i}" for i in range(20)}
         list_fn = _fake_list({("ro", "assembleia"): ids})
@@ -137,10 +141,11 @@ class TestBuildAnnotationPool:
             list_fn=list_fn,
             fetch_fn=fetch_fn,
         )
-        assert result.manifest["allocation"]["effective_target"] == 5
+        allocation = cast(Dict[str, Any], result.manifest["allocation"])
+        assert allocation["effective_target"] == 5
         assert len(result.records) == 5
 
-    def test_manifest_has_reproducibility_fields(self):
+    def test_manifest_has_reproducibility_fields(self) -> None:
         result = opf.build_annotation_pool(
             [opf.Source("ro", "x")],
             n_per_source=1,
@@ -154,8 +159,10 @@ class TestBuildAnnotationPool:
 
 
 class TestWriteHelpers:
-    def test_write_pool_and_manifest_roundtrip(self, tmp_path: Path):
-        records = [{"text": "abc", "label": [], "info": {"raw_id": "r1"}}]
+    def test_write_pool_and_manifest_roundtrip(self, tmp_path: Path) -> None:
+        records: List[Dict[str, Any]] = [
+            {"text": "abc", "label": [], "info": {"raw_id": "r1"}}
+        ]
         pool = tmp_path / "sub" / "pool.jsonl"
         n = opf.write_pool(records, pool)
         assert n == 1
@@ -169,14 +176,117 @@ class TestWriteHelpers:
         assert json.loads(manifest.read_text(encoding="utf-8")) == {"seed": 13}
 
 
+class TestBootstrapPool:
+    _LAW = (
+        "LEI Nº 999, DE 1º DE JANEIRO DE 2020.\n"
+        "Ementa: Dispõe sobre o teste e dá outras providências.\n"
+        "Art. 1º Fica criado o programa de teste.\n"
+        "§ 1º O programa terá duração de:\n"
+        "I - dois anos;\n"
+        "a) prorrogáveis uma vez.\n"
+        "Art. 2º Esta Lei entra em vigor na data de sua publicação.\n"
+    )
+
+    def test_prelabels_with_regex_and_marks_provenance(self) -> None:
+        records: List[Dict[str, Any]] = [
+            {"text": self._LAW, "label": [], "info": {"raw_id": "r1"}}
+        ]
+        result = opf.bootstrap_pool(records)
+        assert len(result.records) == 1
+        rec: Dict[str, Any] = result.records[0]
+        assert rec["label"], "regex should find markers in a well-formed law"
+        cats = {s["category"] for s in rec["label"]}
+        assert "art_marcador" in cats
+        info = rec["info"]
+        assert info["prelabeled_by"] == "regex_segmenter_v1"
+        assert info["audit_status"] == "pending"
+        assert info["raw_id"] == "r1"  # original info preserved
+        assert info["category_counts"]["art_marcador"] == 2
+
+    def test_offsets_are_exact(self) -> None:
+        records: List[Dict[str, Any]] = [{"text": self._LAW, "label": [], "info": {}}]
+        result = opf.bootstrap_pool(records)
+        rec: Dict[str, Any] = result.records[0]
+        for span in rec["label"]:
+            surface = self._LAW[span["start"] : span["end"]]
+            assert surface == surface.strip()
+            assert surface
+
+    def test_manifest_aggregates_per_category(self) -> None:
+        records: List[Dict[str, Any]] = [
+            {"text": self._LAW, "label": [], "info": {}},
+            {"text": "Sem marcador nenhum aqui.", "label": [], "info": {}},
+        ]
+        result = opf.bootstrap_pool(records)
+        m: Dict[str, Any] = dict(result.manifest)
+        assert m["total_records"] == 2
+        assert m["prelabeled_by"] == "regex_segmenter_v1"
+        assert m["spans_per_category"]["art_marcador"] == 2
+        assert m["docs_with_category"]["art_marcador"] == 1
+        assert m["total_spans"] == sum(m["spans_per_category"].values())
+
+    def test_injectable_segment_fn(self) -> None:
+        def fake_segment(text: str) -> list:
+            return [{"category": "ementa", "start": 0, "end": 3}]
+
+        records: List[Dict[str, Any]] = [{"text": "abc def", "label": [], "info": {}}]
+        result = opf.bootstrap_pool(records, segment_fn=fake_segment)
+        first: Dict[str, Any] = result.records[0]
+        assert first["label"] == [{"category": "ementa", "start": 0, "end": 3}]
+
+    def test_load_pool_roundtrip(self, tmp_path: Path) -> None:
+        records: List[Dict[str, Any]] = [
+            {"text": self._LAW, "label": [], "info": {"raw_id": "r1"}}
+        ]
+        path = tmp_path / "pool.jsonl"
+        opf.write_pool(records, path)
+        assert opf.load_pool(path) == records
+
+
+class TestCmdOpfBootstrap:
+    def test_writes_bootstrapped_and_manifest(self, tmp_path: Path) -> None:
+        pool = tmp_path / "pool.jsonl"
+        opf.write_pool(
+            [{"text": TestBootstrapPool._LAW, "label": [], "info": {"raw_id": "r1"}}],
+            pool,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "opf-bootstrap",
+                "--pool",
+                str(pool),
+                "--out-dir",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        boot = tmp_path / "bootstrapped.jsonl"
+        manifest = tmp_path / "bootstrap_manifest.json"
+        assert boot.exists() and manifest.exists()
+        rec = json.loads(boot.read_text(encoding="utf-8").splitlines()[0])
+        assert rec["info"]["prelabeled_by"] == "regex_segmenter_v1"
+        assert rec["label"]
+        # the starved-category warning fires when a category is absent
+        assert "AVISO" in result.output or "ali_marcador" not in result.output
+
+    def test_missing_pool_exits_nonzero(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["opf-bootstrap", "--pool", str(tmp_path / "nope.jsonl")]
+        )
+        assert result.exit_code == 1
+
+
 class TestLabelSpace:
-    def test_committed_label_space_is_valid(self):
+    def test_committed_label_space_is_valid(self) -> None:
         version, names = opf.load_label_space(LABEL_SPACE)
         assert version == "leizilla_normas_v1"
         assert names[0] == "O"
         assert "art_marcador" in names
 
-    def test_rejects_missing_background_class(self, tmp_path: Path):
+    def test_rejects_missing_background_class(self, tmp_path: Path) -> None:
         bad = tmp_path / "ls.json"
         bad.write_text(json.dumps({"span_class_names": ["art_marcador"]}))
         try:
@@ -187,8 +297,8 @@ class TestLabelSpace:
 
 
 class TestCmdOpfSample:
-    def test_writes_pool_and_manifest(self, tmp_path: Path, monkeypatch):
-        def fake_pool(sources, **kwargs):
+    def test_writes_pool_and_manifest(self, tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        def fake_pool(sources: object, **kwargs: object) -> opf.PoolResult:
             return opf.PoolResult(
                 records=[{"text": "t", "label": [], "info": {"raw_id": "r1"}}],
                 manifest={
@@ -221,7 +331,7 @@ class TestCmdOpfSample:
         assert (out / "pool.jsonl").exists()
         assert (out / "sample_manifest.json").exists()
 
-    def test_no_valid_fontes_exits_nonzero(self, tmp_path: Path):
+    def test_no_valid_fontes_exits_nonzero(self, tmp_path: Path) -> None:
         result = runner.invoke(app, ["opf-sample", "--fontes", " , "])
         assert result.exit_code == 1
 
@@ -229,14 +339,14 @@ class TestCmdOpfSample:
 class TestVendoredAnnotateScript:
     """The vendored helper is the CI gate on gold offsets; smoke-test it end to end."""
 
-    def _run(self, *args):
+    def _run(self, *args: str) -> "subprocess.CompletedProcess[str]":
         return subprocess.run(
             [sys.executable, str(ANNOTATE), *args],
             capture_output=True,
             text=True,
         )
 
-    def test_validate_passes_clean_file(self, tmp_path: Path):
+    def test_validate_passes_clean_file(self, tmp_path: Path) -> None:
         rec = {
             "text": "Art. 5º Fica criado.",
             "label": [{"category": "art_marcador", "start": 0, "end": 6}],
@@ -246,7 +356,7 @@ class TestVendoredAnnotateScript:
         r = self._run("validate", str(f), "--label-space", str(LABEL_SPACE))
         assert r.returncode == 0, r.stderr
 
-    def test_validate_catches_bad_offsets(self, tmp_path: Path):
+    def test_validate_catches_bad_offsets(self, tmp_path: Path) -> None:
         rec = {
             "text": "Art. 5º",
             "label": [{"category": "art_marcador", "start": 0, "end": 999}],
@@ -257,14 +367,14 @@ class TestVendoredAnnotateScript:
         assert r.returncode == 1
         assert "offsets" in r.stderr.lower()
 
-    def test_validate_catches_unknown_category(self, tmp_path: Path):
+    def test_validate_catches_unknown_category(self, tmp_path: Path) -> None:
         rec = {"text": "Art. 5º", "label": [{"category": "nope", "start": 0, "end": 6}]}
         f = tmp_path / "u.jsonl"
         f.write_text(json.dumps(rec, ensure_ascii=False) + "\n", encoding="utf-8")
         r = self._run("validate", str(f), "--label-space", str(LABEL_SPACE))
         assert r.returncode == 1
 
-    def test_from_spans_resolves_match_offsets(self, tmp_path: Path):
+    def test_from_spans_resolves_match_offsets(self, tmp_path: Path) -> None:
         rec = {
             "text": "Ementa: cria o fundo.",
             "finds": [{"category": "ementa", "match": "cria o fundo"}],

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -74,9 +74,9 @@ class TestBuildNorma:
             neg_start = text.index(neg)
             neg_end = neg_start + len(neg)
             for sp in spans:
-                assert not (
-                    sp["start"] >= neg_start and sp["end"] <= neg_end
-                ), f"span {sp} labels inside hard negative {neg!r}"
+                assert not (sp["start"] >= neg_start and sp["end"] <= neg_end), (
+                    f"span {sp} labels inside hard negative {neg!r}"
+                )
 
     def test_clean_profile_agrees_with_regex_baseline_on_markers(self) -> None:
         """On clean (no OCR noise) text the regex baseline should re-find the

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -1,0 +1,158 @@
+"""Tests for the synthetic norma generator (OPF Phase 2.5, Path 4).
+
+The load-bearing property is offset exactness by construction:
+``text[start:end] == surface`` for every span, no overlaps, categories in the
+committed label space. Surfaces must also stay in-regime with segmenter.py's
+own cue patterns (so synthetic doesn't drift from the conventions gold uses).
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, cast
+
+from typer.testing import CliRunner
+
+from leizilla import synthetic
+from leizilla.cli import app
+from leizilla.opf import load_label_space
+from leizilla.segmenter import _REVOGA_OPERATIVE, _VIGENCIA_CUE, segment
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LABEL_SPACE = REPO_ROOT / "data" / "opf" / "label_space.json"
+
+
+class TestBuildNorma:
+    def test_offsets_are_exact_by_construction(self) -> None:
+        for seed in range(10):
+            text, spans = synthetic.build_norma(seed)
+            for sp in spans:
+                surface = text[sp["start"] : sp["end"]]
+                assert surface == surface.strip()
+                assert surface
+
+    def test_no_overlapping_spans(self) -> None:
+        for seed in range(10):
+            _text, spans = synthetic.build_norma(seed)
+            for a, b in zip(spans, spans[1:]):
+                assert b["start"] >= a["end"], (a, b)
+
+    def test_categories_in_committed_label_space(self) -> None:
+        _version, names = load_label_space(LABEL_SPACE)
+        _text, spans = synthetic.build_norma(7)
+        for sp in spans:
+            assert sp["category"] in names
+
+    def test_deterministic_for_seed(self) -> None:
+        assert synthetic.build_norma(42) == synthetic.build_norma(42)
+        assert synthetic.build_norma(42) != synthetic.build_norma(43)
+
+    def test_feeds_starved_categories_on_demand(self) -> None:
+        _text, spans = synthetic.build_norma(1, ali_per_inciso=4)
+        cats = [s["category"] for s in spans]
+        assert cats.count("ali_marcador") >= 4
+        assert "vigencia" in cats
+        assert "revogacao" in cats
+        assert "ementa" in cats
+
+    def test_vigencia_revogacao_surfaces_match_segmenter_cues(self) -> None:
+        """Synthetic surfaces must stay in-regime with the real cue patterns."""
+        text, spans = synthetic.build_norma(3)
+        for sp in spans:
+            surface = text[sp["start"] : sp["end"]]
+            if sp["category"] == "vigencia":
+                assert _VIGENCIA_CUE.search(surface)
+            if sp["category"] == "revogacao":
+                assert _REVOGA_OPERATIVE.search(surface)
+
+    def test_hard_negatives_present_but_unlabeled(self) -> None:
+        text, spans = synthetic.build_norma(5, hard_negatives=True)
+        # at least one hard-negative surface must appear in the text...
+        present = [neg for neg, _why in synthetic._HARD_NEGATIVES if neg in text]
+        assert present, "no hard negative was injected"
+        # ...and no span may cover the marker-shaped part inside it.
+        for neg in present:
+            neg_start = text.index(neg)
+            neg_end = neg_start + len(neg)
+            for sp in spans:
+                assert not (
+                    sp["start"] >= neg_start and sp["end"] <= neg_end
+                ), f"span {sp} labels inside hard negative {neg!r}"
+
+    def test_clean_profile_agrees_with_regex_baseline_on_markers(self) -> None:
+        """On clean (no OCR noise) text the regex baseline should re-find the
+        marker spans — synthetic that regex can't parse would be off-regime.
+        (Cue-clause boundaries legitimately differ; markers must not.)
+        """
+        text, spans = synthetic.build_norma(11, ocr_noise=False, hard_negatives=False)
+        regex_spans = {
+            (s["category"], s["start"], s["end"])
+            for s in segment(text)
+            if s["category"].endswith("_marcador")
+        }
+        for sp in spans:
+            if sp["category"].endswith("_marcador"):
+                assert (sp["category"], sp["start"], sp["end"]) in regex_spans, (
+                    sp,
+                    text[sp["start"] : sp["end"]],
+                )
+
+    def test_ocr_noise_produces_off_regex_surfaces(self) -> None:
+        """The OCR-noise regime must produce at least some marker surfaces the
+        regex misses — that residual is the model's whole territory."""
+        missed_any = False
+        for seed in range(20):
+            text, spans = synthetic.build_norma(seed, ocr_noise=True)
+            regex_found = {(s["category"], s["start"], s["end"]) for s in segment(text)}
+            for sp in spans:
+                if (
+                    sp["category"].endswith("_marcador")
+                    and (sp["category"], sp["start"], sp["end"]) not in regex_found
+                ):
+                    missed_any = True
+        assert missed_any
+
+
+class TestBuildDataset:
+    def test_records_are_opf_schema_with_provenance(self) -> None:
+        records, manifest = synthetic.build_dataset(5, seed=13)
+        assert len(records) == 5
+        for rec_obj in records:
+            rec = cast(Dict[str, Any], rec_obj)
+            assert set(rec) == {"text", "label", "info"}
+            assert rec["info"]["source"] == "synthetic"
+            assert "seed" in rec["info"]
+        assert manifest["n"] == 5
+        assert "training-mix only" in str(manifest["usage"])
+
+    def test_manifest_counts_match_records(self) -> None:
+        records, manifest = synthetic.build_dataset(4, seed=1)
+        counted: Dict[str, int] = {}
+        for rec_obj in records:
+            rec = cast(Dict[str, Any], rec_obj)
+            labels = cast(List[Dict[str, Any]], rec["label"])
+            for sp in labels:
+                counted[sp["category"]] = counted.get(sp["category"], 0) + 1
+        assert manifest["spans_per_category"] == dict(sorted(counted.items()))
+
+    def test_deterministic(self) -> None:
+        a_records, _a = synthetic.build_dataset(3, seed=7)
+        b_records, _b = synthetic.build_dataset(3, seed=7)
+        assert a_records == b_records
+
+
+class TestCmdOpfSynth:
+    def test_writes_jsonl_and_manifest(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["opf-synth", "--n", "3", "--out-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        synth = tmp_path / "synthetic.jsonl"
+        manifest = tmp_path / "synthetic_manifest.json"
+        assert synth.exists() and manifest.exists()
+        lines = synth.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3
+        rec = json.loads(lines[0])
+        assert rec["info"]["source"] == "synthetic"
+        assert "NUNCA val/test" in result.output


### PR DESCRIPTION
## What

Answers "how do we scale the gold past v0, using the data leizilla already has on/around the IA?" — with a new **Phase 2.5** section in `docs/opf-finetune.md` (three paths, cheapest first) and the first path implemented as a CLI command: **`leizilla opf-bootstrap`**.

Every method here was validated on the sibling causaganha segmenter on 2026-07-16, which scaled its real gold 20 → 106 documents in one day using the same `from-spans`/`validate` tooling this repo vendors.

## Path 1 — regex-bootstrap + subagent *audit* (implemented)

The regex baseline already scores **exact micro-F1 0.95** on gold. That flips the labeling economics: instead of subagents labeling every document from scratch (the v0 flow), the regex pre-labels everything and one subagent per document only **verifies and corrects** — confirm the easy markers, fix the known residuals (`§` inside citation lists, ementa preamble over-capture — the same ones `opf-regex-eval --errors` already names).

```bash
uv run leizilla opf-sample    --ente ro --fontes assembleia,casacivil --n 50 --seed 13
uv run leizilla opf-bootstrap --pool data/opf/pool/pool.jsonl
# -> bootstrapped.jsonl        (regex pre-labels, info.audit_status="pending")
# -> bootstrap_manifest.json   (spans per category — read this BEFORE dispatching auditors)
```

Design points:
- Every bootstrapped record carries `info.prelabeled_by="regex_segmenter_v1"` + `info.audit_status="pending"` — bootstrapped gold stays distinguishable from de-novo gold all the way into the gold manifest (same provenance discipline as `test_verified_by`).
- The manifest aggregates spans-per-category across the sample, and the CLI **warns when a starved category (`ementa`/`vigencia`/`revogacao`/`ali_marcador`) has zero spans** — causaganha's measured lesson: an 18-doc *general* round produced zero spans for its rarest category, while an 8-doc *pre-filtered* round hit 7/8. Check the manifest before spending auditor passes, not after.
- `bootstrap_pool()` keeps the module's injectable-IO convention (`segment_fn` seam); all 8 new tests are offline/deterministic. 27 tests total in `test_opf.py`, passing.

## Paths 2 & 3 (documented in Phase 2.5)

- **Path 2:** project parsed Leizilla XML rótulos back onto OCR text → **silver** training-mix material at whatever scale the parsed corpus has (never eval gold — parser errors would leak into labels).
- **Path 3:** targeted pre-filters when the bootstrap manifest shows a starved category — alíneas-dense statutes for `ali_marcador`, emendas matching `entra em vigor|revogam-se` for `vigencia`/`revogacao` — with the existing staged-vs-active convention unchanged.

## Hygiene fixes (required to commit at all)

The pre-commit mypy hook was already failing on main for anyone touching these files:

- `tests/test_opf.py` had 27 pre-existing `no-untyped-def` errors — annotated every def, typed the fake-IO factories, replaced object-indexing with `cast()` (chosen over `# type: ignore` because mypy's unused-ignore judgment flips between single-file and multi-file invocations of the same hook).
- `sample_raw_ids`: `Sequence` → `Iterable` — the function is documented as set-safe ("sorts first so the input set's iteration order can't perturb the draw") and its own test passes a `set`; the old signature contradicted both.
- `.pre-commit-config.yaml`: added `types-requests` to the mypy hook env — without stubs the hook fails (`import-untyped`) in `wayback`/`doctor`/`crawler` for any commit touching files that import them.
- `doctor.py`: `bool()` cast on the HEAD-check return (`no-any-return` under the hook's env; no-op for CI's mypy).

## Relationship to #115

Independent — #115 fixes the Phase 3 *training* notebook (T4 OOM/LR/resume-chain lessons); this PR feeds Phase 2/2.5 *data scaling*. Both edit `docs/opf-finetune.md` in different sections; whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECQiKdhjuTNfVVktogY4EZ