### PR TITLE
fix(parser): correct URN type token, mandate provenance, enforce unique paths in LLM prompt

### DIFF
--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -93,8 +93,15 @@ Path rules:
 - Organizational paths (namespaced): tit-N, tit-N-cap-N, tit-N-cap-N-sec-N
 - Use lower-case with hyphens only, first char must be a-z
 - Paths MUST be unique within the document. Before you output, verify no two
-  <dispositivo> share the same path. If the source repeats an article/inciso
-  number, emit it once (the authoritative occurrence) — never a duplicate path.
+  <dispositivo> share the same path. If the source appears to repeat an
+  article/inciso number (OCR duplication, ambiguous renumbering), do NOT pick
+  one occurrence and silently drop the other — that discards normative text.
+  If the repeated occurrences carry the same content, merge them into a
+  single <dispositivo> keeping the full text. If they conflict and cannot be
+  safely disambiguated, fold the ambiguous text into the enclosing
+  dispositivo's path as running text instead of guessing a split — or, if
+  even that is unsafe, set "confidence" below 0.5 and explain the ambiguity
+  in "error" rather than emitting a document that silently lost text.
 
 Provenance (mandatory):
 - Every <versao> MUST contain exactly one <fonte ia-id="{ia_id}"/>, with the
@@ -114,10 +121,15 @@ URN rules — the urn-lex on <lei> and the "urn_lex" field must be identical:
     medida provisória      -> medida.provisoria
     resolução              -> resolucao
     portaria               -> portaria
-- YYYY-MM-DD is the law's ACTUAL publication/enactment date read from the text
-  (the dateline, "Publicada no D.O.E. de…", or the closing "Palácio…, em DD de
-  MÊS de AAAA"). Use a year-only date (just YYYY) when the day/month are missing.
-  Do NOT substitute today's date into the URN.
+- YYYY-MM-DD is the date of the ACT ITSELF — signature/promulgation date, not
+  the publication date (LexML Parte 2 §10.1 treats publication as a separate
+  event from the norm's representative date). Read it from the closing
+  formula ("Palácio…, em DD de MÊS de AAAA") or an equivalent signature
+  dateline. Do NOT use a "Publicada no D.O.E. de…" notice for this date —
+  that is the publication date, and using it here would produce a different
+  URN for the same norm depending on which notice the source happens to
+  carry. Use a year-only date (just YYYY) when the day/month of the act's own
+  date are missing. Do NOT substitute today's date into the URN.
 - NUMERO is the digits-only law number (same value as the "numero" field).
 
 Use vigente-em={today} — this is the "as of" reference for the snapshot and is
@@ -262,6 +274,30 @@ def _is_well_formed(xml_str: str) -> bool:
         return False
 
 
+_LEI_NS = "{https://leizilla.org/lei/0.1}"
+
+
+def _find_provenance_mismatch(root: ET.Element, ia_id: str) -> Optional[str]:
+    """Check every <versao> carries exactly one <fonte ia-id="{ia_id}"/>.
+
+    The XSD itself allows multiple <fonte> per <versao> (future multi-witness
+    reconciliation) and only validates the ia-id's generic format, so a model
+    that hallucinates an extra source or a different well-formed raw id would
+    otherwise pass unnoticed. This narrower single-source invariant is what
+    the prompt promises for LLM-parsed output specifically, so it is enforced
+    here rather than in the XSD. Returns a reason string on mismatch, else
+    None.
+    """
+    for versao in root.iter(f"{_LEI_NS}versao"):
+        fontes = versao.findall(f"{_LEI_NS}fonte")
+        if len(fontes) != 1:
+            return f"versao com {len(fontes)} <fonte> (esperado exatamente 1)"
+        fonte_id = fontes[0].get("ia-id")
+        if fonte_id != ia_id:
+            return f"fonte ia-id={fonte_id!r} != ia_id esperado {ia_id!r}"
+    return None
+
+
 def parse_law(
     ocr_text: str,
     ia_id: str,
@@ -361,6 +397,16 @@ def parse_law(
     if not xml or not _is_well_formed(xml):
         logger.warning(
             "%s: confidence %.2f mas xml ausente/malformado", ia_id, confidence
+        )
+        return None
+
+    provenance_error = _find_provenance_mismatch(ET.fromstring(xml), ia_id)
+    if provenance_error:
+        logger.warning(
+            "%s: confidence %.2f mas proveniência inválida: %s",
+            ia_id,
+            confidence,
+            provenance_error,
         )
         return None
 

--- a/src/leizilla/parser.py
+++ b/src/leizilla/parser.py
@@ -64,9 +64,9 @@ Required fields:
 - "xml": complete Leizilla XML v0.1 string (see format below)
 - "confidence": float 0.0–1.0 (how well you parsed the text)
 - "tipo": document type slug — "lei", "decreto", "lei-complementar", etc.
-- "numero": law number as string (e.g. "9999")
+- "numero": law number as string, digits only (e.g. "9999")
 - "ano": year as integer
-- "urn_lex": URN LEX string, or null if date cannot be determined
+- "urn_lex": URN LEX string (see URN rules); null only if the text has no date at all
 
 Leizilla XML v0.1 format (namespace https://leizilla.org/lei/0.1):
 
@@ -91,16 +91,37 @@ Leizilla XML v0.1 format (namespace https://leizilla.org/lei/0.1):
 Path rules:
 - Normative paths (global): ementa, preambulo, art-N, art-N-par-unico, art-N-par-M, art-N-inc-N, art-N-inc-N-ali-a
 - Organizational paths (namespaced): tit-N, tit-N-cap-N, tit-N-cap-N-sec-N
-- Paths must be unique within the document
 - Use lower-case with hyphens only, first char must be a-z
+- Paths MUST be unique within the document. Before you output, verify no two
+  <dispositivo> share the same path. If the source repeats an article/inciso
+  number, emit it once (the authoritative occurrence) — never a duplicate path.
 
-URN format for state laws (ente={ente_name}):
-  urn:lex:br;{ente_name}:estadual:lei:YYYY-MM-DD;NUMERO
-For federal laws (ente=federal):
-  urn:lex:br:federal:lei:YYYY-MM-DD;NUMERO
+Provenance (mandatory):
+- Every <versao> MUST contain exactly one <fonte ia-id="{ia_id}"/>, with the
+  ia-id EXACTLY "{ia_id}" — never empty, never omitted, never a different value.
 
-Use vigente-em={today} unless you know a better date.
-All dispositivos share the same fonte ia-id: {ia_id}
+URN rules — the urn-lex on <lei> and the "urn_lex" field must be identical:
+  state laws (ente={ente_name}):  urn:lex:br;{ente_name}:estadual:TIPO:YYYY-MM-DD;NUMERO
+  federal laws (ente=federal):    urn:lex:br:federal:TIPO:YYYY-MM-DD;NUMERO
+- TIPO is the LexML token for THIS document — NOT always "lei". The "lei" in the
+  example above is illustrative; replace it per this map (LexML uses dots in the
+  URN token, never hyphens):
+    lei                    -> lei
+    lei complementar       -> lei.complementar
+    decreto                -> decreto
+    decreto-lei            -> decreto.lei
+    emenda constitucional  -> emenda.constitucional
+    medida provisória      -> medida.provisoria
+    resolução              -> resolucao
+    portaria               -> portaria
+- YYYY-MM-DD is the law's ACTUAL publication/enactment date read from the text
+  (the dateline, "Publicada no D.O.E. de…", or the closing "Palácio…, em DD de
+  MÊS de AAAA"). Use a year-only date (just YYYY) when the day/month are missing.
+  Do NOT substitute today's date into the URN.
+- NUMERO is the digits-only law number (same value as the "numero" field).
+
+Use vigente-em={today} — this is the "as of" reference for the snapshot and is
+independent of the publication date encoded in the URN.
 
 If text is unreadable, not a law, or confidence < 0.5, output only:
 {{"confidence": 0.0, "error": "brief reason"}}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -327,6 +327,77 @@ class TestParseLaw:
         with _llm(bad):
             assert parser.parse_law("ocr text", _IA_ID, "ro") is None
 
+    def test_returns_none_when_versao_has_no_fonte(self):
+        xml_no_fonte = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"'
+            ' urn-lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;9999"'
+            ' vigente-em="2026-05-20">'
+            '<dispositivo path="ementa">'
+            "<versao><texto>Sem fonte.</texto></versao>"
+            "</dispositivo>"
+            "</lei>"
+        )
+        bad = json.dumps(
+            {
+                "xml": xml_no_fonte,
+                "confidence": 0.9,
+                "tipo": "lei",
+                "numero": "9999",
+                "ano": 1999,
+            }
+        )
+        with _llm(bad):
+            assert parser.parse_law("ocr text", _IA_ID, "ro") is None
+
+    def test_returns_none_when_versao_has_multiple_fontes(self):
+        xml_multi_fonte = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"'
+            ' urn-lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;9999"'
+            ' vigente-em="2026-05-20">'
+            '<dispositivo path="ementa">'
+            "<versao><texto>Duas fontes.</texto>"
+            f'<fonte ia-id="{_IA_ID}"/><fonte ia-id="{_IA_ID}-outra"/></versao>'
+            "</dispositivo>"
+            "</lei>"
+        )
+        bad = json.dumps(
+            {
+                "xml": xml_multi_fonte,
+                "confidence": 0.9,
+                "tipo": "lei",
+                "numero": "9999",
+                "ano": 1999,
+            }
+        )
+        with _llm(bad):
+            assert parser.parse_law("ocr text", _IA_ID, "ro") is None
+
+    def test_returns_none_when_fonte_ia_id_mismatches(self):
+        xml_wrong_fonte = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"'
+            ' urn-lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;9999"'
+            ' vigente-em="2026-05-20">'
+            '<dispositivo path="ementa">'
+            "<versao><texto>Fonte errada.</texto>"
+            '<fonte ia-id="leizilla-raw-ro-casacivil-coddoc-00001"/></versao>'
+            "</dispositivo>"
+            "</lei>"
+        )
+        bad = json.dumps(
+            {
+                "xml": xml_wrong_fonte,
+                "confidence": 0.9,
+                "tipo": "lei",
+                "numero": "9999",
+                "ano": 1999,
+            }
+        )
+        with _llm(bad):
+            assert parser.parse_law("ocr text", _IA_ID, "ro") is None
+
     def test_raises_when_no_key_configured(self):
         empty = {"ANTHROPIC_API_KEY": None}
         with _llm(_LLM_OK, keys=empty):
@@ -438,10 +509,32 @@ class TestParseLaw:
         assert len(user_content) <= parser._HTML_CHAR_LIMIT + 200
 
     def test_html_input_type_sets_parse_method(self):
-        with _llm(_LLM_OK):
+        html_ia_id = "https://example.gov.br/lei/1"
+        xml_html_source = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<lei xmlns="https://leizilla.org/lei/0.1" schema-version="0.1"'
+            ' urn-lex="urn:lex:br;rondonia:estadual:lei:1999-06-15;9999"'
+            ' vigente-em="2026-05-20">'
+            '<dispositivo path="ementa">'
+            "<versao><texto>Institui o Dia Estadual.</texto>"
+            f'<fonte ia-id="{html_ia_id}"/></versao>'
+            "</dispositivo>"
+            "</lei>"
+        )
+        ok_html = json.dumps(
+            {
+                "xml": xml_html_source,
+                "confidence": 0.9,
+                "tipo": "lei",
+                "numero": "9999",
+                "ano": 1999,
+                "urn_lex": "urn:lex:br;rondonia:estadual:lei:1999-06-15;9999",
+            }
+        )
+        with _llm(ok_html):
             result = parser.parse_law(
                 "html content",
-                "https://example.gov.br/lei/1",
+                html_ia_id,
                 "ro",
                 input_type="html",
             )


### PR DESCRIPTION
The LLM parsing prompt (`_SYSTEM` in `parser.py`) drives every field in the published dataset. A code review surfaced three prompt-level defects that let bad data through into the shipped Parquet. This is a **prompt-only** change — no code paths touched.

## 1. Wrong URN type token
The prompt hardcoded `:estadual:lei:` in both the XML example and the URN format section, so the model copied `lei` for every document — a Lei Complementar or Emenda Constitucional got a URN claiming `:lei:`. Since `urn_lex` is the primary source of `tipo_lei` / `data_publicacao` in the ETL (`_parse_lei_fields`), this **mislabels the norm type** in the dataset.

Now the prompt gives the LexML type-token map (`lei` → `lei`, `lei complementar` → `lei.complementar`, `decreto` → `decreto`, `emenda constitucional` → `emenda.constitucional`, …) and states the `lei` in the example is illustrative. The ETL URN regex already accepts dotted tokens (`[a-z][a-z0-9.]*`), so this parses correctly downstream.

## 2. Provenance could be empty
The prompt only said "all dispositivos share the same fonte ia-id"; a model that omitted `ia-id` on a `<fonte>` still produced XML the ETL accepts, **counting it in `num_fontes` while the id points to nothing**. Now every `<versao>` MUST carry exactly one `<fonte ia-id="…"/>` with the exact id — never empty, never omitted.

## 3. Duplicate paths + today-as-publication-date
Added an explicit pre-output uniqueness self-check (duplicate `dispositivo` paths corrupt the `versao_id` identity), and instructed the model to read the **actual** publication/enactment date from the text rather than substituting today's date (a null/today date collapses the temporal-versioning intervals).

## Deliberately NOT changed
The parser already rejects non-digit `numero` (`numero_str.isdigit()`), so the prompt does **not** add letter-suffix handling — telling the model to drop a suffix would silently conflate e.g. Lei 72 and 72-A. That stays a separate code-level limitation (tracked as an issue).

## Verification
- `_SYSTEM.format(...)` smoke test passes (no stray braces)
- ruff check + ruff format clean
- mypy clean on `parser.py`
- all 57 tests in `test_parser.py` pass