### PR TITLE
fix(etl): make versao_id unique across laws (include lei_id)

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -344,7 +344,7 @@ Agrupadas por origem (lei / dispositivo / versão). Toda metadata de lei e dispo
 
 | coluna | tipo | nullable | nota |
 |---|---|---|---|
-| `versao_id` | VARCHAR | NO | `{dispositivo_path}#{em}` |
+| `versao_id` | VARCHAR | NO | `{lei_id}#{dispositivo_path}#{em}` |
 | `em` | DATE | NO | data de início da versão (chave natural) |
 | `ate` | DATE | YES | inferido; NULL = ainda vigente |
 | `alterado_por` | VARCHAR | YES | URN da lei alteradora |

--- a/src/leizilla/etl.py
+++ b/src/leizilla/etl.py
@@ -268,7 +268,7 @@ def xml_to_rows(xml_content: str, lei_id: str, ente: str) -> list[dict[str, Any]
                         }
                     )
 
-                versao_id = f"{path}#{em.isoformat() if em else 'unknown'}"
+                versao_id = f"{lei_id}#{path}#{em.isoformat() if em else 'unknown'}"
 
                 rows.append(
                     {
@@ -303,8 +303,15 @@ def consolidate_xmls(
 ) -> list[dict[str, Any]]:
     """Convert multiple (lei_id, ente, xml_content) items to versoes rows."""
     rows: list[dict[str, Any]] = []
+    seen_versao_ids: set[str] = set()
     for lei_id, ente, xml_content in xml_items:
-        rows.extend(xml_to_rows(xml_content, lei_id, ente))
+        lei_rows = xml_to_rows(xml_content, lei_id, ente)
+        for row in lei_rows:
+            vid = row["versao_id"]
+            if vid in seen_versao_ids:
+                raise ValueError(f"Duplicate versao_id detected: {vid}")
+            seen_versao_ids.add(vid)
+        rows.extend(lei_rows)
     return rows
 
 

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -120,6 +120,12 @@ class TestXmlToRowsSimple:
     def test_ate_is_none_single_versao(self) -> None:
         assert all(r["ate"] is None for r in self.rows)
 
+    def test_versao_id_format(self) -> None:
+        # Issue #119: versao_id must include lei_id to be globally unique in Parquet
+        # Expected format: {lei_id}#{path}#{em}
+        art1 = next(r for r in self.rows if r["dispositivo_path"] == "art-1")
+        assert art1["versao_id"] == "leizilla-ro-lei-09999-1999#art-1#1999-06-15"
+
     def test_inicio_tipo_default(self) -> None:
         assert all(r["inicio_tipo"] == "data-publicacao" for r in self.rows)
 
@@ -336,6 +342,27 @@ class TestConsolidateXmls:
         lei_ids = {r["lei_id"] for r in rows}
         assert "leizilla-ro-lei-09999-1999" in lei_ids
         assert "leizilla-ro-lei-00500-1990" in lei_ids
+
+    def test_versao_id_unique_across_laws(self) -> None:
+        # Issue #119: Same path#em in two different laws must get distinct versao_ids
+        items = [
+            ("lei-1", "ro", _SIMPLE),
+            ("lei-2", "ro", _SIMPLE),  # Same XML, different lei_id
+        ]
+        rows = consolidate_xmls(items)
+        # 5 rows per law = 10 rows total, 10 unique versao_ids
+        versao_ids = {r["versao_id"] for r in rows}
+        assert len(versao_ids) == 10
+        assert "lei-1#art-1#1999-06-15" in versao_ids
+        assert "lei-2#art-1#1999-06-15" in versao_ids
+
+    def test_duplicate_versao_id_raises(self) -> None:
+        items = [
+            ("lei-1", "ro", _SIMPLE),
+            ("lei-1", "ro", _SIMPLE),  # Exact same lei_id and XML -> duplicate IDs
+        ]
+        with pytest.raises(ValueError, match="Duplicate versao_id detected"):
+            consolidate_xmls(items)
 
     def test_empty_input(self) -> None:
         assert consolidate_xmls([]) == []


### PR DESCRIPTION
This PR fixes issue #119, a data integrity bug where `versao_id` collides across different laws because it lacked the `lei_id`.

Changes:
- Updates `versao_id` generation in `src/leizilla/etl.py` to use `{lei_id}#{path}#{em}`.
- Adds an assertion loop in `consolidate_xmls` to track seen `versao_id`s and fail loudly on duplicates.
- Updates `docs/SCHEMA.md` to document the new `versao_id` format.
- Adds and updates tests in `tests/test_etl.py` to assert the new unique format and verify the duplicate check.

Note for downstream consumers: This alters the output value of the `versao_id` column in the published `versoes` Parquet table.

---
*PR created automatically by Jules for task [5799255856704074186](https://jules.google.com/task/5799255856704074186) started by @franklinbaldo*