### PR TITLE
fix(scraper): validate PDF magic bytes on scrape_one's direct-fallback path

### DIFF
--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -84,6 +84,13 @@ def scrape_one(
     if pdf_bytes is None:
         return {"success": False, "reason": "fetch-failed", "url": pdf_url}
 
+    # Valida magic bytes também no fallback direto — um WAF pode servir uma
+    # página de erro HTML com status 200 numa URL .pdf. O caminho Wayback já
+    # descarta esse caso acima (retry via fallback); este check final cobre o
+    # fallback em si, igual ao que harvest_pending_resources já faz.
+    if pdf_bytes[:4] != b"%PDF":
+        return {"success": False, "reason": "not-pdf", "url": pdf_url}
+
     with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
         f.write(pdf_bytes)
         tmp_path = Path(f.name)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -136,6 +136,22 @@ class TestScrapeOne:
         call_kwargs = pub.upload_raw.call_args
         assert call_kwargs.kwargs["fetched_from"] == "source-fallback"
 
+    @patch("leizilla.scraper.wayback.ensure_archived", return_value=None)
+    @patch(
+        "leizilla.scraper.wayback.fetch_bytes",
+        return_value=b"<!DOCTYPE html><html>Request Rejected</html>",
+    )
+    @patch("leizilla.scraper.wayback.save_page", return_value=False)
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    def test_direct_fallback_html_response_rejected(
+        self, _r: Any, _s: Any, _f: Any, _c: Any
+    ) -> None:
+        """WAF servindo HTML (200) numa URL .pdf no fallback direto não deve subir pro IA."""
+        pub = _make_publisher()
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub)
+        assert result == {"success": False, "reason": "not-pdf", "url": _PDF_URL}
+        pub.upload_raw.assert_not_called()
+
 
 class TestMakeRateLimiter:
     def test_returns_callable(self) -> None:


### PR DESCRIPTION
Closes #125.

## Problem

In `scrape_one` (`src/leizilla/scraper.py`), the Wayback fetch path validates PDF magic bytes and falls back to a direct fetch when the response isn't a real PDF (line 70):

```python
if pdf_bytes is not None and pdf_bytes[:4] != b"%PDF":
    pdf_bytes = None
```

But the **direct-fallback fetch** (`wayback.fetch_bytes(pdf_url)`) was passed straight to `publisher.upload_raw` with no such check. A WAF "Request Rejected" HTML page served with `200` at a `.pdf` URL would get uploaded to Internet Archive as if it were the raw law text — silent data corruption in the raw archive.

The sibling function `harvest_pending_resources` (same file) already guards this correctly with a single check after both fetch paths converge. `scrape_one` didn't have the equivalent.

## Fix

Add the same magic-byte check to `scrape_one`, placed after both the Wayback and fallback paths converge (mirroring `harvest_pending_resources`'s pattern) — so it covers whichever path actually supplied the bytes, without duplicating the check per-path. Returns `{"success": False, "reason": "not-pdf", "url": pdf_url}` instead of uploading.

## Testing

- New test `test_direct_fallback_html_response_rejected`: Wayback returns nothing, direct fallback returns an HTML WAF page — asserts the parse is rejected and `upload_raw` is never called.
- `tests/test_scraper.py`: 14/14 pass (13 existing + 1 new).
- `tests/test_ditel.py` (also exercises `scrape_one`): 37/37 pass together with `test_scraper.py`.
- ruff check + ruff format clean.
- mypy clean on `scraper.py` (one pre-existing, unrelated `wayback.py` stub-import note, confirmed present on `main` too).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYNA5VDwYNNVaJ4zwUMaKs)_