### PR TITLE
fix(publisher): bound plaintext IA credential file to a single upload call

### DIFF
--- a/src/leizilla/publisher.py
+++ b/src/leizilla/publisher.py
@@ -1,6 +1,5 @@
 """Publicação no Internet Archive e exportação de datasets."""
 
-import atexit
 import configparser
 import csv
 import hashlib
@@ -547,9 +546,6 @@ def _unidentified_title(ente: str, fonte: str) -> str:
     return f"Leizilla Raw {ente.upper()} {fonte.upper()} UNIDENTIFIED"
 
 
-_ia_config_cache: Dict[tuple[str, str], str] = {}
-
-
 def _ia_subprocess_env(
     access_key: Optional[str], secret_key: Optional[str]
 ) -> Optional[Dict[str, str]]:
@@ -557,31 +553,28 @@ def _ia_subprocess_env(
 
     O CLI ``ia`` ignora ``IA_ACCESS_KEY``/``IA_SECRET_KEY`` e não tem flags de
     chave: ele só lê credenciais de um arquivo de config, cujo caminho pode ser
-    sobrescrito via a env var ``IA_CONFIG_FILE``. Escrevemos um ``ia.ini`` mínimo
-    (uma vez por par de credenciais) e apontamos o subprocess para ele, para que
-    o upload funcione sem um ``~/.config/internetarchive/ia.ini`` pré-existente.
+    sobrescrito via a env var ``IA_CONFIG_FILE``. Escrevemos um ``ia.ini``
+    mínimo (permissões 0600, padrão do ``NamedTemporaryFile``) e apontamos o
+    subprocess para ele, para que o upload funcione sem um
+    ``~/.config/internetarchive/ia.ini`` pré-existente.
+
+    Escreve um arquivo novo a cada chamada — não reaproveita um cache
+    process-wide — para que o caller (``_run_ia_upload``) possa apagá-lo logo
+    após o uso, num ``finally``. Um cache de vida longa só seria removido via
+    ``atexit``, que não roda sob SIGKILL (cancelamento hard de job em CI),
+    deixando a credencial em texto plano no disco pelo resto da vida do
+    container.
     """
     if not access_key or not secret_key:
         return None
-    key = (access_key, secret_key)
-    cfg_path = _ia_config_cache.get(key)
-    if cfg_path is None:
-        cfg = configparser.ConfigParser()
-        cfg["s3"] = {"access": access_key, "secret": secret_key}
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".ini", delete=False, encoding="utf-8"
-        )
-        cfg.write(tmp)
-        tmp.close()
-        cfg_path = tmp.name
-        _ia_config_cache[key] = cfg_path
-        _final_path = cfg_path
-
-        def _cleanup() -> None:
-            Path(_final_path).unlink(missing_ok=True)
-
-        atexit.register(_cleanup)
-    return {**os.environ, "IA_CONFIG_FILE": cfg_path}
+    cfg = configparser.ConfigParser()
+    cfg["s3"] = {"access": access_key, "secret": secret_key}
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".ini", delete=False, encoding="utf-8"
+    )
+    cfg.write(tmp)
+    tmp.close()
+    return {**os.environ, "IA_CONFIG_FILE": tmp.name}
 
 
 # Padrões no stderr do `ia upload` que indicam falha transitória (retry pode ajudar).
@@ -634,34 +627,42 @@ class InternetArchivePublisher:
         (uma vez, antes do loop) — não a cada tentativa de retry interna, já
         que o backoff exponencial já espaça as tentativas da MESMA chamada;
         pacear os dois ao mesmo tempo só somaria esperas redundantes.
+
+        O ``ia.ini`` temporário (credenciais em texto plano) é removido no
+        ``finally`` assim que esta chamada termina — não sobrevive além dela.
         """
         self._upload_rate_limiter(_IA_RATE_LIMIT_KEY)
         env = _ia_subprocess_env(self.access_key, self.secret_key)
-        for attempt in range(1, _IA_UPLOAD_MAX_ATTEMPTS + 1):
-            try:
-                return subprocess.run(
-                    args, capture_output=True, text=True, check=True, env=env
-                )
-            except subprocess.CalledProcessError as e:
-                if (
-                    attempt == _IA_UPLOAD_MAX_ATTEMPTS
-                    or not _RETRYABLE_IA_ERROR_RE.search(e.stderr or "")
-                ):
-                    raise
-                delay = min(
-                    _IA_UPLOAD_MAX_DELAY_S,
-                    _IA_UPLOAD_BASE_DELAY_S * (2 ** (attempt - 1)),
-                )
-                delay += random.uniform(0, delay * 0.25)  # jitter
-                logger.warning(
-                    "ia upload: erro transiente (tentativa %d/%d), retry em %.1fs: %s",
-                    attempt,
-                    _IA_UPLOAD_MAX_ATTEMPTS,
-                    delay,
-                    (e.stderr or "").strip()[:200],
-                )
-                time.sleep(delay)
-        raise AssertionError("unreachable — loop always returns or raises")
+        cfg_path = env.get("IA_CONFIG_FILE") if env else None
+        try:
+            for attempt in range(1, _IA_UPLOAD_MAX_ATTEMPTS + 1):
+                try:
+                    return subprocess.run(
+                        args, capture_output=True, text=True, check=True, env=env
+                    )
+                except subprocess.CalledProcessError as e:
+                    if (
+                        attempt == _IA_UPLOAD_MAX_ATTEMPTS
+                        or not _RETRYABLE_IA_ERROR_RE.search(e.stderr or "")
+                    ):
+                        raise
+                    delay = min(
+                        _IA_UPLOAD_MAX_DELAY_S,
+                        _IA_UPLOAD_BASE_DELAY_S * (2 ** (attempt - 1)),
+                    )
+                    delay += random.uniform(0, delay * 0.25)  # jitter
+                    logger.warning(
+                        "ia upload: erro transiente (tentativa %d/%d), retry em %.1fs: %s",
+                        attempt,
+                        _IA_UPLOAD_MAX_ATTEMPTS,
+                        delay,
+                        (e.stderr or "").strip()[:200],
+                    )
+                    time.sleep(delay)
+            raise AssertionError("unreachable — loop always returns or raises")
+        finally:
+            if cfg_path is not None:
+                Path(cfg_path).unlink(missing_ok=True)
 
     def upload_raw(
         self,

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import json
+import os
+import stat
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -31,16 +33,38 @@ class TestIASubprocessEnv:
         env = _ia_subprocess_env("AKIA-test", "shh-secret")
         assert env is not None
         cfg_path = env["IA_CONFIG_FILE"]
-        content = Path(cfg_path).read_text(encoding="utf-8")
-        assert "[s3]" in content
-        assert "AKIA-test" in content
-        assert "shh-secret" in content
+        try:
+            content = Path(cfg_path).read_text(encoding="utf-8")
+            assert "[s3]" in content
+            assert "AKIA-test" in content
+            assert "shh-secret" in content
+        finally:
+            Path(cfg_path).unlink(missing_ok=True)
 
-    def test_caches_config_per_credential_pair(self):
+    def test_config_file_has_owner_only_permissions(self):
+        # Credentials on disk in plaintext — must not be group/world-readable.
+        env = _ia_subprocess_env("AKIA-test", "shh-secret")
+        assert env is not None
+        cfg_path = env["IA_CONFIG_FILE"]
+        try:
+            mode = stat.S_IMODE(os.stat(cfg_path).st_mode)
+            assert mode == 0o600
+        finally:
+            Path(cfg_path).unlink(missing_ok=True)
+
+    def test_no_longer_caches_across_calls(self):
+        # A process-wide cache only cleaned up via atexit leaves the plaintext
+        # credential file on disk for the container's whole lifetime, and
+        # atexit doesn't run on SIGKILL (hard CI job cancellation). Each call
+        # now writes its own file; the caller deletes it right after use.
         first = _ia_subprocess_env("dup-key", "dup-secret")
         second = _ia_subprocess_env("dup-key", "dup-secret")
         assert first is not None and second is not None
-        assert first["IA_CONFIG_FILE"] == second["IA_CONFIG_FILE"]
+        try:
+            assert first["IA_CONFIG_FILE"] != second["IA_CONFIG_FILE"]
+        finally:
+            Path(first["IA_CONFIG_FILE"]).unlink(missing_ok=True)
+            Path(second["IA_CONFIG_FILE"]).unlink(missing_ok=True)
 
 
 class TestRawIdentifier:
@@ -373,6 +397,45 @@ class TestRunIaUploadRetry:
                 raise AssertionError("expected FileNotFoundError to propagate")
             except FileNotFoundError:
                 pass
+
+    def test_deletes_temp_credential_file_after_success(self):
+        # The plaintext ia.ini must not outlive this single call — see #124.
+        pub = self._publisher()
+        captured_env = {}
+
+        def _capture_env_then_fake_success(args, **kwargs):
+            captured_env.update(kwargs.get("env") or {})
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=_capture_env_then_fake_success):
+            pub._run_ia_upload(["ia", "upload", "some-id"])
+        cfg_path = captured_env["IA_CONFIG_FILE"]
+        assert not Path(cfg_path).exists()
+
+    def test_deletes_temp_credential_file_after_exhausted_retries(self):
+        import subprocess
+
+        pub = self._publisher()
+        captured_env = {}
+        error = subprocess.CalledProcessError(
+            1, "ia", stderr="Please reduce your request rate."
+        )
+
+        def _capture_env_then_fail(args, **kwargs):
+            captured_env.update(kwargs.get("env") or {})
+            raise error
+
+        with (
+            patch("time.sleep"),
+            patch("subprocess.run", side_effect=_capture_env_then_fail),
+        ):
+            try:
+                pub._run_ia_upload(["ia", "upload", "some-id"])
+                raise AssertionError("expected CalledProcessError to propagate")
+            except subprocess.CalledProcessError:
+                pass
+        cfg_path = captured_env["IA_CONFIG_FILE"]
+        assert not Path(cfg_path).exists()
 
 
 class TestListParsedRawIds:


### PR DESCRIPTION
Closes #124.

## Problem

`_ia_subprocess_env` (`src/leizilla/publisher.py`) writes the IA access+secret key to a temp `ia.ini` file (the `ia` CLI only reads credentials from a config file — no env var or flag option), and used to cache that file path per credential pair for the **whole process lifetime**, relying on `atexit.register` for cleanup.

A hard CI job cancellation (timeout → SIGKILL) skips `atexit` entirely, leaving both keys in plaintext on disk with no further cleanup — for however long the container/runner persists afterward.

The issue also asked to double check temp-file permissions. Verified empirically: `tempfile.NamedTemporaryFile` already creates files with `0600` (owner-only) by default in this environment, so that part needed no change — it's now asserted by a test instead of assumed.

## Fix

Removed the process-wide cache (`_ia_config_cache`) and its `atexit` registration. `_ia_subprocess_env` now writes a fresh `ia.ini` on every call; `_run_ia_upload` extracts the path from the returned env dict and deletes it in a `finally` immediately after its retry loop finishes (success or exhausted retries) — so the plaintext credential is never on disk longer than a single upload call, regardless of how the process later dies.

## Testing

- `TestIASubprocessEnv`: rewrote the caching test to assert the new no-caching behavior (two calls now produce two different files), added a permissions test (`0600`), and added cleanup to the existing content test so it doesn't leak temp files.
- `TestRunIaUploadRetry`: two new regression tests — `test_deletes_temp_credential_file_after_success` and `test_deletes_temp_credential_file_after_exhausted_retries` — both capture the `IA_CONFIG_FILE` path passed to the mocked `subprocess.run` and assert it no longer exists on disk after `_run_ia_upload` returns/raises.
- `tests/test_publisher.py` + `tests/test_reconcile.py` (which mocks `_ia_subprocess_env` at the same module level): 67/67 pass.
- ruff check + ruff format clean.
- mypy clean on `publisher.py` (one pre-existing, unrelated `wayback.py` stub-import note, present on `main` too).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYNA5VDwYNNVaJ4zwUMaKs)_