### PR TITLE
fix: validate PDF magic bytes on direct fallback in scrape_one

### DIFF
--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -85,7 +85,10 @@ def scrape_one(
         return {"success": False, "reason": "fetch-failed", "url": pdf_url}
 
     if pdf_bytes[:4] != b"%PDF":
-        print(f"[WARN] not a valid PDF for {lei_data.get('chave')} ({pdf_url}): header={pdf_bytes[:32]!r}", file=sys.stderr)
+        print(
+            f"[WARN] not a valid PDF for {lei_data.get('chave')} ({pdf_url}): header={pdf_bytes[:32]!r}",
+            file=sys.stderr,
+        )
         return {"success": False, "reason": "not-pdf", "url": pdf_url}
 
     with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:

--- a/src/leizilla/scraper.py
+++ b/src/leizilla/scraper.py
@@ -84,6 +84,10 @@ def scrape_one(
     if pdf_bytes is None:
         return {"success": False, "reason": "fetch-failed", "url": pdf_url}
 
+    if pdf_bytes[:4] != b"%PDF":
+        print(f"[WARN] not a valid PDF for {lei_data.get('chave')} ({pdf_url}): header={pdf_bytes[:32]!r}", file=sys.stderr)
+        return {"success": False, "reason": "not-pdf", "url": pdf_url}
+
     with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
         f.write(pdf_bytes)
         tmp_path = Path(f.name)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -136,6 +136,22 @@ class TestScrapeOne:
         call_kwargs = pub.upload_raw.call_args
         assert call_kwargs.kwargs["fetched_from"] == "source-fallback"
 
+    @patch("leizilla.scraper.wayback.ensure_archived", return_value=None)
+    @patch(
+        "leizilla.scraper.wayback.fetch_bytes",
+        return_value=b"<!DOCTYPE html><html>error</html>",
+    )
+    @patch("leizilla.scraper.wayback.save_page", return_value=False)
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    def test_direct_fallback_rejects_non_pdf(
+        self, _r: Any, _s: Any, _f: Any, _c: Any
+    ) -> None:
+        """Fallback direto retornando HTML (não PDF) não deve ser upado pro IA."""
+        pub = _make_publisher()
+        result = scrape_one(_FONTE_URL, _PDF_URL, _LEI, pub)
+        assert result == {"success": False, "reason": "not-pdf", "url": _PDF_URL}
+        pub.upload_raw.assert_not_called()
+
 
 class TestMakeRateLimiter:
     def test_returns_callable(self) -> None:


### PR DESCRIPTION
Fixes issue #125 by adding PDF magic byte validation (`b"%PDF"`) to the direct fallback path in `scrape_one`. Without this check, WAF HTML error pages served with `200 OK` at `.pdf` URLs would be uploaded directly to the Internet Archive.

Added unit test to ensure fallback responses returning non-PDF bytes are correctly rejected without calling the IA publisher. Tested by running `uv run leizilla dev check` successfully.

---
*PR created automatically by Jules for task [12938823925509960139](https://jules.google.com/task/12938823925509960139) started by @franklinbaldo*