### PR TITLE
fix: pin explicit schema for exported Parquet (fixes #123)

### DIFF
--- a/src/leizilla/etl.py
+++ b/src/leizilla/etl.py
@@ -159,6 +159,43 @@ def _iter_dispositivos(parent: ET.Element) -> list[ET.Element]:
     return parent.findall(f"{{{NS}}}dispositivo")
 
 
+PARQUET_SCHEMA: dict[str, str] = {
+    "lei_id": "VARCHAR",
+    "ente": "VARCHAR",
+    "tipo_lei": "VARCHAR",
+    "numero_lei": "VARCHAR",
+    "ano_lei": "INTEGER",
+    "data_publicacao": "DATE",
+    "urn_lex_lei": "VARCHAR",
+    "vigente_em": "DATE",
+    "lei_revogada": "BOOLEAN",
+    "lei_revogada_em": "DATE",
+    "lei_revogada_por": "VARCHAR",
+    "lei_revogada_tipo": "VARCHAR",
+    "dispositivo_path": "VARCHAR",
+    "dispositivo_tipo": "VARCHAR",
+    "dispositivo_ordem": "INTEGER",
+    "dispositivo_parent_path": "VARCHAR",
+    "dispositivo_revogado": "BOOLEAN",
+    "dispositivo_revogado_em": "DATE",
+    "dispositivo_revogado_por": "VARCHAR",
+    "dispositivo_revogado_tipo": "VARCHAR",
+    "urn_dispositivo": "VARCHAR",
+    "versao_id": "VARCHAR",
+    "em": "DATE",
+    "ate": "DATE",
+    "alterado_por": "VARCHAR",
+    "inicio_tipo": "VARCHAR",
+    "texto": "VARCHAR",
+    "texto_normalizado": "VARCHAR",
+    "fontes": "VARCHAR",
+    "num_fontes": "INTEGER",
+    "tem_divergencia": "BOOLEAN",
+    "hash_texto": "VARCHAR",
+    "quality": "VARCHAR",
+}
+
+
 def xml_to_rows(xml_content: str, lei_id: str, ente: str) -> list[dict[str, Any]]:
     """Parse Leizilla XML v0.1 into versoes rows per SCHEMA.md §3.1."""
     root = ET.fromstring(xml_content)
@@ -322,7 +359,7 @@ def _json_default(obj: object) -> str:
 
 
 def write_parquet(rows: list[dict[str, Any]], output_path: Path) -> None:
-    """Write versoes rows to Parquet (SNAPPY) via DuckDB read_json_auto."""
+    """Write versoes rows to Parquet (SNAPPY) via DuckDB read_json with explicit schema."""
     import os
     import tempfile
 
@@ -341,9 +378,17 @@ def write_parquet(rows: list[dict[str, Any]], output_path: Path) -> None:
 
         conn = duckdb.connect()
         try:
+            # Generate the dictionary string representation expected by DuckDB
+            columns_str = (
+                "{"
+                + ", ".join(f"'{k}': '{v}'" for k, v in PARQUET_SCHEMA.items())
+                + "}"
+            )
             # Use parameterized ? to avoid SQL string interpolation for file paths
+            # but schema dictionary has to be inline
             conn.execute(
-                "CREATE TABLE _rows AS SELECT * FROM read_json_auto(?)", [tmp_path]
+                f"CREATE TABLE _rows AS SELECT * FROM read_json(?, columns={columns_str})",
+                [tmp_path],
             )
             conn.table("_rows").write_parquet(str(output_path), compression="snappy")
         finally:

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -396,21 +396,97 @@ class TestWriteParquet:
         ).fetchone()[0]  # type: ignore[index]
         assert count == len(rows)
 
-    def test_roundtrip_columns_present(self, tmp_path: Path) -> None:
+    def test_schema_matches_pinned(self, tmp_path: Path) -> None:
+        """The exported Parquet schema must strictly match docs/SCHEMA.md §3.1."""
         import duckdb
+        from leizilla.etl import PARQUET_SCHEMA
 
         rows = xml_to_rows(_SIMPLE, "leizilla-ro-lei-09999-1999", "ro")
         out = tmp_path / "versoes.parquet"
         write_parquet(rows, out)
-        cols = {
-            row[0]
-            for row in duckdb.execute(
-                "SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet(?))",
-                [str(out)],
-            ).fetchall()
+
+        # Mapping from DuckDB logical types back to our generic types
+        duckdb_to_our_types = {
+            "VARCHAR": "VARCHAR",
+            "BIGINT": "INTEGER",
+            "INTEGER": "INTEGER",
+            "DATE": "DATE",
+            "BOOLEAN": "BOOLEAN",
         }
-        required = {"lei_id", "ente", "dispositivo_path", "em", "texto", "fontes"}
-        assert required.issubset(cols)
+
+        actual_schema = {}
+        for row in duckdb.execute(
+            "SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet(?))",
+            [str(out)],
+        ).fetchall():
+            col_name, col_type = row[0], row[1]
+            actual_schema[col_name] = duckdb_to_our_types.get(col_type, col_type)
+
+        assert actual_schema == PARQUET_SCHEMA
+
+    def test_schema_is_stable_with_all_nulls(self, tmp_path: Path) -> None:
+        """Regression test for #123: all-null columns must not infer as VARCHAR or NULL."""
+        import duckdb
+        from leizilla.etl import PARQUET_SCHEMA
+        import datetime
+
+        # Create a single row where all optional columns are None
+        row = {
+            "lei_id": "123",
+            "ente": "ro",
+            "tipo_lei": "lei",
+            "numero_lei": "72-a",
+            "ano_lei": 2020,
+            "data_publicacao": datetime.date(2020, 1, 1),
+            "urn_lex_lei": None,
+            "vigente_em": datetime.date(2020, 1, 1),
+            "lei_revogada": False,
+            "lei_revogada_em": None,
+            "lei_revogada_por": None,
+            "lei_revogada_tipo": None,
+            "dispositivo_path": "art1",
+            "dispositivo_tipo": "artigo",
+            "dispositivo_ordem": 0,
+            "dispositivo_parent_path": None,
+            "dispositivo_revogado": False,
+            "dispositivo_revogado_em": None,
+            "dispositivo_revogado_por": None,
+            "dispositivo_revogado_tipo": None,
+            "urn_dispositivo": None,
+            "versao_id": "v1",
+            "em": datetime.date(2020, 1, 1),
+            "ate": None,
+            "alterado_por": None,
+            "inicio_tipo": "data-publicacao",
+            "texto": None,
+            "texto_normalizado": None,
+            "fontes": "[]",
+            "num_fontes": 0,
+            "tem_divergencia": False,
+            "hash_texto": None,
+            "quality": None,
+        }
+
+        out = tmp_path / "nulls.parquet"
+        write_parquet([row], out)
+
+        duckdb_to_our_types = {
+            "VARCHAR": "VARCHAR",
+            "BIGINT": "INTEGER",
+            "INTEGER": "INTEGER",
+            "DATE": "DATE",
+            "BOOLEAN": "BOOLEAN",
+        }
+
+        actual_schema = {}
+        for r in duckdb.execute(
+            "SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet(?))",
+            [str(out)],
+        ).fetchall():
+            col_name, col_type = r[0], r[1]
+            actual_schema[col_name] = duckdb_to_our_types.get(col_type, col_type)
+
+        assert actual_schema == PARQUET_SCHEMA
 
     def test_creates_parent_dir(self, tmp_path: Path) -> None:
         rows = xml_to_rows(_SIMPLE, "leizilla-ro-lei-09999-1999", "ro")


### PR DESCRIPTION
Fixes #123.

`write_parquet` was previously relying on DuckDB's `read_json_auto` to infer the schema types from the NDJSON data rows. This resulted in unstable schemas when reading dataset fragments that might contain all nulls for an optional column. This PR fixes the inference step to explicitly pass the pinned schema, ensuring a deterministic schema type matching `docs/SCHEMA.md` is correctly exported for stability across tools. Regression tests were added to confirm behavior in the all-null cases.

---
*PR created automatically by Jules for task [9831848327838003050](https://jules.google.com/task/9831848327838003050) started by @franklinbaldo*