### PR TITLE
fix: add --limit flag to scrape command to prevent workflow timeouts

### DIFF
--- a/.github/workflows/rondonia_crawler.yml
+++ b/.github/workflows/rondonia_crawler.yml
@@ -53,7 +53,8 @@ jobs:
           uv run leizilla scrape \
             --ente ro --fonte assembleia \
             --start 1 --end 5000 \
-            --skip-existing
+            --skip-existing \
+            --limit 500
 
       - name: Scrape — ro/assembleia (dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -94,7 +95,8 @@ jobs:
           uv run leizilla scrape \
             --ente ro --fonte casacivil --tipo lei \
             --start 1 --end 6000 \
-            --skip-existing
+            --skip-existing \
+            --limit 500
 
       - name: Scrape — ro/casacivil lei (dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -135,7 +137,8 @@ jobs:
           uv run leizilla scrape \
             --ente ro --fonte casacivil --tipo lc \
             --start 1 --end 1300 \
-            --skip-existing
+            --skip-existing \
+            --limit 500
 
       - name: Scrape — ro/casacivil lc (dispatch)
         if: github.event_name == 'workflow_dispatch'

--- a/src/leizilla/cli.py
+++ b/src/leizilla/cli.py
@@ -410,6 +410,11 @@ def cmd_scrape(
         "--skip-existing/--no-skip-existing",
         help="Pula itens cujo raw IA item já existe (consulta IA antes do loop)",
     ),
+    limit: Optional[int] = typer.Option(
+        None,
+        "--limit",
+        help="Limite de novos itens a processar (itens pulados não contam)",
+    ),
 ) -> None:
     """Scrape leis: discover → robots → wayback → upload_raw/upload_raw_html para IA."""
 
@@ -462,6 +467,7 @@ def cmd_scrape(
             )
             ok = 0
             skipped_ok = 0
+            processed = 0
             total_laws_count = 0
             index_cache: Dict[str, str] = {}
 
@@ -475,6 +481,8 @@ def cmd_scrape(
                 )
                 total_laws_count += len(laws)
                 for law in laws:
+                    if limit is not None and processed >= limit:
+                        break
                     fonte_url = law.get("url_original")
                     if not fonte_url:
                         continue
@@ -484,6 +492,7 @@ def cmd_scrape(
                         if ia_id in already_scraped:
                             skipped_ok += 1
                             continue
+                    processed += 1
                     result = scrape_one_html(
                         fonte_url, law, publisher, rate_limiter, index_cache
                     )
@@ -603,8 +612,11 @@ def cmd_scrape(
 
             ok = 0
             skipped_ok = 0
+            processed = 0
             index_cache: Dict[str, str] = {}
             for law in laws:
+                if limit is not None and processed >= limit:
+                    break
                 pdf_url = law.get("url_pdf_original")
                 fonte_url = law.get("url_original")
                 if not pdf_url or not fonte_url:
@@ -616,6 +628,7 @@ def cmd_scrape(
                     if ia_id in already_scraped:
                         skipped_ok += 1
                         continue
+                processed += 1
                 result = scrape_one(
                     fonte_url,
                     pdf_url,

--- a/tests/test_scrape_skip_existing.py
+++ b/tests/test_scrape_skip_existing.py
@@ -167,6 +167,142 @@ class TestCmdScrapeSkipExisting:
         )
         mock_scrape.assert_called_once()
 
+    @patch("leizilla.scraper.scrape_one_html")
+    @patch("leizilla.publisher.InternetArchivePublisher")
+    @patch(
+        "leizilla.publisher.list_raw_ids",
+        return_value={"leizilla-raw-federal-planalto-lei-00001"},
+    )
+    @patch("leizilla.fontes.federal.discover_planalto_laws")
+    def test_planalto_limit(
+        self, mock_discover, mock_list, mock_pub_cls, mock_scrape
+    ):
+        """Testa se o limit interrompe corretamente os novos itens, sem contar os pulados."""
+        mock_discover.return_value = [
+            {
+                "ente": "federal",
+                "fonte": "planalto",
+                "chave": "lei-00001",
+                "url_original": "https://www.planalto.gov.br/ccivil_03/leis/L1.htm",
+            },
+            {
+                "ente": "federal",
+                "fonte": "planalto",
+                "chave": "lei-00002",
+                "url_original": "https://www.planalto.gov.br/ccivil_03/leis/L2.htm",
+            },
+            {
+                "ente": "federal",
+                "fonte": "planalto",
+                "chave": "lei-00003",
+                "url_original": "https://www.planalto.gov.br/ccivil_03/leis/L3.htm",
+            },
+        ]
+        mock_pub_cls.return_value = MagicMock()
+        mock_scrape.return_value = _UPLOAD_OK
+
+        result = runner.invoke(
+            app,
+            [
+                "scrape",
+                "--ente",
+                "federal",
+                "--fonte",
+                "planalto",
+                "--tipo",
+                "lei",
+                "--start",
+                "1",
+                "--end",
+                "3",
+                "--skip-existing",
+                "--limit",
+                "1",
+            ],
+        )
+
+        # O item 1 deve ser pulado, o item 2 deve ser processado, o item 3 deve ser interrompido pelo limit.
+        mock_scrape.assert_called_once()
+        assert "1 pulados" in result.output
+        assert "1/3 com sucesso" in result.output
+
+    @patch("leizilla.scraper.scrape_one")
+    @patch("leizilla.publisher.InternetArchivePublisher")
+    @patch(
+        "leizilla.publisher.list_raw_ids",
+        return_value={"leizilla-raw-ro-casacivil-lei-00001"},
+    )
+    @patch("leizilla.crawler.discover_casacivil_laws")
+    def test_casacivil_limit(
+        self, mock_discover, mock_list, mock_pub_cls, mock_scrape
+    ):
+        """Testa se o limit interrompe corretamente os PDFs, sem contar os pulados."""
+        mock_discover.return_value = [
+            {
+                "ente": "ro",
+                "fonte": "casacivil",
+                "chave": "lei-00001",
+                "url_original": "http://ditel/L1.pdf",
+                "url_pdf_original": "http://ditel/L1.pdf",
+            },
+            {
+                "ente": "ro",
+                "fonte": "casacivil",
+                "chave": "lei-00002",
+                "url_original": "http://ditel/L2.pdf",
+                "url_pdf_original": "http://ditel/L2.pdf",
+            },
+            {
+                "ente": "ro",
+                "fonte": "casacivil",
+                "chave": "lei-00003",
+                "url_original": "http://ditel/L3.pdf",
+                "url_pdf_original": "http://ditel/L3.pdf",
+            },
+        ]
+        mock_pub_cls.return_value = MagicMock()
+        mock_scrape.return_value = _UPLOAD_OK
+
+        with patch("leizilla.discovery.WaybackCdxDiscovery.run", return_value=[]), \
+             patch("leizilla.discovery.load_manifest", return_value={"fontes": {"casacivil": {"probe": [{"templates": ["http://ditel/L{num}.pdf"], "start": 1}]}}}):
+
+            with patch("leizilla.cli.asyncio.run") as mock_asyncio:
+                # Simular o comportamento do asyncio.run chamando a corrotina
+                def side_effect(coro):
+                    import asyncio
+                    loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(loop)
+                    try:
+                        return loop.run_until_complete(coro)
+                    finally:
+                        loop.close()
+                mock_asyncio.side_effect = side_effect
+
+                result = runner.invoke(
+                    app,
+                    [
+                        "scrape",
+                        "--ente",
+                        "ro",
+                        "--fonte",
+                        "casacivil",
+                        "--tipo",
+                        "lei",
+                        "--start",
+                        "1",
+                        "--end",
+                        "3",
+                        "--skip-existing",
+                        "--limit",
+                        "1",
+                    ],
+                )
+
+        # O item 1 deve ser pulado, o item 2 deve ser processado, o item 3 deve ser interrompido pelo limit.
+        mock_scrape.assert_called_once()
+        assert "1 pulados" in result.output
+        assert "1/3 com sucesso" in result.output
+
     @patch("leizilla.publisher.list_raw_ids", return_value=set())
     def test_skip_existing_reports_ia_count_in_output(self, mock_list):
         """Com --skip-existing, output inclui contagem de itens existentes no IA."""

--- a/tests/test_scrape_skip_existing.py
+++ b/tests/test_scrape_skip_existing.py
@@ -174,9 +174,7 @@ class TestCmdScrapeSkipExisting:
         return_value={"leizilla-raw-federal-planalto-lei-00001"},
     )
     @patch("leizilla.fontes.federal.discover_planalto_laws")
-    def test_planalto_limit(
-        self, mock_discover, mock_list, mock_pub_cls, mock_scrape
-    ):
+    def test_planalto_limit(self, mock_discover, mock_list, mock_pub_cls, mock_scrape):
         """Testa se o limit interrompe corretamente os novos itens, sem contar os pulados."""
         mock_discover.return_value = [
             {
@@ -233,9 +231,7 @@ class TestCmdScrapeSkipExisting:
         return_value={"leizilla-raw-ro-casacivil-lei-00001"},
     )
     @patch("leizilla.crawler.discover_casacivil_laws")
-    def test_casacivil_limit(
-        self, mock_discover, mock_list, mock_pub_cls, mock_scrape
-    ):
+    def test_casacivil_limit(self, mock_discover, mock_list, mock_pub_cls, mock_scrape):
         """Testa se o limit interrompe corretamente os PDFs, sem contar os pulados."""
         mock_discover.return_value = [
             {
@@ -263,19 +259,33 @@ class TestCmdScrapeSkipExisting:
         mock_pub_cls.return_value = MagicMock()
         mock_scrape.return_value = _UPLOAD_OK
 
-        with patch("leizilla.discovery.WaybackCdxDiscovery.run", return_value=[]), \
-             patch("leizilla.discovery.load_manifest", return_value={"fontes": {"casacivil": {"probe": [{"templates": ["http://ditel/L{num}.pdf"], "start": 1}]}}}):
-
+        with (
+            patch("leizilla.discovery.WaybackCdxDiscovery.run", return_value=[]),
+            patch(
+                "leizilla.discovery.load_manifest",
+                return_value={
+                    "fontes": {
+                        "casacivil": {
+                            "probe": [
+                                {"templates": ["http://ditel/L{num}.pdf"], "start": 1}
+                            ]
+                        }
+                    }
+                },
+            ),
+        ):
             with patch("leizilla.cli.asyncio.run") as mock_asyncio:
                 # Simular o comportamento do asyncio.run chamando a corrotina
                 def side_effect(coro):
                     import asyncio
+
                     loop = asyncio.new_event_loop()
                     asyncio.set_event_loop(loop)
                     try:
                         return loop.run_until_complete(coro)
                     finally:
                         loop.close()
+
                 mock_asyncio.side_effect = side_effect
 
                 result = runner.invoke(


### PR DESCRIPTION
Added `--limit` to `leizilla scrape` command to control max new items scraped per execution. Updated workflows to use `--limit 500`. Resolves #135, #136.

---
*PR created automatically by Jules for task [14387136634091670576](https://jules.google.com/task/14387136634091670576) started by @franklinbaldo*