### PR TITLE
feat: authoritative index enumeration for casacivil discovery

### DIFF
--- a/src/leizilla/discovery.py
+++ b/src/leizilla/discovery.py
@@ -238,6 +238,90 @@ class SequentialDiscovery:
         return resources
 
 
+
+
+
+
+class CasacivilIndexDiscovery:
+    """Estratégia de descobrimento que lê a página de índice da Casa Civil."""
+
+    def __init__(self, config: Dict[str, Any], ente: str, fonte: str) -> None:
+        self.url = config["url"]
+        self.ente = ente
+        self.fonte = fonte
+
+    def run(self, storage: Optional[DuckDBStorage] = None) -> List[Dict[str, Any]]:
+        # Obey ADR-0004: prefer Wayback
+        from leizilla import wayback
+
+        logger.info(f"Rodando CasacivilIndex Discovery para {self.ente}/{self.fonte} na URL {self.url}...")
+        resources = []
+
+        wb_snap = wayback.closest_snapshot(self.url)
+        html_content = None
+
+        if wb_snap:
+            wb_url, _ = wb_snap
+            html_bytes = wayback.fetch_bytes(wb_url)
+            if html_bytes is not None:
+                html_content = html_bytes.decode("utf-8", errors="ignore")
+
+        if html_content is None:
+            # Note: ADR-0008 says we need to obey robots + ~1 req/s rate limit
+            from leizilla.scraper import robots
+            if not robots.is_allowed(self.url):
+                logger.error(f"robots.txt blocked fetch for {self.url}")
+                return []
+
+            # Fetch using standard Python library directly, avoiding "wayback.fetch_bytes" abstraction for live domains
+            import time
+            time.sleep(1.0) # rate limit
+            try:
+                req = urllib.request.Request(
+                    self.url,
+                    headers={"User-Agent": "leizilla-crawler/0.1"}
+                )
+                with urllib.request.urlopen(req, timeout=30.0) as r:
+                    html_content = r.read().decode("utf-8", errors="ignore")
+            except Exception as e:
+                logger.error(f"Falha ao buscar índice ao vivo {self.url}: {e}")
+
+        if html_content is None:
+            logger.error(f"Falha ao buscar índice {self.url}")
+            return []
+
+        # Find all hrefs to .pdf files
+        pattern = re.compile(
+            r"""href=['"]?([^'" >]+\.pdf)['"]?""",
+            re.IGNORECASE,
+        )
+        matches = pattern.finditer(html_content)
+        for match in matches:
+            href = match.group(1)
+            filename = href.split("/")[-1]
+            tipo, chave = parse_filename(filename)
+
+            if not tipo or not chave:
+                tipo, chave = "", f"documento-{filename.rsplit('.', 1)[0]}"
+
+            absolute_url = urllib.parse.urljoin(self.url, href)
+
+            resources.append({
+                "url": absolute_url,
+                "ente": self.ente,
+                "fonte": self.fonte,
+                "tipo_documento": tipo,
+                "chave": chave,
+                "status": "pending",
+                "wayback_snapshot": None,
+            })
+
+        logger.info(
+            f"CasacivilIndex Discovery concluído: {len(resources)} recursos encontrados"
+        )
+        return resources
+
+
 class PlaywrightCrawlerDiscovery:
     """Estratégia de descobrimento que usa o LeisCrawler (Playwright) para o portal ALRO."""
 
@@ -302,6 +386,7 @@ STRATEGIES: Dict[
 ] = {
     "wayback-cdx": WaybackCdxDiscovery,
     "sequential": SequentialDiscovery,
+    "casacivil-index": CasacivilIndexDiscovery,
     "playwright-crawler": PlaywrightCrawlerDiscovery,
 }
 

--- a/src/leizilla/manifests/ro.json
+++ b/src/leizilla/manifests/ro.json
@@ -5,48 +5,68 @@
       "tipo_ingestion": "pdf",
       "discovery": [
         {
+          "strategy": "casacivil-index",
+          "url": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/"
+        },
+        {
           "strategy": "wayback-cdx",
           "prefix": "http://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/"
         }
       ],
       "probe": [
         {
-          "templates": ["https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/L{num}.pdf"],
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/L{num}.pdf"
+          ],
           "start": 1,
           "head_check": false
         },
         {
-          "templates": ["https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/LC{num}.pdf"],
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/LC{num}.pdf"
+          ],
           "start": 1,
           "head_check": false
         },
         {
-          "templates": ["https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/D{num}.pdf"],
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/D{num}.pdf"
+          ],
           "start": 1,
           "head_check": true
         },
         {
-          "templates": ["https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/EC{num}.pdf"],
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/EC{num}.pdf"
+          ],
           "start": 1,
           "head_check": true
         },
         {
-          "templates": ["https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/Res{num}.pdf"],
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/Res{num}.pdf"
+          ],
           "start": 1,
           "head_check": true
         },
         {
-          "templates": ["https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/Port{num}.pdf"],
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/Port{num}.pdf"
+          ],
           "start": 1,
           "head_check": true
         },
         {
-          "templates": ["https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/DEC{num}.pdf"],
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/DEC{num}.pdf"
+          ],
           "start": 1,
           "head_check": true
         },
         {
-          "templates": ["https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/DL{num}.pdf"],
+          "templates": [
+            "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/DL{num}.pdf"
+          ],
           "start": 1,
           "head_check": true
         }

--- a/tests/fixtures/casacivil_index.html
+++ b/tests/fixtures/casacivil_index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Casacivil Index Page</title>
+</head>
+<body>
+    <a href="Files/L6001.pdf">Lei 6001</a>
+    <a href="Files/LC1301.pdf">LC 1301</a>
+    <a href="Files/EC146.pdf">EC 146</a>
+    <a href="Files/D1.pdf">Decreto 1</a>
+    <a href="Files/DL2.pdf">Decreto-Lei 2</a>
+    <a href="Files/Res3.pdf">Resolução 3</a>
+    <a href="Files/Port4.pdf">Portaria 4</a>
+</body>
+</html>

--- a/tests/test_casacivil_discovery.py
+++ b/tests/test_casacivil_discovery.py
@@ -1,5 +1,8 @@
 """Testes para discover_casacivil_laws — enumeração sem Playwright."""
 
+from unittest.mock import patch
+from leizilla.discovery import CasacivilIndexDiscovery
+
 import pytest
 
 from leizilla.crawler import (
@@ -85,3 +88,59 @@ class TestDiscoverCasacivilLaws:
             assert len(laws) == 5
         finally:
             socket.getaddrinfo = original_getaddrinfo
+
+
+
+
+
+
+class TestCasacivilIndexDiscovery:
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    @patch("leizilla.wayback.closest_snapshot", return_value=None)
+    @patch("urllib.request.urlopen")
+    def test_casacivil_index_discovery_enumerates_all_tipos(self, mock_urlopen, mock_snap, mock_robots):
+        from unittest.mock import MagicMock
+        config = {
+            "strategy": "casacivil-index",
+            "url": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/",
+        }
+
+        with open("tests/fixtures/casacivil_index.html", "r") as f:
+            html_content = f.read()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__.return_value = mock_resp
+        mock_resp.read.return_value = html_content.encode("utf-8")
+        mock_urlopen.return_value = mock_resp
+
+        discoverer = CasacivilIndexDiscovery(config, "ro", "casacivil")
+        resources = discoverer.run()
+
+        assert len(resources) == 7
+
+        chaves = [r["chave"] for r in resources]
+        assert "lei-06001" in chaves
+        assert "lc-01301" in chaves
+        assert "ec-00146" in chaves
+        assert "decreto-00001" in chaves
+        assert "decreto-lei-00002" in chaves
+        assert "resolucao-00003" in chaves
+        assert "portaria-00004" in chaves
+
+        urls = [r["url"] for r in resources]
+        assert "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/L6001.pdf" in urls
+        assert "https://ditel.casacivil.ro.gov.br/COTEL/Livros/Files/EC146.pdf" in urls
+
+    @patch("leizilla.scraper.robots.is_allowed", return_value=True)
+    @patch("leizilla.wayback.closest_snapshot", return_value=None)
+    @patch("urllib.request.urlopen", side_effect=Exception("Network failure"))
+    def test_casacivil_index_discovery_fails_open(self, mock_urlopen, mock_snap, mock_robots):
+        config = {
+            "strategy": "casacivil-index",
+            "url": "https://ditel.casacivil.ro.gov.br/COTEL/Livros/",
+        }
+
+        discoverer = CasacivilIndexDiscovery(config, "ro", "casacivil")
+        resources = discoverer.run()
+
+        assert resources == []


### PR DESCRIPTION
Fixes #122

This PR replaces the blind range-probing strategy with a concrete, enumeration-based discovery strategy for the Casacivil portal.

It achieves this by parsing the `casacivil` index page directly (`https://ditel.casacivil.ro.gov.br/COTEL/Livros/`) to extract all available `(tipo, número)` pairs from `.pdf` hyperlinks.

As per #122, it covers the missing types exposed by the casacivil index:
- `ec`
- `decreto`
- `resolucao`
- `portaria`
- `decreto-lei`
along with `lei` and `lc`. 

The original probe ranges in `ro.json` were left intact, and the new enumeration strategy is added as the primary authoritative source. The strategy adheres to ADR-0004 (Wayback primary fallback) and ADR-0008 (1s rate limit and `robots.txt` obedience), handling fail-open behavior appropriately when network requests fail. Mocked tests confirm correct functionality.

---
*PR created automatically by Jules for task [2845307013442739603](https://jules.google.com/task/2845307013442739603) started by @franklinbaldo*